### PR TITLE
1.0.1: Everest NDK fixes, bc:Default cleanup, and accumulated engine/settings work

### DIFF
--- a/K2.App/App.xaml.cs
+++ b/K2.App/App.xaml.cs
@@ -20,13 +20,27 @@ namespace K2.App;
 /// </summary>
 public partial class App : Application
 {
-    /// <summary>Log file next to the executable, shared by all modules.</summary>
-    public static readonly string LogPath = Path.Combine(
-        AppContext.BaseDirectory, "K2.App.log");
+    /// <summary>
+    /// Per-user, always-writable data folder (%LocalAppData%\K2.App\), shared by all
+    /// modules. NOT next to the executable: K2 installs to Program Files by default,
+    /// which is admin-write-protected — writing there without elevation used to fail
+    /// silently and drop all logging.
+    /// </summary>
+    private static readonly string DataDir = EnsureDataDir();
+
+    private static string EnsureDataDir()
+    {
+        var dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "K2.App");
+        try { Directory.CreateDirectory(dir); } catch { /* best-effort, same as the writers below */ }
+        return dir;
+    }
+
+    /// <summary>Log file.</summary>
+    public static readonly string LogPath = Path.Combine(DataDir, "K2.App.log");
 
     /// <summary>Separate crash log file for native/fatal crashes.</summary>
-    public static readonly string CrashLogPath = Path.Combine(
-        AppContext.BaseDirectory, "K2.App.crash.log");
+    public static readonly string CrashLogPath = Path.Combine(DataDir, "K2.App.crash.log");
 
     // Held for the process lifetime; released automatically by the OS on exit.
     private static Mutex? _singleInstanceMutex;
@@ -972,7 +986,7 @@ public partial class App : Application
         try
         {
             var suffix = string.IsNullOrEmpty(tag) ? "" : $"_{tag}";
-            var dumpPath = Path.Combine(AppContext.BaseDirectory,
+            var dumpPath = Path.Combine(DataDir,
                 $"K2.App_{DateTime.Now:yyyyMMdd_HHmmss}{suffix}.dmp");
             using var fs = new FileStream(dumpPath, FileMode.Create, FileAccess.Write);
             // MiniDumpWithDataSegs | MiniDumpWithHandleData = 0x01 | 0x04

--- a/K2.App/K2.App.csproj
+++ b/K2.App/K2.App.csproj
@@ -27,6 +27,9 @@
     <AssemblyName>K2.App</AssemblyName>
     <RootNamespace>K2.App</RootNamespace>
     <ApplicationIcon>Assets\K2_icon.ico</ApplicationIcon>
+    <!-- requireAdministrator — see app.manifest: needed to control BaseCampService
+         (LocalSystem), otherwise it can silently respawn Base Camp's DisplayPad worker. -->
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <!-- Libreria condivisa: motore azioni dei tasti + ponte Python.

--- a/K2.App/MainWindow.DisplayDial.cs
+++ b/K2.App/MainWindow.DisplayDial.cs
@@ -2,35 +2,68 @@
 // Controls the visible pages on the Everest Max rotary display
 // and clock, screensaver, auto-off, menu color settings.
 //
-// FW_EXTEND_INFO ↔ Display Dial mapping (to verify with USB capture):
+// FW_EXTEND_INFO ↔ Display Dial mapping:
 //   byMMDockShowMenu  = page bitmask (bit0=Clock … bit7=Custom)
-//   byMMDockScreenSetup = clock format, 12h/24h (assumed — see DialClockTypeIndex)
-//   wMMDockScreenSaver  = screensaver timeout in seconds (0=disabled)
-//   wMMDockTurnOff      = auto-off timeout in seconds (0=disabled)
+//   byMMDockScreenSetup = NOT clock format, NOT written by K2 anymore. A real
+//                         Base Camp USB capture (_reference/usb_dumps/
+//                         evclock.pcapng, 2026-07-15) proved it stays constant
+//                         while toggling 12h/24h in Base Camp's own UI — clock
+//                         format is instead carried on every periodic
+//                         SetClockInfo call (see EverestService.UpdateClock,
+//                         _dialClockTimer below). What byMMDockScreenSetup
+//                         actually does remains unknown; left untouched.
+//   byMMDockMenuIndex = NOT WRITTEN by K2 (2026-07-15, real hardware test via
+//                       K2 itself, not just packet captures): SetExtendInfo
+//                       returned True after writing menuIndex=67 (0x43,
+//                       clock content + both enable bits packed in, per the
+//                       real Base Camp USB captures' byte layout), but the
+//                       immediately following GetExtendInfo read back
+//                       menuIndex=0 — the SDK/firmware silently discards this
+//                       field via this call even though the API reports
+//                       success. wMMDockScreenSaver/wMMDockTurnOff round-
+//                       tripped correctly in the same test (ss=2, off=30
+//                       both came back as written), so this is specific to
+//                       byMMDockMenuIndex, not a general SetExtendInfo
+//                       failure. Base Camp's own USB traffic DOES show this
+//                       byte changing and sticking within its session, so it
+//                       must be set through some other command (plausibly the
+//                       same mechanism as EverestSdkNative.SetPCInfo, whose
+//                       doc comment says it drives byMMDockMenuIndex into the
+//                       97-101/113 range as a side effect) — not yet
+//                       identified. Read-only for now: K2 shows whatever the
+//                       device reports but the "what the screensaver shows"
+//                       combo has NO device effect until that command is
+//                       found (would need a fresh raw-HID capture, not just
+//                       SetExtendInfo's blob).
+//   wMMDockScreenSaver  = screensaver timeout in seconds — CONFIRMED, including
+//                         0=disabled: real hardware test round-tripped ss=2
+//                         correctly through SetExtendInfo/GetExtendInfo.
+//   wMMDockTurnOff      = auto-off timeout in seconds — CONFIRMED, same as above
+//                         (off=30 round-tripped in the same real hardware test).
 //   MMDockColor         = menu color
 //
 // Enable/disable checkboxes for screensaver and turn-off mirror Base Camp's
 // own DB model (BaseCamp.Data.DisplayDial: EnableSecreenSaver/EnableTurnOff
-// are separate bool columns from ScreenSaverTime/TurnOffTime) — when
-// unchecked, K2 sends 0 (disabled) to the firmware but keeps the configured
-// seconds value so it's not lost if re-enabled.
+// are separate bool columns from ScreenSaverTime/TurnOffTime) — K2 has no
+// confirmed separate device-side enable flag (see byMMDockMenuIndex above:
+// the bits that looked like enable flags in the packet captures live in a
+// field K2 can't actually write), so it falls back to zeroing
+// wMMDockScreenSaver/wMMDockTurnOff for "disabled" — confirmed round-tripping
+// correctly (see above), unlike the byMMDockMenuIndex approach it replaces.
 //
-// Clock style (analog/digital) and "screensaver shows" (which page acts as
-// the screensaver) are real Base Camp concepts — BaseCamp.Data.DisplayDial
-// has ClockType/ScreenSaverType columns, and BaseCampLinux's raw protocol
-// has a confirmed STYLE_ANALOG/STYLE_DIGITAL byte and a MAIN_DISPLAY_MODES
-// menu-byte table — but neither has a confirmed byte mapping in SDKDLL's
-// FW_EXTEND_INFO for THIS SDK (the existing byMMDockMenuIndex comment in
-// EverestSdkNative.cs quotes different values than BaseCampLinux's table,
-// so they are not directly interchangeable). Both combos are therefore
-// UI + persisted-only for now; wiring them to a device field needs a USB
-// capture first (see _reference/USB_SNIFF_GUIDE.md), consistent with the
-// project's "don't guess the bit-layout" rule.
+// Clock STYLE (analog/digital) is still NOT confirmed against a device field:
+// both real USB captures show ambiguous/inconclusive byte changes around the
+// clock-type UI actions (multiple candidate bytes moving together, and most
+// clicks producing byte-identical packets — possibly Base Camp itself doesn't
+// wire analog/digital to firmware, only 12h/24h). Left UI + persisted-only,
+// per the project's "don't guess the bit-layout" rule, until a cleaner
+// isolated capture (one click at a time) resolves it.
 
 using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Threading;
 using K2.App.Services;
 using K2.Core;
 
@@ -40,6 +73,23 @@ public partial class MainWindow
 {
     // ── Flag to prevent re-entry during value loading ──
     private bool _dialLoading;
+
+    /// <summary>
+    /// Ticks the Media Dock clock every second (<c>EverestService.UpdateClock</c>) —
+    /// see that method's remarks (real Base Camp sends the format on every
+    /// periodic clock call, not via SetExtendInfo). Runs for the app's lifetime;
+    /// the Tick handler no-ops if the driver isn't open, same tolerance as other
+    /// pollers in this codebase. Unlike the RbDialClockType radio buttons
+    /// themselves, this always carries <see cref="_dialAppliedFormat24h"/> — the
+    /// clock must keep ticking continuously (it's not a one-shot setting write),
+    /// but which format it uses only changes on "Apply to device", same as
+    /// every other Display Dial field.
+    /// </summary>
+    private DispatcherTimer? _dialClockTimer;
+
+    /// <summary>Clock format last pushed via "Apply to device" (or loaded at
+    /// startup) — see <see cref="_dialClockTimer"/>.</summary>
+    private bool _dialAppliedFormat24h = true;
 
     // ── Bit mapping for byMMDockShowMenu (to be confirmed with USB capture) ──
     [Flags]
@@ -56,19 +106,27 @@ public partial class MainWindow
         All        = 0xFF
     }
 
-    // Screensaver-function combo entries, in the same order as the page
-    // toggles above. Values are internal page names (persisted), not a
-    // confirmed device byte — see file header.
-    private static readonly (string Key, string Value)[] DialFunctions =
+    // Screensaver-function combo entries: what the screensaver shows.
+    // Code layout confirmed against two independent real Base Camp USB
+    // captures (_reference/usb_dumps/evsettings.pcapng + evsettings2.pcapng,
+    // 2026-07-15). NOT the same list as the 8 page-visibility checkboxes
+    // above (byMMDockShowMenu, a bitmask, unrelated field): Base Camp's real
+    // combo here is image/clock/timer/stopwatch/volume/brightness/pcinfo/apm,
+    // not clock/profile/lighting/volume/brightness/pcinfo/apm/custom as
+    // previously guessed. NOT WRITTEN to the device — see file header
+    // (byMMDockMenuIndex): kept only so "Read from device" can show what the
+    // device currently reports, and so the combo/persisted choice survive a
+    // future fix once the real write command is found.
+    private static readonly (string Key, string Value, byte Code, bool IsSpecialRaw)[] DialFunctions =
     {
-        ("dial_clock",     "clock"),
-        ("dial_profile",   "profile"),
-        ("dial_lighting",  "lighting"),
-        ("dial_volume",    "volume"),
-        ("dial_brightness","brightness"),
-        ("dial_pcinfo",    "pcinfo"),
-        ("dial_apm",       "apm"),
-        ("dial_custom",    "custom"),
+        ("dial_image",     "image",      2,   false),
+        ("dial_timer",     "timer",      3,   false),
+        ("dial_clock",     "clock",      4,   false),
+        ("dial_stopwatch", "stopwatch",  7,   false),
+        ("dial_volume",    "volume",     8,   false),
+        ("dial_brightness","brightness", 9,   false),
+        ("dial_pcinfo",    "pcinfo",     14,  false),
+        ("dial_apm",       "apm",        113, true),
     };
 
     // ─────────────────────── Init ───────────────────────
@@ -83,7 +141,7 @@ public partial class MainWindow
     {
         // Populate screensaver-function combo (which page shows as screensaver)
         CbDialScreenSaverFunction.Items.Clear();
-        foreach (var (key, _) in DialFunctions)
+        foreach (var (key, _, _, _) in DialFunctions)
             CbDialScreenSaverFunction.Items.Add(Loc.Get(key));
 
         // Load saved settings (or defaults)
@@ -95,6 +153,18 @@ public partial class MainWindow
         finally
         {
             _dialLoading = false;
+        }
+        _dialAppliedFormat24h = DialClockTypeIndex == 0;
+
+        if (_dialClockTimer is null)
+        {
+            _dialClockTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _dialClockTimer.Tick += (_, _) =>
+            {
+                if (_everest is { IsOpen: true })
+                    _everest.UpdateClock(format24h: _dialAppliedFormat24h);
+            };
+            _dialClockTimer.Start();
         }
     }
 
@@ -117,6 +187,7 @@ public partial class MainWindow
 
         int clockStyle = ParseInt(_evStore?.GetSetting("dial.clockStyle"), 0);
         (clockStyle == 1 ? RbDialClockAnalog : RbDialClockDigital).IsChecked = true;
+        UpdateDialClockFormatVisibility();
 
         string ssFunction = _evStore?.GetSetting("dial.screenSaverFunction") ?? DialFunctions[0].Value;
         int ssIndex = Array.FindIndex(DialFunctions, f => f.Value == ssFunction);
@@ -134,6 +205,14 @@ public partial class MainWindow
                 (Color)ColorConverter.ConvertFromString(menuColor));
         }
         catch { /* fallback: keep XAML default */ }
+    }
+
+    /// <summary>Analog clocks have no 12h/24h digit format — hide the format
+    /// segmented control while "Analog" is selected.</summary>
+    private void UpdateDialClockFormatVisibility()
+    {
+        PnlDialClockFormat.Visibility = RbDialClockAnalog.IsChecked == true
+            ? Visibility.Collapsed : Visibility.Visible;
     }
 
     private void SaveDialSettings()
@@ -182,9 +261,14 @@ public partial class MainWindow
             return;
         }
 
-        // Update only the fields controlled by the Display Dial panel
+        // Update only the fields controlled by the Display Dial panel.
+        // byMMDockScreenSetup and byMMDockMenuIndex are NOT written here — see
+        // file header for why (clock format goes through SetClockInfo instead;
+        // menuIndex writes are silently discarded by the device, confirmed on
+        // real hardware). Writing a value that's confirmed not to stick would
+        // just violate the project's "don't guess the bit-layout" rule for no
+        // benefit.
         info.byMMDockShowMenu = BuildPageByte();
-        info.byMMDockScreenSetup = (byte)DialClockTypeIndex;  // 0=24h, 1=12h (to be confirmed)
         info.wMMDockScreenSaver = CkDialScreenSaverEnable.IsChecked == true
             ? ParseUshort(TxtDialScreenSaver.Text, 30) : (ushort)0;
         info.wMMDockTurnOff = CkDialTurnOffEnable.IsChecked == true
@@ -200,8 +284,14 @@ public partial class MainWindow
 
         bool ok = _everest.SetExtendInfo(info);
         LogEverest($"[DIAL] SetExtendInfo -> {ok}  pages=0x{info.byMMDockShowMenu:X2} " +
-                   $"clock={info.byMMDockScreenSetup} ss={info.wMMDockScreenSaver} " +
-                   $"off={info.wMMDockTurnOff}");
+                   $"menuIndex={info.byMMDockMenuIndex} " +
+                   $"ss={info.wMMDockScreenSaver} off={info.wMMDockTurnOff}");
+
+        // Clock format doesn't live in FW_EXTEND_INFO (see file header) — push
+        // it separately, on the same "Apply to device" trigger as everything else.
+        _dialAppliedFormat24h = DialClockTypeIndex == 0;
+        LogEverest($"[DIAL] UpdateClock(format24h={_dialAppliedFormat24h}) -> " +
+                   $"{_everest.UpdateClock(_dialAppliedFormat24h)}");
 
         SaveDialSettings();
     }
@@ -229,10 +319,30 @@ public partial class MainWindow
             CkDialAPM.IsChecked      = (pages & (byte)DialPage.APM) != 0;
             CkDialCustom.IsChecked   = (pages & (byte)DialPage.Custom) != 0;
 
-            (info.byMMDockScreenSetup == 1 ? RbDialClock12h : RbDialClock24h).IsChecked = true;
+            // Clock format (12h/24h) is intentionally left untouched here:
+            // byMMDockScreenSetup doesn't carry it (see ApplyDialToDevice's
+            // comment) — K2's own persisted choice (_dialClockTimer/
+            // RbDialClockType_Checked) is the source of truth, not the device.
+
+            // byMMDockMenuIndex is a PACKED byte (contentNibble<<4 | enableBits)
+            // for every content type except the special-raw "apm" — see file
+            // header. Check special-raw entries first (exact match) before
+            // falling back to nibble matching, so apm's 113 (0x71) can't be
+            // mistaken for a nibble-7 ("stopwatch") + enableBits=1 combination.
+            // Display-only: K2 never writes this field (see file header), so
+            // it just reflects whatever Base Camp or the firmware itself last
+            // set it to — selecting a different option in the combo has no
+            // effect on the device.
+            byte menuIndex = info.byMMDockMenuIndex;
+            int fnIndex = Array.FindIndex(DialFunctions, f => f.IsSpecialRaw && f.Code == menuIndex);
+            if (fnIndex < 0)
+                fnIndex = Array.FindIndex(DialFunctions, f => !f.IsSpecialRaw && f.Code == (menuIndex >> 4));
+            CbDialScreenSaverFunction.SelectedIndex = fnIndex >= 0 ? fnIndex : 0;
 
             // The firmware only reports a timeout, not a separate enable flag
-            // (Base Camp keeps that flag DB-side). 0 => disabled, keep the last
+            // (Base Camp keeps that flag DB-side, and K2's own attempt at a
+            // device-side flag via byMMDockMenuIndex was confirmed not to
+            // stick — see file header). 0 => disabled, keep the last
             // configured seconds value in the textbox instead of overwriting it.
             CkDialScreenSaverEnable.IsChecked = info.wMMDockScreenSaver != 0;
             if (info.wMMDockScreenSaver != 0) TxtDialScreenSaver.Text = info.wMMDockScreenSaver.ToString();
@@ -245,7 +355,7 @@ public partial class MainWindow
                 Color.FromRgb(c.r, c.g, c.b));
 
             LogEverest($"[DIAL] Read from device: pages=0x{pages:X2} " +
-                       $"clock={info.byMMDockScreenSetup} ss={info.wMMDockScreenSaver} " +
+                       $"menuIndex={info.byMMDockMenuIndex} ss={info.wMMDockScreenSaver} " +
                        $"off={info.wMMDockTurnOff} color=({c.r},{c.g},{c.b})");
 
             SaveDialSettings();
@@ -272,6 +382,7 @@ public partial class MainWindow
 
     private void RbDialClockStyle_Checked(object sender, RoutedEventArgs e)
     {
+        UpdateDialClockFormatVisibility();
         if (_dialLoading) return;
         SaveDialSettings();
     }
@@ -282,6 +393,11 @@ public partial class MainWindow
         SaveDialSettings();
     }
 
+    // Every Display Dial field — including screensaver/turn-off enable+timeout
+    // and clock format — only reaches the device on an explicit "Apply to
+    // device" click (BtnDialApply_Click). Edits here only update the local
+    // UI/persisted settings; see ApplyDialToDevice for the one place that
+    // actually talks to the firmware.
     private void CkDialScreenSaverEnable_Click(object sender, RoutedEventArgs e)
     {
         if (_dialLoading) return;

--- a/K2.App/MainWindow.DisplayPad.cs
+++ b/K2.App/MainWindow.DisplayPad.cs
@@ -456,6 +456,7 @@ public partial class MainWindow
         if (res != MessageBoxResult.OK) return;
         _dpStore.ClearProfile(id, slot);
         DpLog($"[UI] Profile {slot} restored to defaults.");
+        DpRefreshProfiles(id);
         ResetDpNavigation();
         DpRequestRepaint(id);
     }

--- a/K2.App/MainWindow.Everest.cs
+++ b/K2.App/MainWindow.Everest.cs
@@ -1065,6 +1065,7 @@ public partial class MainWindow
         ApplyCurrentEffect();
         ApplyEverestSettingsToDevice();
         StartLedPreview();
+        EvUploadNdkImages(); // display keys are device-global: re-push on every fresh connect
 
         // Restore custom device name if previously set
         var savedName = _evStore.GetSetting("device.name");
@@ -1102,6 +1103,7 @@ public partial class MainWindow
             ApplyCurrentEffect();
             ApplyEverestSettingsToDevice();
             StartLedPreview();
+            EvUploadNdkImages(); // display keys are device-global: re-push on every fresh connect
         }
     }
 
@@ -1163,81 +1165,97 @@ public partial class MainWindow
             string profileName = root.Element("ProfileName")?.Value
                                  ?? System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
 
-            var bindings = root.Descendants("EverestKeyBidings").ToList();
+            // Real Base Camp XML exports the EverestKeyBindings navigation property as
+            // a wrapper containing <KeyboardBinding> items (item element = the real
+            // decompiled class name, confirmed 2026-07-15 against a genuine Base Camp
+            // XML export — see EvProfileExporter's doc comment). Older K2 exports
+            // (pre-fix) used flat, typo'd <EverestKeyBidings> elements — kept as a
+            // fallback so previously-exported K2 files still import.
+            var bindings = root.Descendants("KeyboardBinding").ToList();
+            if (bindings.Count == 0)
+                bindings = root.Descendants("EverestKeyBidings").ToList();
             if (bindings.Count == 0)
             {
-                LogEverest("[IMP-XML] No EverestKeyBidings found in XML.");
+                LogEverest("[IMP-XML] No KeyboardBinding/EverestKeyBidings found in XML.");
                 return;
             }
 
             int regular = 0, touch = 0;
 
+            // FunctionType=="K2Action" is K2's own round-trip encoding (ActionType/Value
+            // stashed verbatim in SubFunctionType/FunctionValue); anything else is real
+            // Base Camp vocabulary translated through the shared table.
+            static (string? ActionType, string? ActionValue) TranslateBinding(System.Xml.Linq.XElement b)
+            {
+                string? funcType  = b.Element("FunctionType")?.Value;
+                string? subType   = b.Element("SubFunctionType")?.Value;
+                string? funcValue = b.Element("FunctionValue")?.Value;
+                if (funcType == "K2Action")
+                    return (subType, string.IsNullOrEmpty(funcValue) ? null : funcValue);
+                return BaseCampDbImporter.TranslateAction(funcType, subType, funcValue);
+            }
+
+            var touchBindings = new List<(int MatrixId, System.Xml.Linq.XElement El)>();
             foreach (var b in bindings)
             {
                 if (!int.TryParse(b.Element("DLLMatrixIndex")?.Value, out int matrixId)) continue;
                 bool isTouchKey = b.Element("IsTouchKey")?.Value
                                    ?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
+                if (isTouchKey) { touchBindings.Add((matrixId, b)); continue; }
 
-                string? funcType  = b.Element("FunctionType")?.Value;
-                string? subType   = b.Element("SubFunctionType")?.Value;
-                string? funcValue = b.Element("FunctionValue")?.Value;
+                var (actionType, actionValue) = TranslateBinding(b);
+                if (actionType is null) continue;
+                _evStore.SaveKey(new EverestKeyRecord(slot, matrixId, null, actionType, actionValue));
+                regular++;
+            }
 
-                string? actionType, actionValue;
-                if (funcType == "K2Action")
+            // NDK 0-3 (numpad LCD display keys, device-global in K2): assigned by ORDER
+            // among the touch-key bindings, not by DLLMatrixIndex value. K2's own exports
+            // use synthetic KeyIds 9001-9004 in ascending order (see EvProfileExporter),
+            // but a genuine Base Camp XML export uses BC's own real, arbitrary KeyId for
+            // these — matching by "matrixId - 9001" silently dropped every touch key
+            // (icon included) from any real BC file. Ordering by DLLMatrixIndex then
+            // taking the first NdkCount mirrors BaseCampDbImporter.ImportEverestProfile's
+            // DB-based import, so both sources land on identical results.
+            int ndkIndex = 0;
+            foreach (var (_, b) in touchBindings.OrderBy(t => t.MatrixId))
+            {
+                if (ndkIndex >= NdkCount) break;
+                var (actionType, actionValue) = TranslateBinding(b);
+
+                string? imageB64 = b.Element("base64Image")?.Value;
+                if (!string.IsNullOrEmpty(imageB64))
                 {
-                    actionType  = subType;
-                    actionValue = string.IsNullOrEmpty(funcValue) ? null : funcValue;
-                }
-                else
-                {
-                    (actionType, actionValue) = BaseCampDbImporter.TranslateAction(funcType, subType, funcValue);
-                }
-
-                if (isTouchKey)
-                {
-                    // NDK 0-3: synthetic KeyId 9001-9004 (see EvProfileExporter) — device-global in K2.
-                    int ndkIndex = matrixId - 9001;
-                    if (ndkIndex < 0 || ndkIndex > 3) continue;
-
-                    string? imageB64 = b.Element("base64Image")?.Value;
-                    if (!string.IsNullOrEmpty(imageB64))
+                    try
                     {
-                        try
+                        var bytes = BaseCampDbImporter.DecodeBase64Image(imageB64);
+                        if (bytes is not null)
                         {
-                            var bytes = BaseCampDbImporter.DecodeBase64Image(imageB64);
-                            if (bytes is not null)
-                            {
-                                string dir = System.IO.Path.Combine(
-                                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                                    "K2.App", "imported_xml_ev");
-                                System.IO.Directory.CreateDirectory(dir);
-                                string file = System.IO.Path.Combine(dir, $"ndk_{ndkIndex}.png");
-                                System.IO.File.WriteAllBytes(file, bytes);
-                                _evStore.SetSetting($"ndk.{ndkIndex}.imagePath", file);
-                            }
+                            string dir = System.IO.Path.Combine(
+                                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                                "K2.App", "imported_xml_ev");
+                            System.IO.Directory.CreateDirectory(dir);
+                            string file = System.IO.Path.Combine(dir, $"ndk_{ndkIndex}.png");
+                            System.IO.File.WriteAllBytes(file, bytes);
+                            _evStore.SetSetting($"ndk.{ndkIndex}.imagePath", file);
                         }
-                        catch (Exception ex) { LogEverest($"[IMP-XML] ndk #{ndkIndex} image decode failed: {ex.Message}"); }
                     }
-                    if (actionType is not null)
-                    {
-                        _evStore.SetSetting($"ndk.{ndkIndex}.actionType", actionType);
-                        _evStore.SetSetting($"ndk.{ndkIndex}.actionValue", actionValue ?? "");
-                    }
-                    touch++;
+                    catch (Exception ex) { LogEverest($"[IMP-XML] ndk #{ndkIndex} image decode failed: {ex.Message}"); }
                 }
-                else
+                if (actionType is not null)
                 {
-                    if (actionType is null) continue;
-                    _evStore.SaveKey(new EverestKeyRecord(slot, matrixId, null, actionType, actionValue));
-                    regular++;
+                    _evStore.SetSetting($"ndk.{ndkIndex}.actionType", actionType);
+                    _evStore.SetSetting($"ndk.{ndkIndex}.actionValue", actionValue ?? "");
                 }
+                touch++;
+                ndkIndex++;
             }
 
             _evStore.SetCurrentProfile(slot);
             EvRefreshProfiles();
             EvSelectProfileSlot(slot);
-            ReloadEverestProfile();
-            if (_everest.IsOpen && touch > 0) EvUploadNdkImages(slot);
+            ReloadEverestProfile(); // also re-uploads NDK images to hardware when connected
+            if (touch > 0) LoadNdkState(); // refresh canvas thumbnails with the imported icons
 
             LogEverest($"[IMP-XML] '{profileName}' -> slot {slot}: {regular} keys, {touch} display keys");
             LblStatus.Text = Loc.Get("dp_imported_xml", profileName, slot);
@@ -1325,10 +1343,9 @@ public partial class MainWindow
                 totalRegular += reg;
                 totalTouch   += touch;
                 LogEverest($"[IMP-BC] slot {profile.Slot} '{profile.Name}': {reg} keys, {touch} display keys");
-
-                // Upload numpad display key images to hardware (if connected)
-                if (_everest.IsOpen && touch > 0)
-                    EvUploadNdkImages(profile.Slot);
+                // NDK images are device-global (not per-profile): no need to re-upload
+                // inside this per-profile loop — ReloadEverestProfile() below does it
+                // once, after every profile has been imported.
 
                 if (profile.IsSelected) activeSlot = profile.Slot;
             }
@@ -1357,34 +1374,59 @@ public partial class MainWindow
     }
 
     /// <summary>
-    /// After importing BC profiles, uploads ndk images stored in EverestStore
-    /// to the hardware (for the given profile slot).
+    /// Pushes the current NDK (numpad LCD display key) images to hardware and tells the
+    /// firmware which pic slot maps to which physical key (<see cref="NdkRefreshDevicePicSlots"/>).
+    /// NDK state is device-global (EverestStore's <c>ndk.{i}.*</c> settings), not
+    /// per-profile — but switching the Everest's active FIRMWARE profile (<c>_everest.
+    /// SwitchProfile</c>) resets the on-device LCD picture slots the same way it does
+    /// regular keys/RGB, so this must run any time a profile is (re)loaded or the device
+    /// is freshly opened — not just right after a BC/XML import, which is all that
+    /// called it before.
     /// </summary>
-    private void EvUploadNdkImages(int profileSlot)
+    private void EvUploadNdkImages()
     {
+        bool any = false;
         for (int i = 0; i < 4; i++)
         {
-            // ndk.{i}.imagePath is global (not per-profile) in EverestStore
             var path = _evStore.GetSetting($"ndk.{i}.imagePath");
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) continue;
             try
             {
-                _everest.UploadNumpadImage(path, i + 1); // imagePathOrBase64, keyIndex (1-based)
-                LogEverest($"[IMP-BC] ndk.{i} uploaded: {System.IO.Path.GetFileName(path)}");
+                // Matches NdkApplyImage's first (and usually successful) attempt:
+                // 0-based keyIndex, picSlot=0 — the combo already confirmed to work on
+                // real hardware there. (The old i+1/1-based call here was a separate,
+                // never-hit bug: it only ever ran right after an import, and would have
+                // targeted the wrong physical key — or, for i=3, an out-of-range one.)
+                bool ok = _everest.UploadNumpadImage(path, i, picSlot: 0);
+                any |= ok;
+                LogEverest($"[NDK] ndk.{i} uploaded: {System.IO.Path.GetFileName(path)} -> {ok}");
             }
             catch (Exception ex)
             {
-                LogEverest($"[IMP-BC] ndk.{i} upload failed: {ex.Message}");
+                LogEverest($"[NDK] ndk.{i} upload failed: {ex.Message}");
             }
         }
+        if (any) NdkRefreshDevicePicSlots();
     }
 
     private void CbEvProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_evSuppressProfile) return;
         if (CbEvProfile.SelectedItem is not EvProfileItem pi) return;
-        _evStore.SetCurrentProfile(pi.Slot);
-        LogEverest($"[UI ] Everest profile selected: {pi.Slot}");
+        int slot = pi.Slot;
+
+        if (pi.IsNew)
+        {
+            // Create empty profile (see EverestStore.MarkProfileExists for why this
+            // doesn't use a placeholder Keys row like MacroPad/DisplayPad do).
+            _evStore.MarkProfileExists(slot);
+            LogEverest($"[UI ] New empty Everest profile created: slot {slot}");
+            EvRefreshProfiles();
+            EvSelectProfileSlot(slot);
+        }
+
+        _evStore.SetCurrentProfile(slot);
+        LogEverest($"[UI ] Everest profile selected: {slot}");
         ReloadEverestProfile();
     }
 
@@ -1408,6 +1450,13 @@ public partial class MainWindow
             LogEverest("[WARN] select a key first");
             return;
         }
+        // NDK display-key entry (see EvAddNdkEntriesToKeyList): configured via its own
+        // image+action dialog, not the regular ButtonActionDialog/Keys-table path.
+        if (key.NdkIndex is int ndkIdx)
+        {
+            ConfigureNdkKey(ndkIdx);
+            return;
+        }
         if (key.KeyMatrix == 261)
         {
             LogEverest("[WARN] FN is reserved (Fn-layer key) — no action can be assigned to it");
@@ -1427,6 +1476,11 @@ public partial class MainWindow
     private void BtnEvRemove_Click(object sender, RoutedEventArgs e)
     {
         if (LvEvKeys.SelectedItem is not EverestKey key) return;
+        if (key.NdkIndex is int ndkIdx)
+        {
+            ClearNdkKey(ndkIdx);
+            return;
+        }
         _evKeys.Remove(key);
         _evByMatrix.Remove(key.KeyMatrix);
         _evStore.RemoveKey(EvCurrentProfile(), key.KeyMatrix);
@@ -1525,7 +1579,59 @@ public partial class MainWindow
             _evKeys.Add(k);
             _evByMatrix[r.KeyMatrix] = k;
         }
+        EvAddNdkEntriesToKeyList();
+        // Re-push the (device-global) NDK images/pic-slot mapping any time a profile is
+        // (re)loaded — see EvUploadNdkImages's doc comment for why this can't be limited
+        // to just the import flows that originally called it.
+        if (_everest.IsOpen) EvUploadNdkImages();
         LogEverest($"[DB  ] profile {profile}: loaded {_evKeys.Count} keys");
+    }
+
+    /// <summary>
+    /// Surfaces the 4 numpad LCD "display keys" (NDK) in the same mapped-keys list as
+    /// regular keys, but only when a key differs from its default (empty) state — i.e.
+    /// carries a custom action and/or a custom icon. NDK state is device-global (not
+    /// per-profile, see MainWindow.NumpadDisplayKeys.cs), so the same entries show up
+    /// regardless of which profile is selected. KeyMatrix is a negative placeholder
+    /// (display keys have no real matrix code) and these entries are deliberately kept
+    /// OUT of _evByMatrix — BtnEvConfig/BtnEvRemove branch on NdkIndex before touching
+    /// any KeyMatrix-keyed persistence.
+    /// </summary>
+    private void EvAddNdkEntriesToKeyList()
+    {
+        for (int i = 0; i < NdkCount; i++)
+        {
+            string? at  = _evStore.GetSetting($"ndk.{i}.actionType");
+            string? av  = _evStore.GetSetting($"ndk.{i}.actionValue");
+            string? img = _evStore.GetSetting($"ndk.{i}.imagePath");
+            bool hasImg = !string.IsNullOrEmpty(img) && System.IO.File.Exists(img);
+            bool hasAct = !string.IsNullOrEmpty(at);
+            if (!hasImg && !hasAct) continue; // default/empty display key — omit
+
+            _evKeys.Add(new EverestKey(-(i + 1))
+            {
+                NdkIndex    = i,
+                Label       = Loc.Get("ev_display_key_label", i + 1),
+                ActionType  = hasAct ? at : null,
+                ActionValue = hasAct ? av : null,
+                HasImage    = hasImg,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Re-derives just the NDK entries in the mapped-keys list (drops the old ones,
+    /// re-adds whichever display keys still differ from default) without touching the
+    /// regular per-profile keys already loaded in <see cref="_evKeys"/>/<see cref="_evByMatrix"/>.
+    /// Called after any NDK edit — from the canvas display-key buttons
+    /// (MainWindow.NumpadDisplayKeys.cs) as well as from this list's own Configure/Remove
+    /// buttons — so both surfaces of the same state stay in sync.
+    /// </summary>
+    private void EvRefreshNdkInKeyList()
+    {
+        for (int i = _evKeys.Count - 1; i >= 0; i--)
+            if (_evKeys[i].NdkIndex is not null) _evKeys.RemoveAt(i);
+        EvAddNdkEntriesToKeyList();
     }
 
     // ============================================================
@@ -1535,19 +1641,28 @@ public partial class MainWindow
     private int EvCurrentProfile()
         => CbEvProfile.SelectedItem is EvProfileItem pi ? pi.Slot : 1;
 
-    /// <summary>Rebuilds the Everest profile combo with names (slots 1..5).</summary>
+    /// <summary>Populates the Everest profile combo with configured profiles + "New
+    /// profile…" (device firmware always has 5 fixed slots — see EverestStore.
+    /// GetExistingProfiles — but the UI only lists the ones actually in use, same
+    /// as MacroPad/DisplayPad).</summary>
     private void EvRefreshProfiles()
     {
         _evSuppressProfile = true;
         try
         {
-            var items = Enumerable.Range(1, EverestService.ProfileCount)
-                .Select(s =>
-                {
-                    string name = _evStore.GetProfileName(s) ?? Loc.Get("profile_n", s);
-                    return new EvProfileItem(s, name);
-                })
-                .ToList();
+            var existing = _evStore.GetExistingProfiles();
+            if (existing.Count == 0) existing.Add(1);
+            var items = new List<EvProfileItem>();
+            foreach (var slot in existing)
+            {
+                string name = _evStore.GetProfileName(slot) ?? Loc.Get("profile_n", slot);
+                items.Add(new EvProfileItem(slot, name));
+            }
+            int nextFree = Enumerable.Range(1, EverestService.ProfileCount)
+                .FirstOrDefault(s => !existing.Contains(s));
+            if (nextFree > 0)
+                items.Add(new EvProfileItem(nextFree, Loc.Get("new_profile")));
+
             CbEvProfile.DisplayMemberPath = nameof(EvProfileItem.Label);
             CbEvProfile.ItemsSource = items;
         }
@@ -1561,7 +1676,7 @@ public partial class MainWindow
         try
         {
             if (CbEvProfile.ItemsSource is List<EvProfileItem> items)
-                CbEvProfile.SelectedItem = items.Find(x => x.Slot == slot) ?? items[0];
+                CbEvProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
         }
         finally { _evSuppressProfile = false; }
     }
@@ -1583,6 +1698,13 @@ public partial class MainWindow
     private void BtnEvDeleteProfile_Click(object sender, RoutedEventArgs e)
     {
         int slot = EvCurrentProfile();
+        // Cannot delete the last real profile
+        if (_evStore.GetExistingProfiles().Count <= 1)
+        {
+            MessageBox.Show(Loc.Get("delete_profile_last"),
+                Loc.Get("delete_profile"), MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
         string profileName = _evStore.GetProfileName(slot) ?? Loc.Get("profile_n", slot);
         var res = MessageBox.Show(
             Loc.Get("delete_profile_confirm", profileName),
@@ -1613,6 +1735,7 @@ public partial class MainWindow
         if (res != MessageBoxResult.OK) return;
         _evStore.ResetProfileToDefaults(slot);
         LogEverest($"[UI ] Everest profile {slot} restored to defaults.");
+        EvRefreshProfiles();
         ReloadEverestProfile();
     }
 

--- a/K2.App/MainWindow.Everest60.cs
+++ b/K2.App/MainWindow.Everest60.cs
@@ -314,6 +314,7 @@ public partial class MainWindow
         Ev60RgbPanel.RestoreDefaults();
         Ev60KeyBindingPanel.RestoreDefaults();
         LogEverest60($"[UI ] Everest 60 profile {slot} restored to defaults.");
+        Ev60RefreshProfiles();
     }
 
     // ------------------------------------------------------------

--- a/K2.App/MainWindow.Keys.cs
+++ b/K2.App/MainWindow.Keys.cs
@@ -204,6 +204,7 @@ public partial class MainWindow
         if (res != MessageBoxResult.OK) return;
         _store.ClearProfile(id, slot);
         Log($"[UI ] MacroPad profile {slot} restored to defaults.");
+        MpRefreshProfiles(id);
         ReloadCurrentProfile();
     }
 

--- a/K2.App/MainWindow.Layout.cs
+++ b/K2.App/MainWindow.Layout.cs
@@ -66,6 +66,11 @@ public partial class MainWindow
     private void UpdateKeyboardLayout()
     {
         if (_everest is null) return;
+        // Skip while an NDK picture upload is in flight — the firmware transiently reports
+        // both accessories unplugged while it's busy writing to flash (see _ndkUploadBusy in
+        // MainWindow.NumpadDisplayKeys.cs), which would otherwise flicker them out of the UI
+        // until the next successful poll. NdkApplyImage re-runs this once the write settles.
+        if (_ndkUploadBusy) return;
 
         byte dockPos   = _everest.MMDockPlugPosition();
         byte numpadPos = _everest.NumpadPlugPosition();

--- a/K2.App/MainWindow.Makalu.cs
+++ b/K2.App/MainWindow.Makalu.cs
@@ -179,6 +179,7 @@ public partial class MainWindow
         MkRgbSettings.RestoreDefaults();
         MkDpiRemap.MkReloadRemap(slot);
         LogMakalu($"[UI ] Makalu profile {slot} restored to defaults.");
+        MkRefreshProfiles();
     }
 
     // ------------------------------------------------------------

--- a/K2.App/MainWindow.NumpadDisplayKeys.cs
+++ b/K2.App/MainWindow.NumpadDisplayKeys.cs
@@ -181,7 +181,18 @@ public partial class MainWindow
     private void NdkButton_Click(object sender, RoutedEventArgs e)
     {
         if (sender is not Button { Tag: int keyIndex }) return;
+        ConfigureNdkKey(keyIndex);
+    }
 
+    /// <summary>
+    /// Opens the unified image+action dialog for display key <paramref name="keyIndex"/>
+    /// and applies the result. Shared by the canvas display-key button (above) and by
+    /// LvEvKeys's "Configure" button once an NDK entry appears in that same mapped-keys
+    /// list (see MainWindow.Everest.cs's EvAddNdkEntriesToKeyList/BtnEvConfig_Click) —
+    /// both surfaces edit the same underlying state, so both must refresh the list.
+    /// </summary>
+    private void ConfigureNdkKey(int keyIndex)
+    {
         var dlg = new NdkKeyConfigDialog(
             keyIndex, _ndkImagePaths[keyIndex], _ndkActions[keyIndex].Type, _ndkActions[keyIndex].Value, _evActionHost)
         { Owner = this };
@@ -203,6 +214,7 @@ public partial class MainWindow
         }
 
         SaveNdkKey(keyIndex);
+        EvRefreshNdkInKeyList();
         LogEverest($"[NDK] key={keyIndex} <- action={dlg.ActionType ?? "none"}, image {(dlg.ImageChanged ? "changed" : "unchanged")}");
     }
 
@@ -255,6 +267,7 @@ public partial class MainWindow
 
         NdkRefreshAfterSwap(sourceIndex);
         NdkRefreshAfterSwap(targetIndex);
+        EvRefreshNdkInKeyList();
 
         LogEverest($"[NDK] swapped key={sourceIndex} <-> key={targetIndex}");
     }
@@ -289,6 +302,11 @@ public partial class MainWindow
     /// Uploads <paramref name="imagePath"/> (already 72×72 — either user-cropped or
     /// auto-generated, both via <see cref="NdkKeyConfigDialog"/>) to display key
     /// <paramref name="keyIndex"/>, persists it, and refreshes the thumbnail.
+    /// While the upload + device-side refresh (<see cref="NdkRefreshDevicePicSlots"/>) run,
+    /// all 4 NDK buttons are disabled and the wait cursor is shown — same "block until the
+    /// hardware reload settles" contract Base Camp uses, and the same intent as DisplayPad's
+    /// <c>_dpRepaintBusy</c> guard (see MainWindow.DisplayPad.cs), just synchronous here since
+    /// the SDK calls themselves are blocking.
     /// </summary>
     private void NdkApplyImage(int keyIndex, string imagePath)
     {
@@ -298,46 +316,81 @@ public partial class MainWindow
             return;
         }
 
-        // Upload to device — try parameter combinations for debugging.
-        // SDK: targetDev=1, targetPic=picSlot, targetSubItem=keyIndex.
-        // Try different (picSlot, keyIndex) combinations to find which
-        // mapping works for all 4 display keys.
-        bool ok = false;
-
-        // Attempt 1: picSlot=0, subItem=keyIndex (all on the same slot)
-        ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: 0);
-        LogEverest($"[NDK] Upload key={keyIndex} try1(pic=0,sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-
-        if (!ok)
+        NdkSetButtonsEnabled(false);
+        _ndkUploadBusy = true;
+        var oldCursor = Mouse.OverrideCursor;
+        Mouse.OverrideCursor = Cursors.Wait;
+        try
         {
-            // Attempt 2: picSlot=keyIndex, subItem=keyIndex
-            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)keyIndex);
-            LogEverest($"[NDK] Upload key={keyIndex} try2(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-        }
+            // Upload to device — try parameter combinations for debugging.
+            // SDK: targetDev=1, targetPic=picSlot, targetSubItem=keyIndex.
+            // Try different (picSlot, keyIndex) combinations to find which
+            // mapping works for all 4 display keys.
+            bool ok = false;
 
-        if (!ok)
+            // Attempt 1: picSlot=0, subItem=keyIndex (all on the same slot)
+            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: 0);
+            LogEverest($"[NDK] Upload key={keyIndex} try1(pic=0,sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+
+            if (!ok)
+            {
+                // Attempt 2: picSlot=keyIndex, subItem=keyIndex
+                ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)keyIndex);
+                LogEverest($"[NDK] Upload key={keyIndex} try2(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+            }
+
+            if (!ok)
+            {
+                // Attempt 3: picSlot=keyIndex+1, subItem=keyIndex
+                ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)(keyIndex + 1));
+                LogEverest($"[NDK] Upload key={keyIndex} try3(pic={keyIndex + 1},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+            }
+
+            if (!ok)
+            {
+                // Attempt 4: strip mode (targetDev=0, targetPic=2+keyIndex)
+                ok = _everest.UploadNumpadImageStrip(imagePath, keyIndex, picSlot: (byte)keyIndex);
+                LogEverest($"[NDK] Upload key={keyIndex} try4-strip(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+            }
+
+            if (ok)
+            {
+                _ndkImagePaths[keyIndex] = imagePath;
+                NdkSetThumbnail(keyIndex, imagePath);
+                SaveNdkKey(keyIndex);
+
+                // Update SetDisplayKeyPic to show the new image
+                NdkRefreshDevicePicSlots();
+            }
+        }
+        finally
         {
-            // Attempt 3: picSlot=keyIndex+1, subItem=keyIndex
-            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)(keyIndex + 1));
-            LogEverest($"[NDK] Upload key={keyIndex} try3(pic={keyIndex + 1},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+            Mouse.OverrideCursor = oldCursor;
+            NdkSetButtonsEnabled(true);
+            // The firmware reports the numpad/dock as unplugged (byNumpadPlug/byMMDockPlug
+            // == 0) while it's busy writing the new NDK picture to flash — UpdateKeyboardLayout
+            // (MainWindow.Layout.cs) was suppressed for the duration (_ndkUploadBusy), so it
+            // never acted on that transient reading. Run it once now that the write settled to
+            // pick up the real state (also catches an actual unplug that happened meanwhile).
+            _ndkUploadBusy = false;
+            UpdateKeyboardLayout();
         }
+    }
 
-        if (!ok)
-        {
-            // Attempt 4: strip mode (targetDev=0, targetPic=2+keyIndex)
-            ok = _everest.UploadNumpadImageStrip(imagePath, keyIndex, picSlot: (byte)keyIndex);
-            LogEverest($"[NDK] Upload key={keyIndex} try4-strip(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-        }
+    /// <summary>Set while <see cref="NdkApplyImage"/> is writing a picture to the device —
+    /// <see cref="UpdateKeyboardLayout"/> (MainWindow.Layout.cs) skips its poll-driven
+    /// numpad/dock visibility update during this window, since the firmware transiently
+    /// reports both as unplugged while busy with the flash write, which would otherwise
+    /// flicker them out of the UI until the next successful poll.</summary>
+    private bool _ndkUploadBusy;
 
-        if (ok)
-        {
-            _ndkImagePaths[keyIndex] = imagePath;
-            NdkSetThumbnail(keyIndex, imagePath);
-            SaveNdkKey(keyIndex);
-
-            // Update SetDisplayKeyPic to show the new image
-            NdkRefreshDevicePicSlots();
-        }
+    /// <summary>Enables/disables all 4 NDK buttons while a hardware reload is in flight,
+    /// so the user can't queue up another upload before the previous one (and its
+    /// device-side pic-slot refresh) has actually settled.</summary>
+    private void NdkSetButtonsEnabled(bool enabled)
+    {
+        foreach (var btn in _ndkButtons)
+            if (btn is not null) btn.IsEnabled = enabled;
     }
 
     /// <summary>Sends SetDisplayKeyPic with the current slots.</summary>
@@ -371,10 +424,19 @@ public partial class MainWindow
     {
         int idx = NdkIndexFromMenu(sender);
         if (idx < 0) return;
+        ClearNdkKey(idx);
+    }
+
+    /// <summary>Clears display key <paramref name="idx"/>'s action and icon. Shared by
+    /// the canvas context menu (above) and LvEvKeys's "Remove" button for an NDK entry
+    /// (see BtnEvRemove_Click in MainWindow.Everest.cs).</summary>
+    private void ClearNdkKey(int idx)
+    {
         _ndkActions[idx] = (null, null);
         _ndkImagePaths[idx] = null;
         NdkClearThumbnail(idx);
         SaveNdkKey(idx);
+        EvRefreshNdkInKeyList();
         LogEverest($"[NDK] key={idx} action removed");
     }
 

--- a/K2.App/MainWindow.Settings.cs
+++ b/K2.App/MainWindow.Settings.cs
@@ -70,6 +70,7 @@ public partial class MainWindow
     {
         bool debug = AppSettings.DebugMode;
         CkAppDebugMode.IsChecked = debug;
+        PnlDebugNativeEngines.Visibility = debug ? Visibility.Visible : Visibility.Collapsed;
 
         switch (AppSettings.LogLevel)
         {
@@ -82,6 +83,7 @@ public partial class MainWindow
         CkEvNativeEngine.IsChecked = AppSettings.EverestNativeEngine;
         CkAutoStopBaseCamp.IsChecked = AppSettings.AutoStopBaseCamp;
         CkKillBcWorker.IsChecked = AppSettings.KillBaseCampWorker;
+        CkRestartBcOnClose.IsChecked = AppSettings.RestartBaseCampOnClose;
         InitBcAutostartCheckbox();
 
         CkCloseToTray.IsChecked = AppSettings.CloseToTray;
@@ -171,6 +173,40 @@ public partial class MainWindow
         if (on) Services.BaseCampProcessGuard.KillDisplayPadWorkers(msg => DpLog(msg));
     }
 
+    /// <summary>Persists the "restart Base Camp on close" flag. Read at the moment K2's
+    /// window actually closes (see MainWindow.xaml.cs's OnWindowClosed).</summary>
+    private void CkRestartBcOnClose_Click(object sender, RoutedEventArgs e)
+    {
+        AppSettings.SetRestartBaseCampOnClose(CkRestartBcOnClose.IsChecked == true);
+    }
+
+    /// <summary>Copies the current app log (and crash log, if any) to a user-chosen
+    /// folder — "Export log" button in the General group.</summary>
+    private void BtnAppExportLog_Click(object sender, RoutedEventArgs e)
+    {
+        var folder = new Microsoft.Win32.OpenFolderDialog { Title = Loc.Get("export_pick_folder") };
+        if (folder.ShowDialog(this) != true) return;
+
+        try
+        {
+            string dest = System.IO.Path.Combine(folder.FolderName, System.IO.Path.GetFileName(App.LogPath));
+            System.IO.File.Copy(App.LogPath, dest, overwrite: true);
+
+            if (System.IO.File.Exists(App.CrashLogPath))
+            {
+                string destCrash = System.IO.Path.Combine(folder.FolderName, System.IO.Path.GetFileName(App.CrashLogPath));
+                System.IO.File.Copy(App.CrashLogPath, destCrash, overwrite: true);
+            }
+
+            LblStatus.Text = Loc.Get("settings_export_log_done", folder.FolderName);
+        }
+        catch (System.Exception ex)
+        {
+            MessageBox.Show(this, ex.Message, Loc.Get("settings_export_log_btn"),
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
     private void CkBcAutostart_Click(object sender, RoutedEventArgs e)
     {
         bool enable = CkBcAutostart.IsChecked == true;
@@ -200,6 +236,7 @@ public partial class MainWindow
         bool debug = CkAppDebugMode.IsChecked == true;
         AppSettings.SetDebugMode(debug);
         ApplyDebugModeToAllDevices(debug);
+        PnlDebugNativeEngines.Visibility = debug ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void RbLogLevel_Checked(object sender, RoutedEventArgs e)

--- a/K2.App/MainWindow.xaml
+++ b/K2.App/MainWindow.xaml
@@ -1153,17 +1153,8 @@
                                                 <StackPanel Grid.Column="2">
                                                     <TextBlock Text="{loc:Get dial_clock_section}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                                                     <WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                                        <TextBlock Text="{loc:Get dial_clock_label}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                                        <Border Style="{StaticResource K2SegmentedGroupBorder}" Width="90" Margin="0,0,16,0">
-                                                            <UniformGrid Rows="1">
-                                                                <RadioButton x:Name="RbDialClock24h" Content="24h" GroupName="DialClockType"
-                                                                             Style="{StaticResource K2SegmentedButton}" Checked="RbDialClockType_Checked"/>
-                                                                <RadioButton x:Name="RbDialClock12h" Content="12h" GroupName="DialClockType"
-                                                                             Style="{StaticResource K2SegmentedButton}" Checked="RbDialClockType_Checked"/>
-                                                            </UniformGrid>
-                                                        </Border>
                                                         <TextBlock Text="{loc:Get dial_clock_style_label}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                                        <Border Style="{StaticResource K2SegmentedGroupBorder}" Width="140">
+                                                        <Border Style="{StaticResource K2SegmentedGroupBorder}" Width="140" Margin="0,0,16,0">
                                                             <UniformGrid Rows="1">
                                                                 <RadioButton x:Name="RbDialClockDigital" Content="{loc:Get dial_clock_digital}" GroupName="DialClockStyle"
                                                                              Style="{StaticResource K2SegmentedButton}" Checked="RbDialClockStyle_Checked"/>
@@ -1171,6 +1162,17 @@
                                                                              Style="{StaticResource K2SegmentedButton}" Checked="RbDialClockStyle_Checked"/>
                                                             </UniformGrid>
                                                         </Border>
+                                                        <StackPanel x:Name="PnlDialClockFormat" Orientation="Horizontal">
+                                                            <TextBlock Text="{loc:Get dial_clock_label}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                            <Border Style="{StaticResource K2SegmentedGroupBorder}" Width="90">
+                                                                <UniformGrid Rows="1">
+                                                                    <RadioButton x:Name="RbDialClock24h" Content="24h" GroupName="DialClockType"
+                                                                                 Style="{StaticResource K2SegmentedButton}" Checked="RbDialClockType_Checked"/>
+                                                                    <RadioButton x:Name="RbDialClock12h" Content="12h" GroupName="DialClockType"
+                                                                                 Style="{StaticResource K2SegmentedButton}" Checked="RbDialClockType_Checked"/>
+                                                                </UniformGrid>
+                                                            </Border>
+                                                        </StackPanel>
                                                     </WrapPanel>
 
                                                     <TextBlock Text="{loc:Get dial_screensaver_section}" FontWeight="SemiBold" Margin="0,0,0,8"/>
@@ -2889,10 +2891,18 @@
                                       Click="CkCloseToTray_Click" FontSize="14"/>
                             <CheckBox x:Name="CkK2Autostart" Content="{loc:Get settings_k2_autostart}"
                                       Click="CkK2Autostart_Click" FontSize="14" Margin="0,12,0,0"/>
+                            <TextBlock Text="{loc:Get settings_k2_autostart_hint}" Foreground="#9A9AA2"
+                                       TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
                             <CheckBox x:Name="CkStartMinToTray" Content="{loc:Get settings_start_min_tray}"
                                       Click="CkStartMinToTray_Click" FontSize="14" Margin="0,12,0,0"/>
                             <TextBlock Text="{loc:Get settings_start_min_tray_hint}" Foreground="#9A9AA2"
                                        TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
+                            <Button x:Name="BtnAppExportLog" Content="{loc:Get settings_export_log_btn}"
+                                    Padding="8,4" HorizontalAlignment="Left" Margin="0,16,0,0"
+                                    Click="BtnAppExportLog_Click"
+                                    Style="{StaticResource K2IconButton}" Tag="&#xE898;"/>
+                            <TextBlock Text="{loc:Get settings_export_log_hint}" Foreground="#9A9AA2"
+                                       TextWrapping="Wrap" Margin="0,6,0,0" FontSize="12"/>
                         </StackPanel>
                     </GroupBox>
 
@@ -2910,6 +2920,20 @@
                     <TextBlock Text="{loc:Get settings_debug_mode_hint}" Foreground="#9A9AA2"
                                TextWrapping="Wrap" Margin="20,4,0,20" FontSize="12"/>
 
+                    <!-- Native USB engines are always on by default now — surfaced only under
+                         Debug Mode, as a diagnostic opt-out rather than a base setting. -->
+                    <StackPanel x:Name="PnlDebugNativeEngines" Margin="20,0,0,20" Visibility="Collapsed">
+                        <CheckBox x:Name="CkDpNativeEngine" Content="{loc:Get settings_dp_native}"
+                                  Click="CkDpNativeEngine_Click" FontSize="14"/>
+                        <TextBlock Text="{loc:Get settings_dp_native_hint}" Foreground="#9A9AA2"
+                                   TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
+
+                        <CheckBox x:Name="CkEvNativeEngine" Content="{loc:Get settings_ev_native}"
+                                  Click="CkEvNativeEngine_Click" FontSize="14" Margin="0,16,0,0"/>
+                        <TextBlock Text="{loc:Get settings_ev_native_hint}" Foreground="#9A9AA2"
+                                   TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
+                    </StackPanel>
+
                     <GroupBox x:Name="GbAppLogLevel" Header="{loc:Get settings_log_level}" Margin="0,4,0,0">
                         <StackPanel Margin="8">
                             <RadioButton x:Name="RbLogOff"     Content="{loc:Get log_off}"
@@ -2921,16 +2945,6 @@
                         </StackPanel>
                     </GroupBox>
 
-                    <CheckBox x:Name="CkDpNativeEngine" Content="{loc:Get settings_dp_native}"
-                              Click="CkDpNativeEngine_Click" FontSize="14" Margin="0,20,0,0"/>
-                    <TextBlock Text="{loc:Get settings_dp_native_hint}" Foreground="#9A9AA2"
-                               TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
-
-                    <CheckBox x:Name="CkEvNativeEngine" Content="{loc:Get settings_ev_native}"
-                              Click="CkEvNativeEngine_Click" FontSize="14" Margin="0,16,0,0"/>
-                    <TextBlock Text="{loc:Get settings_ev_native_hint}" Foreground="#9A9AA2"
-                               TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
-
                     <CheckBox x:Name="CkAutoStopBaseCamp" Content="{loc:Get settings_auto_stop_bc}"
                               Click="CkAutoStopBaseCamp_Click" FontSize="14" Margin="0,20,0,0"/>
                     <TextBlock Text="{loc:Get settings_auto_stop_bc_hint}" Foreground="#9A9AA2"
@@ -2939,6 +2953,11 @@
                     <CheckBox x:Name="CkKillBcWorker" Content="{loc:Get settings_kill_bc_worker}"
                               Click="CkKillBcWorker_Click" FontSize="14" Margin="0,16,0,0"/>
                     <TextBlock Text="{loc:Get settings_kill_bc_worker_hint}" Foreground="#9A9AA2"
+                               TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
+
+                    <CheckBox x:Name="CkRestartBcOnClose" Content="{loc:Get settings_restart_bc_on_close}"
+                              Click="CkRestartBcOnClose_Click" FontSize="14" Margin="0,16,0,0"/>
+                    <TextBlock Text="{loc:Get settings_restart_bc_on_close_hint}" Foreground="#9A9AA2"
                                TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
 
                     <CheckBox x:Name="CkBcAutostart" Content="{loc:Get settings_bc_autostart}"

--- a/K2.App/MainWindow.xaml.cs
+++ b/K2.App/MainWindow.xaml.cs
@@ -553,6 +553,12 @@ public partial class MainWindow : Window
         _usbRec.Dispose();
         CleanupDisplayPad();
         _trayIcon?.Dispose();
+
+        // Put Base Camp back the way K2 found it, if the user asked for that (see
+        // Settings > General > "Restart Base Camp on close").
+        if (AppSettings.RestartBaseCampOnClose)
+            Services.BaseCampProcessGuard.RestartKilledProcesses(App.WriteLog);
+
         // ShutdownMode is OnExplicitShutdown (see App.OnStartup) so that hiding the
         // window to the tray never ends the process — the real close must ask for it.
         Application.Current.Shutdown();
@@ -581,6 +587,7 @@ public sealed class EvProfileItem(int slot, string label)
 {
     public int Slot { get; } = slot;
     public string Label { get; } = label;
+    public bool IsNew => Label.StartsWith("+");
     public override string ToString() => Label;
 }
 

--- a/K2.App/Models/EverestKey.cs
+++ b/K2.App/Models/EverestKey.cs
@@ -16,8 +16,28 @@ public sealed class EverestKey : INotifyPropertyChanged
 {
     public EverestKey(int keyMatrix) => KeyMatrix = keyMatrix;
 
-    /// <summary>Hardware matrix code: stable key identity.</summary>
+    /// <summary>Hardware matrix code: stable key identity. For an NDK entry (see
+    /// <see cref="NdkIndex"/>) this is a negative placeholder — display keys have no
+    /// real matrix code and never go through <c>_evByMatrix</c>.</summary>
     public int KeyMatrix { get; }
+
+    /// <summary>Set (0-3) for one of the 4 numpad LCD "display keys" (NDK), surfaced in
+    /// this same mapped-keys list when it carries a non-default action or image — null
+    /// for a regular keyboard key. NDK state lives in EverestStore's global
+    /// <c>ndk.{i}.*</c> settings, not the per-profile Keys table (see
+    /// MainWindow.NumpadDisplayKeys.cs) — callers must branch on this before touching
+    /// <see cref="KeyMatrix"/>-keyed persistence.</summary>
+    public int? NdkIndex { get; init; }
+
+    private bool _hasImage;
+    /// <summary>True if an NDK entry has a custom icon (independent of <see cref="HasAction"/> —
+    /// a display key can carry only an icon, only an action, or both). Always false for a
+    /// regular key.</summary>
+    public bool HasImage
+    {
+        get => _hasImage;
+        set { if (_hasImage == value) return; _hasImage = value; OnChanged(); OnChanged(nameof(Display)); }
+    }
 
     private string _label = "";
     /// <summary>User-assigned name (e.g. "F5", "Macro 1", "Encoder CW").</summary>
@@ -78,7 +98,9 @@ public sealed class EverestKey : INotifyPropertyChanged
     {
         get
         {
-            string body = string.IsNullOrEmpty(_actionType) ? "(empty)" : _actionType;
+            string body = !string.IsNullOrEmpty(_actionType) ? _actionType
+                         : _hasImage ? K2.Core.Loc.Get("ev_display_key_icon_only")
+                         : "(empty)";
             return $"{Name}  —  {body}";
         }
     }

--- a/K2.App/Services/BaseCampDbImporter.cs
+++ b/K2.App/Services/BaseCampDbImporter.cs
@@ -259,6 +259,15 @@ public sealed class BaseCampDbImporter
         return imported;
     }
 
+    /// <summary>
+    /// True if the action is Base Camp's "Default" placeholder preserved verbatim by an
+    /// older import (<c>bc:Default</c>) — it means "no custom binding", so every store
+    /// load treats it as an empty button instead of a mapping. New imports no longer
+    /// produce it (<see cref="TranslateAction"/> maps "Default" to no action).
+    /// </summary>
+    internal static bool IsBcDefaultAction(string? actionType) =>
+        string.Equals(actionType, "bc:Default", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>Parses {"Id":2407,...} from OptionalText to extract the folder page ID.</summary>
     internal static int ParseFolderPageId(string? optionalText)
     {
@@ -341,7 +350,7 @@ public sealed class BaseCampDbImporter
             "Mouse Button" =>
                 ("mouse", subType?.ToLowerInvariant()),
 
-            "Disable" or "Disabled" =>
+            "Disable" or "Disabled" or "Default" =>
                 (null, null),
 
             _ =>
@@ -1135,9 +1144,19 @@ public sealed class BaseCampDbImporter
     /// </summary>
     internal static byte[]? DecodeBase64Image(string raw)
     {
-        // BC sometimes stores an internal asset path instead of base64 data.
-        // These paths can't be resolved outside Base Camp — skip them.
-        var trimmed = raw.TrimStart();
+        // BC sometimes stores a filesystem path instead of embedded base64 data
+        // (e.g. a custom icon that was picked but never re-encoded into the
+        // export). Load it straight from disk if it still exists there.
+        var trimmed = raw.Trim();
+        try
+        {
+            if (File.Exists(trimmed))
+                return File.ReadAllBytes(trimmed);
+        }
+        catch { /* not a usable path — fall through and try base64 */ }
+
+        // BC's internal asset paths (e.g. "/Icons/foo.png") and remote URLs
+        // aren't resolvable outside Base Camp and won't exist on disk — skip them.
         if (trimmed.StartsWith('/') || trimmed.StartsWith("http", StringComparison.OrdinalIgnoreCase))
             return null;
 

--- a/K2.App/Services/BaseCampProcessGuard.cs
+++ b/K2.App/Services/BaseCampProcessGuard.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Win32;
 
@@ -131,6 +132,195 @@ internal static class BaseCampProcessGuard
         {
             log?.Invoke($"[AutoStop] could not stop BaseCampService: {ex.Message}");
         }
+    }
+
+    /// <summary>Starts the Base Camp Windows service via <c>sc.exe</c> (mirror of
+    /// <see cref="StopBaseCampService"/>). Requires admin rights; fails silently
+    /// (logged, not thrown) otherwise.</summary>
+    private static void StartBaseCampService(Action<string>? log)
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("sc.exe", "start BaseCampService")
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            using var sc = System.Diagnostics.Process.Start(psi);
+            sc?.WaitForExit(3000);
+            log?.Invoke(sc != null && sc.ExitCode == 0
+                ? "[Restart] BaseCampService started."
+                : "[Restart] BaseCampService not started (not installed, already running, or admin rights needed).");
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"[Restart] could not start BaseCampService: {ex.Message}");
+        }
+    }
+
+    // ================================================================
+    // Restart on K2 close — AppSettings.RestartBaseCampOnClose
+    // ================================================================
+
+    /// <summary>
+    /// Puts Base Camp back the way it normally starts: the Windows service, plus every
+    /// enabled Base Camp Windows-autostart entry (usually just "Base Camp.exe", which
+    /// spawns its own worker processes the same way it would after a fresh boot), plus
+    /// MountainDisplayPadWorker directly (it has no autostart entry of its own — Base
+    /// Camp normally launches it internally, but relaunching it here doesn't depend on
+    /// that). Called on K2 close when <see cref="AppSettings.RestartBaseCampOnClose"/> is
+    /// enabled.
+    ///
+    /// Deliberately NOT based on "what K2 personally killed this run": if Base Camp was
+    /// already stopped before K2 even started (e.g. the previous K2 session already shut
+    /// it down and it never came back), there would be nothing recorded to relaunch even
+    /// though the user still wants it running again — confirmed on hardware 2026-07-15.
+    /// Each executable is skipped if a process with that name is already running, so this
+    /// is safe to call even when Base Camp never got auto-stopped this session.
+    /// Returns the number of processes actually launched.
+    /// </summary>
+    public static int RestartKilledProcesses(Action<string>? log = null)
+    {
+        StartBaseCampService(log);
+
+        int started = 0;
+
+        var entries = FindAutostartEntries().Where(e => e.Enabled).ToList();
+        if (entries.Count == 0)
+            log?.Invoke("[Restart] no enabled Base Camp autostart entry found in the registry.");
+        foreach (var entry in entries)
+        {
+            if (LaunchCommand(entry.Command, log)) started++;
+        }
+
+        if (!IsRunning("MountainDisplayPadWorker"))
+        {
+            string[] installDirs = NativeDependencyResolver.BaseCampDirectories();
+            string? worker = ResolveExePath(installDirs, "MountainDisplayPadWorker");
+            if (worker is null)
+            {
+                log?.Invoke(installDirs.Length == 0
+                    ? "[Restart] no Base Camp installation folder found — cannot locate MountainDisplayPadWorker.exe."
+                    : $"[Restart] MountainDisplayPadWorker.exe not found under {string.Join(" | ", installDirs)}.");
+            }
+            else
+            {
+                try
+                {
+                    var psi = new System.Diagnostics.ProcessStartInfo(worker)
+                    {
+                        UseShellExecute = false,
+                        CreateNoWindow = true, // background worker, no UI of its own
+                        WorkingDirectory = Path.GetDirectoryName(worker) ?? "",
+                    };
+                    System.Diagnostics.Process.Start(psi);
+                    started++;
+                    log?.Invoke($"[Restart] relaunched silently: {worker}");
+                }
+                catch (Exception ex)
+                {
+                    log?.Invoke($"[Restart] could not relaunch {worker}: {ex.Message}");
+                }
+            }
+        }
+
+        return started;
+    }
+
+    private static bool IsRunning(string processName)
+    {
+        try { return System.Diagnostics.Process.GetProcessesByName(processName).Length > 0; }
+        catch { return false; }
+    }
+
+    /// <summary>Splits a registry Run-key command (quoted path, or an unquoted path that
+    /// may itself contain spaces followed by arguments — e.g.
+    /// <c>C:\Program Files (x86)\Mountain Base Camp\Base Camp.exe --hidden</c>) into an
+    /// executable path and its argument string, then launches it exactly as Windows
+    /// autostart would — skipped if a process with the exe's name is already running.
+    /// Returns true if a new process was started.</summary>
+    private static bool LaunchCommand(string command, Action<string>? log)
+    {
+        var (exe, args) = SplitCommandLine(command);
+        if (exe is null || !File.Exists(exe))
+        {
+            log?.Invoke($"[Restart] could not resolve executable from autostart command: {command}");
+            return false;
+        }
+
+        string name = Path.GetFileNameWithoutExtension(exe);
+        if (IsRunning(name))
+        {
+            log?.Invoke($"[Restart] {name} already running, skipping.");
+            return false;
+        }
+
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo(exe)
+            {
+                Arguments = args,
+                UseShellExecute = false,
+                WorkingDirectory = Path.GetDirectoryName(exe) ?? "",
+            };
+            System.Diagnostics.Process.Start(psi);
+            log?.Invoke($"[Restart] relaunched: {exe} {args}".TrimEnd());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"[Restart] could not relaunch {exe}: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>Mirrors how CreateProcess resolves an unquoted lpCommandLine: a quoted
+    /// path is taken as-is; otherwise, walk forward to each ".exe" occurrence and accept
+    /// the first prefix that actually exists on disk (handles "Base Camp.exe" being an
+    /// unquoted path that itself contains a space, followed by arguments).</summary>
+    private static (string? exe, string args) SplitCommandLine(string command)
+    {
+        command = command.Trim();
+        if (command.Length == 0) return (null, "");
+
+        if (command[0] == '"')
+        {
+            int end = command.IndexOf('"', 1);
+            if (end > 0)
+                return (command.Substring(1, end - 1), command.Substring(end + 1).Trim());
+        }
+
+        int searchFrom = 0;
+        while (true)
+        {
+            int exeIdx = command.IndexOf(".exe", searchFrom, StringComparison.OrdinalIgnoreCase);
+            if (exeIdx < 0) return (command, ""); // no ".exe" found: best-effort, treat whole string as the path
+            int end = exeIdx + 4;
+            string candidate = command.Substring(0, end);
+            if (File.Exists(candidate))
+                return (candidate, command.Substring(end).Trim());
+            searchFrom = end;
+        }
+    }
+
+    /// <summary>Finds "{processName}.exe" under any of the given install folders (recursive
+    /// — Base Camp's Electron GUI keeps some executables under resources\bin). Returns the
+    /// first match, or null if not found in any of them.</summary>
+    private static string? ResolveExePath(string[] installDirs, string processName)
+    {
+        foreach (var dir in installDirs)
+        {
+            try
+            {
+                var match = Directory.EnumerateFiles(dir, processName + ".exe", SearchOption.AllDirectories)
+                    .FirstOrDefault();
+                if (match is not null) return match;
+            }
+            catch { /* unreadable subfolder: skip */ }
+        }
+        return null;
     }
 
     // ================================================================

--- a/K2.App/Services/DisplayPadStore.cs
+++ b/K2.App/Services/DisplayPadStore.cs
@@ -127,11 +127,7 @@ ON CONFLICT(DeviceId, Profile, PageId, ButtonIndex) DO UPDATE SET
         cmd.Parameters.AddWithValue("$pg", pageId);
         using var r = cmd.ExecuteReader();
         while (r.Read())
-            result.Add(new DpButtonRecord(deviceId, profile,
-                r.GetInt32(0), r.GetInt32(1),
-                r.IsDBNull(2) ? null : r.GetString(2),
-                r.IsDBNull(3) ? null : r.GetString(3),
-                r.IsDBNull(4) ? null : r.GetString(4)));
+            AddButtonRow(result, deviceId, profile, r);
         return result;
     }
 
@@ -147,12 +143,28 @@ ON CONFLICT(DeviceId, Profile, PageId, ButtonIndex) DO UPDATE SET
         cmd.Parameters.AddWithValue("$p", profile);
         using var r = cmd.ExecuteReader();
         while (r.Read())
-            result.Add(new DpButtonRecord(deviceId, profile,
-                r.GetInt32(0), r.GetInt32(1),
-                r.IsDBNull(2) ? null : r.GetString(2),
-                r.IsDBNull(3) ? null : r.GetString(3),
-                r.IsDBNull(4) ? null : r.GetString(4)));
+            AddButtonRow(result, deviceId, profile, r);
         return result;
+    }
+
+    /// <summary>
+    /// Materializes one Buttons row (PageId, ButtonIndex, ImagePath, ActionType, ActionValue
+    /// in that SELECT order). A leftover <c>bc:Default</c> action from an old BC import is
+    /// no mapping at all: the row is dropped outright, unless it carries an icon — then the
+    /// icon is kept and only the action is discarded.
+    /// </summary>
+    private static void AddButtonRow(List<DpButtonRecord> result, int deviceId, int profile,
+        SqliteDataReader r)
+    {
+        string? img = r.IsDBNull(2) ? null : r.GetString(2);
+        string? at  = r.IsDBNull(3) ? null : r.GetString(3);
+        string? av  = r.IsDBNull(4) ? null : r.GetString(4);
+        if (BaseCampDbImporter.IsBcDefaultAction(at))
+        {
+            if (img is null) return;
+            at = null; av = null;
+        }
+        result.Add(new DpButtonRecord(deviceId, profile, r.GetInt32(0), r.GetInt32(1), img, at, av));
     }
 
     /// <summary>Legacy alias — loads root page (pageId=0) only.</summary>

--- a/K2.App/Services/EvProfileExporter.cs
+++ b/K2.App/Services/EvProfileExporter.cs
@@ -16,6 +16,20 @@ namespace K2.App.Services;
 /// confirmed for the DisplayPad (<see cref="DpProfileExporter"/>), shared in the
 /// real Base Camp code via <c>BaseCampDbImporter.TranslateAction</c>.
 ///
+/// **XML element names (confirmed 2026-07-15 against a real Base Camp XML export
+/// and the decompiled <c>Profile</c>/<c>KeyboardBinding</c> classes)**: the DB
+/// TABLE name (<c>EverestKeyBidings</c>, with Base Camp's own typo) is NOT what
+/// appears in exported XML — that's a distinct navigation PROPERTY on
+/// <c>Profile</c>, correctly spelled <c>EverestKeyBindings</c>, rendered by
+/// XmlSerializer as a wrapper element containing one child per item named after
+/// the item's CLASS, <c>KeyboardBinding</c> (same convention verified for
+/// DisplayPad: wrapper <c>DisplayPadKeyBindings</c> / item
+/// <c>DisplayPadLayerBidings</c>, its class name). This exporter previously wrote
+/// flat <c>EverestKeyBidings</c> elements (typo, no wrapper) — self-consistent
+/// with K2's own importer but never actually readable by real Base Camp, and real
+/// Base Camp XML was never readable by K2 either (see
+/// <c>MainWindow.Everest.cs</c>'s <c>BtnEvImportXml_Click</c>).
+///
 /// Includes both the regular keys (KeyMatrix stored in <see cref="EverestStore"/>)
 /// and the 4 numpad LCD keys (NDK). Note: in K2, NDK images/actions are
 /// GLOBAL device settings (not per-profile — see
@@ -51,6 +65,12 @@ public static class EvProfileExporter
             new XElement("ProfileName", profileName),
             new XElement("OrderNo", slot));
 
+        // Wrapper element matching Base Camp's real Profile.EverestKeyBindings
+        // navigation property (see class doc comment) — each binding below is a
+        // <KeyboardBinding> child of this wrapper, not a flat sibling of Profile.
+        var bindingsEl = new XElement("EverestKeyBindings");
+        root.Add(bindingsEl);
+
         // ---- Regular keys ----
         foreach (var k in store.LoadProfile(slot))
         {
@@ -84,7 +104,7 @@ public static class EvProfileExporter
                 exported++;
             }
 
-            root.Add(BuildBinding(k.KeyMatrix, k.KeyMatrix, k.Label ?? $"K{k.KeyMatrix}",
+            bindingsEl.Add(BuildBinding(k.KeyMatrix, k.KeyMatrix, k.Label ?? $"K{k.KeyMatrix}",
                 isAssigned, isTouchKey: false, functionType, subType, funcValue, imageB64: null));
         }
 
@@ -131,7 +151,7 @@ public static class EvProfileExporter
 
             if (!bcCompatible || hasImage)
             {
-                root.Add(BuildBinding(keyId, keyId, $"NDK{i}",
+                bindingsEl.Add(BuildBinding(keyId, keyId, $"NDK{i}",
                     isAssigned, isTouchKey: true, functionType, subType, funcValue, imageB64));
             }
         }
@@ -146,10 +166,10 @@ public static class EvProfileExporter
         int keyId, int dllMatrixIndex, string keyName, bool isAssigned, bool isTouchKey,
         string? functionType, string? subType, string? funcValue, string? imageB64)
     {
-        // Tag "EverestKeyBidings" = real Base Camp table name (same assumption
-        // already made for the DisplayPad — NEVER verified against a real
-        // export of an Everest profile, see _PROJECT_MAP.md).
-        return new XElement("EverestKeyBidings",
+        // Tag "KeyboardBinding" = real Base Camp per-item class name (confirmed
+        // 2026-07-15 against a real Base Camp XML export + decompiled classes —
+        // see this file's doc comment; NOT the DB table name "EverestKeyBidings").
+        return new XElement("KeyboardBinding",
             new XElement("ProfileId", 0),
             new XElement("KeyId", keyId),
             new XElement("KeyName", keyName),

--- a/K2.App/Services/Everest60Store.cs
+++ b/K2.App/Services/Everest60Store.cs
@@ -170,11 +170,16 @@ ON CONFLICT(Key) DO UPDATE SET Value=excluded.Value";
         cmd.Parameters.AddWithValue("$p", profile);
         using var r = cmd.ExecuteReader();
         while (r.Read())
+        {
+            string? at = r.IsDBNull(2) ? null : r.GetString(2);
+            // Leftover bc:Default from an old BC import = "no custom binding": empty key.
+            if (BaseCampDbImporter.IsBcDefaultAction(at)) continue;
             result.Add(new Ev60KeyRecord(
                 profile, r.GetInt32(0),
                 r.IsDBNull(1) ? null : r.GetString(1),
-                r.IsDBNull(2) ? null : r.GetString(2),
+                at,
                 r.IsDBNull(3) ? null : r.GetString(3)));
+        }
         return result;
     }
 

--- a/K2.App/Services/EverestService.cs
+++ b/K2.App/Services/EverestService.cs
@@ -1062,23 +1062,30 @@ public sealed class EverestService : IDisposable
     }
 
     /// <summary>
-    /// Updates the clock on the Media Dock's display with the current time.
-    /// Call periodically (every second, as Base Camp does).
+    /// Updates the clock on the Media Dock's display with the current time and
+    /// format. Call periodically (every second, as Base Camp does).
     /// </summary>
-    public bool UpdateClock()
+    /// <remarks>
+    /// <b>2026-07-15, real Base Camp USB capture (_reference/usb_dumps/evclock.pcapng):</b>
+    /// toggling the clock format (12h/24h) in Base Camp's own UI produces ZERO
+    /// change to FW_EXTEND_INFO (byMMDockScreenSetup stays constant throughout)
+    /// — the format is instead carried on every periodic <c>SetClockInfo</c> call
+    /// itself (this method), not through SetExtendInfo. Previously this method
+    /// only ever re-sent whatever <c>GetClockInfo</c> reported, so K2's Display
+    /// Dial 12h/24h buttons had no way to actually reach the device (nothing
+    /// called this method either — see MainWindow.DisplayDial.cs). Now takes the
+    /// desired format explicitly and forces the clock on, since nothing else in
+    /// K2 ever sets it true.
+    /// </remarks>
+    public bool UpdateClock(bool format24h)
     {
         lock (_sdkLock)
         try
         {
-            // First read whether the clock is enabled and the format
-            bool clockEnabled = false, format24h = false;
-            bool gotClock = EverestSdkNative.GetClockInfo(ref clockEnabled, ref format24h);
-            if (!gotClock || !clockEnabled) return false;
-
             var now = DateTime.Now;
             bool ok = EverestSdkNative.SetClockInfo(
                 now.Month, now.Day, now.Hour, now.Minute, now.Second,
-                clockEnabled, format24h);
+                clockEnabled: true, format24h);
             return ok;
         }
         catch (Exception ex)

--- a/K2.App/Services/EverestStore.cs
+++ b/K2.App/Services/EverestStore.cs
@@ -101,6 +101,50 @@ ON CONFLICT(KeyId) DO UPDATE SET ColorHex=excluded.ColorHex, ImagePath=excluded.
 
     // ---------- keys ----------
 
+    /// <summary>Profile slots that are actually configured — mirrors MacroPadStore/
+    /// DpStore's GetExistingProfiles, used to hide empty slots from the profile
+    /// combo (the device firmware always has 5 fixed slots, but K2's UI only lists
+    /// the ones actually in use, same as every other module). A slot counts as
+    /// existing if it has a bound key, a custom name, or the "exists" marker set
+    /// by <see cref="MarkProfileExists"/> for brand-new empty profiles — unlike
+    /// MacroPad/DisplayPad, Everest's key list is a sparse ListView (not a
+    /// fixed-size grid), so a dummy placeholder Keys row would show up as a
+    /// visible blank row instead of being invisible filler.</summary>
+    public List<int> GetExistingProfiles()
+    {
+        var result = new SortedSet<int>();
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT DISTINCT Profile FROM Keys WHERE ActionType IS NOT NULL";
+            using var r = cmd.ExecuteReader();
+            while (r.Read()) result.Add(r.GetInt32(0));
+        }
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = @"SELECT Key, Value FROM Settings
+                                WHERE Key LIKE 'profile.%.name' OR Key LIKE 'profile.%.exists'";
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                string key = r.GetString(0);
+                string value = r.IsDBNull(1) ? "" : r.GetString(1);
+                if (string.IsNullOrEmpty(value)) continue;
+                var parts = key.Split('.');
+                if (parts.Length == 3 && int.TryParse(parts[1], out int slot))
+                    result.Add(slot);
+            }
+        }
+
+        return new List<int>(result);
+    }
+
+    /// <summary>Marks an otherwise-empty profile as "existing" so it shows up in the
+    /// profile combo — see <see cref="GetExistingProfiles"/> for why this uses a
+    /// Settings flag instead of a placeholder Keys row.</summary>
+    public void MarkProfileExists(int profile) => SetSetting($"profile.{profile}.exists", "1");
+
     public IReadOnlyList<EverestKeyRecord> LoadProfile(int profile)
     {
         var result = new List<EverestKeyRecord>();
@@ -111,11 +155,16 @@ ON CONFLICT(KeyId) DO UPDATE SET ColorHex=excluded.ColorHex, ImagePath=excluded.
         cmd.Parameters.AddWithValue("$p", profile);
         using var r = cmd.ExecuteReader();
         while (r.Read())
+        {
+            string? at = r.IsDBNull(2) ? null : r.GetString(2);
+            // Leftover bc:Default from an old BC import = "no custom binding": empty key.
+            if (BaseCampDbImporter.IsBcDefaultAction(at)) continue;
             result.Add(new EverestKeyRecord(
                 profile, r.GetInt32(0),
                 r.IsDBNull(1) ? null : r.GetString(1),
-                r.IsDBNull(2) ? null : r.GetString(2),
+                at,
                 r.IsDBNull(3) ? null : r.GetString(3)));
+        }
         return result;
     }
 
@@ -169,8 +218,10 @@ ON CONFLICT(Profile, KeyMatrix) DO UPDATE SET
         cmd.CommandText = "DELETE FROM Keys WHERE Profile=$p";
         cmd.Parameters.AddWithValue("$p", profile);
         cmd.ExecuteNonQuery();
-        // Clear the saved name too
+        // Clear the saved name and "exists" marker too, so the slot disappears
+        // from the profile combo (see GetExistingProfiles) until reused.
         SetSetting($"profile.{profile}.name", "");
+        SetSetting($"profile.{profile}.exists", "");
     }
 
     /// <summary>Deletes only this profile's key bindings — unlike <see cref="ClearProfile"/>,
@@ -183,6 +234,9 @@ ON CONFLICT(Profile, KeyMatrix) DO UPDATE SET
         cmd.CommandText = "DELETE FROM Keys WHERE Profile=$p";
         cmd.Parameters.AddWithValue("$p", profile);
         cmd.ExecuteNonQuery();
+        // Keep the slot visible in the profile combo — this clears content, not
+        // identity/existence (unlike ClearProfile/delete).
+        MarkProfileExists(profile);
     }
 
     /// <summary>Wipes every profile, key binding, setting and keycap override — used by the

--- a/K2.App/Services/K2AutostartService.cs
+++ b/K2.App/Services/K2AutostartService.cs
@@ -7,7 +7,12 @@ namespace K2.App.Services;
 /// Manages K2.App's own Windows-autostart entry (HKCU Run key) — separate from
 /// <see cref="BaseCampProcessGuard"/>'s Base Camp autostart management, which only
 /// enables/disables existing entries and never touches K2's own. HKCU-only by design:
-/// no admin rights required, matching "start with Windows" as a per-user preference.
+/// no admin rights required to write the entry itself.
+///
+/// CAVEAT: K2.App now carries a requireAdministrator manifest (see app.manifest — needed
+/// to control BaseCampService, which runs as LocalSystem). Windows does NOT auto-elevate
+/// Run-key entries at logon, so an app manifested requireAdministrator launched this way
+/// can fail to start silently. See settings_k2_autostart_hint in the Settings tab.
 /// </summary>
 internal static class K2AutostartService
 {

--- a/K2.App/Services/MacroPadStore.cs
+++ b/K2.App/Services/MacroPadStore.cs
@@ -114,10 +114,15 @@ ON CONFLICT(KeyId) DO UPDATE SET ColorHex=excluded.ColorHex, ImagePath=excluded.
         cmd.Parameters.AddWithValue("$p", profile);
         using var r = cmd.ExecuteReader();
         while (r.Read())
+        {
+            string? at = r.IsDBNull(1) ? null : r.GetString(1);
+            // Leftover bc:Default from an old BC import = "no custom binding": empty key.
+            if (BaseCampDbImporter.IsBcDefaultAction(at)) continue;
             result.Add(new MacroKeyRecord(
                 deviceId, profile, r.GetInt32(0),
-                r.IsDBNull(1) ? null : r.GetString(1),
+                at,
                 r.IsDBNull(2) ? null : r.GetString(2)));
+        }
         return result;
     }
 

--- a/K2.App/app.manifest
+++ b/K2.App/app.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="K2.App.app"/>
+
+  <!-- Elevation is required to control BaseCampService (runs as LocalSystem): without
+       it, sc.exe stop/start silently fails (access denied) and Base Camp's service can
+       respawn MountainDisplayPadWorker on its own, reintroducing the DisplayPad icon
+       corruption K2's auto-stop is meant to prevent — confirmed on hardware 2026-07-15
+       (worker was back up right after K2's kill, service inaccessible without admin). -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 8.1 / 10 / 11 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/K2.Core/AppSettings.cs
+++ b/K2.Core/AppSettings.cs
@@ -30,12 +30,13 @@ public static class AppSettings
     {
         public bool DebugMode { get; set; }
         public K2LogLevel LogLevel { get; set; } = K2LogLevel.Normal;
-        public bool DisplayPadNativeEngine { get; set; }
-        public bool EverestNativeEngine { get; set; }
+        public bool DisplayPadNativeEngine { get; set; } = true;
+        public bool EverestNativeEngine { get; set; } = true;
         public bool KillBaseCampWorker { get; set; } = true;
         public bool AutoStopBaseCamp { get; set; } = true;
         public bool CloseToTray { get; set; }
         public bool StartMinimizedToTray { get; set; }
+        public bool RestartBaseCampOnClose { get; set; }
         public List<string> RecentExecPaths { get; set; } = new();
         public List<string> RecentFolderPaths { get; set; } = new();
         public string? MakaluDeviceName { get; set; }
@@ -80,10 +81,12 @@ public static class AppSettings
     }
 
     /// <summary>
-    /// Experimental: drive the DisplayPad through the raw USB-HID engine
-    /// (DisplayPadNativeClient) instead of DisplayPadSDK.dll + satellite process.
-    /// Read once at startup (backend is chosen when MainWindow is constructed),
-    /// so changing it requires an app restart.
+    /// Drive the DisplayPad through the raw USB-HID engine (DisplayPadNativeClient)
+    /// instead of DisplayPadSDK.dll + satellite process. Default ON — the native engine
+    /// is now the standard path; the checkbox only surfaces under Settings &gt; Debug Mode
+    /// as a diagnostic opt-out (fall back to the SDK) if it ever needs ruling out.
+    /// Read once at startup (backend is chosen when MainWindow is constructed), so
+    /// changing it requires an app restart.
     /// </summary>
     public static bool DisplayPadNativeEngine
     {
@@ -103,12 +106,13 @@ public static class AppSettings
     }
 
     /// <summary>
-    /// Experimental: drive the Everest Max's connectivity (open/close/init) and RGB
-    /// effects through the raw USB-HID engine (<c>EverestHidNative</c>) instead of
-    /// SDKDLL.dll. The full 171-key remap event stream, numpad display icons, and
-    /// Media Dock still go through SDKDLL.dll regardless of this flag — those are not
-    /// natively implemented yet (unconfirmed wire protocol, see task/memory "Everest
-    /// nativo — Fase 3/4"). Read once at startup, so changing it requires a restart.
+    /// Drive the Everest Max's connectivity (open/close/init) and RGB effects through the
+    /// raw USB-HID engine (<c>EverestHidNative</c>) instead of SDKDLL.dll. The full
+    /// 171-key remap event stream, numpad display icons, and Media Dock still go through
+    /// SDKDLL.dll regardless of this flag — those are not natively implemented yet
+    /// (unconfirmed wire protocol, see task/memory "Everest nativo — Fase 3/4"). Default
+    /// ON for what it covers; the checkbox only surfaces under Settings &gt; Debug Mode as
+    /// a diagnostic opt-out. Read once at startup, so changing it requires a restart.
     /// </summary>
     public static bool EverestNativeEngine
     {
@@ -206,6 +210,32 @@ public static class AppSettings
         {
             if (_data.StartMinimizedToTray == value) return;
             _data.StartMinimizedToTray = value;
+            Save();
+        }
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// When true, K2 puts Base Camp back the way it normally starts (see
+    /// <see cref="Services.BaseCampProcessGuard.RestartKilledProcesses"/>: Windows
+    /// service + autostart entries + MountainDisplayPadWorker) when the user closes K2
+    /// (real exit, not close-to-tray). MountainDisplayPadWorker is always relaunched
+    /// silently (no window); other Base Camp executables (e.g. the GUI) are relaunched
+    /// the normal way. Default OFF — most users who enabled auto-stop want Base Camp to
+    /// stay stopped after closing K2.
+    /// </summary>
+    public static bool RestartBaseCampOnClose
+    {
+        get { EnsureLoaded(); return _data.RestartBaseCampOnClose; }
+    }
+
+    public static void SetRestartBaseCampOnClose(bool value)
+    {
+        EnsureLoaded();
+        lock (_lock)
+        {
+            if (_data.RestartBaseCampOnClose == value) return;
+            _data.RestartBaseCampOnClose = value;
             Save();
         }
         Changed?.Invoke();

--- a/K2.Core/Loc.cs
+++ b/K2.Core/Loc.cs
@@ -17,10 +17,16 @@ namespace K2.Core;
 ///   2. Embedded default <c>Strings.xml</c> shipped inside K2.Core
 ///
 /// The language code comes from (in order):
-///   - <c>K2.lang</c> file next to the running executable  (written by <see cref="SetLanguage"/>)
+///   - <c>K2.lang</c> file in <c>%LocalAppData%\K2\</c> (written by <see cref="SetLanguage"/>)
+///   - <c>K2.lang</c> next to the running executable (legacy location, read-only —
+///     kept so installs that saved it there while running elevated still pick it up)
 ///   - <c>K2_LANG</c> environment variable
 ///   - Current UI culture's two-letter ISO code (e.g. "it", "de")
 /// Set <c>K2_LANG=en</c> (or write "en" in K2.lang) to force English (built-in default).
+///
+/// <c>%LocalAppData%</c> (not the exe folder) is used deliberately: K2 installs to
+/// Program Files by default, which is admin-write-protected. Writing there without
+/// elevation used to fail silently, so the language choice never persisted.
 ///
 /// To switch language at runtime call <see cref="SetLanguage"/> — it saves the choice
 /// and raises <see cref="RestartRequested"/> so the host app can restart.
@@ -58,9 +64,9 @@ public static class Loc
     }
 
     /// <summary>
-    /// Saves <paramref name="lang"/> to the <c>K2.lang</c> file next to the
-    /// executable, then raises <see cref="RestartRequested"/> so the host app
-    /// can restart and pick up the new language.
+    /// Saves <paramref name="lang"/> to the <c>K2.lang</c> file under
+    /// <c>%LocalAppData%\K2\</c>, then raises <see cref="RestartRequested"/> so the
+    /// host app can restart and pick up the new language.
     /// Always writes and restarts — never skips silently.
     /// </summary>
     public static void SetLanguage(string lang)
@@ -68,13 +74,19 @@ public static class Loc
         lang = lang.Trim().ToLowerInvariant();
         try
         {
-            var langFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "K2.lang");
-            File.WriteAllText(langFile, lang);
+            Directory.CreateDirectory(DataDir);
+            File.WriteAllText(LangFilePath, lang);
         }
         catch { /* non-fatal */ }
 
         RestartRequested?.Invoke(lang);
     }
+
+    /// <summary>Per-user, always-writable data folder — never needs admin rights.</summary>
+    private static readonly string DataDir = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "K2");
+
+    private static readonly string LangFilePath = Path.Combine(DataDir, "K2.lang");
 
     /// <summary>
     /// Explicitly initialize the localization system.
@@ -90,12 +102,20 @@ public static class Loc
 
         // 2. Determine language (K2.lang file > env var > UI culture)
         var exeDir = AppDomain.CurrentDomain.BaseDirectory;
-        var langFile = Path.Combine(exeDir, "K2.lang");
 
         string? lang = null;
-        if (File.Exists(langFile))
+        if (File.Exists(LangFilePath))
         {
-            try { lang = File.ReadAllText(langFile).Trim(); } catch { }
+            try { lang = File.ReadAllText(LangFilePath).Trim(); } catch { }
+        }
+        if (lang == null)
+        {
+            // Legacy location (pre-fix installs that saved it while running elevated).
+            var legacyLangFile = Path.Combine(exeDir, "K2.lang");
+            if (File.Exists(legacyLangFile))
+            {
+                try { lang = File.ReadAllText(legacyLangFile).Trim(); } catch { }
+            }
         }
         lang ??= Environment.GetEnvironmentVariable("K2_LANG");
         lang ??= "en"; // default: English (user can switch via the language menu; choice is saved to K2.lang)

--- a/K2.Core/Strings.it.xml
+++ b/K2.Core/Strings.it.xml
@@ -143,6 +143,11 @@
   <string name="settings_bc_autostart_hint">Attiva/disattiva le voci di esecuzione automatica di Base Camp (stesso meccanismo della scheda Avvio di Gestione Attività — reversibile). Le voci in HKLM possono richiedere K2 come amministratore.</string>
   <string name="settings_bc_autostart_none">Nessuna voce di avvio automatico di Base Camp trovata nel registro.</string>
   <string name="settings_bc_autostart_done">Avvio automatico Base Camp: {0} voci aggiornate.</string>
+  <string name="settings_restart_bc_on_close">Riavvia Base Camp alla chiusura di K2</string>
+  <string name="settings_restart_bc_on_close_hint">Alla chiusura di K2, rilancia i processi di Base Camp che aveva fermato automaticamente (GUI, worker, Makalu monitor, servizio Windows) — così Base Camp torna com'era prima dell'avvio di K2. MountainDisplayPadWorker viene sempre rilanciato in modo silenzioso, senza finestra. Disattivato di default: chi attiva lo stop automatico di solito vuole che Base Camp resti fermo dopo la chiusura di K2.</string>
+  <string name="settings_export_log_btn">Esporta log…</string>
+  <string name="settings_export_log_hint">Copia il log corrente di K2.App (e il crash log, se presente) in una cartella a tua scelta — utile da allegare quando segnali un problema.</string>
+  <string name="settings_export_log_done">Log esportato in {0}</string>
   <!-- Prompt importazione da Base Camp -->
   <string name="settings_bc_import_group">Importazione da Base Camp</string>
   <string name="settings_bc_import_btn">Importa da Base Camp…</string>
@@ -160,6 +165,7 @@
   <string name="settings_general">Opzioni generali</string>
   <string name="settings_close_to_tray">Chiudi nella system tray invece di uscire</string>
   <string name="settings_k2_autostart">Avvia K2 all'avvio di Windows</string>
+  <string name="settings_k2_autostart_hint">K2 ora richiede i diritti di amministratore (per controllare BaseCampService). Windows non eleva automaticamente le app avviate dalla chiave di registro Run al login, quindi questa voce da sola potrebbe non riuscire ad avviare K2 silenziosamente — in tal caso usa Utilità di pianificazione (un'attività impostata su "Esegui con i privilegi più elevati" al login).</string>
   <string name="settings_start_min_tray">Avvia direttamente ridotto a icona (tray)</string>
   <string name="settings_start_min_tray_hint">K2 si avvia con i driver attivi ma la finestra nascosta nella tray — riaprila in qualsiasi momento dall'icona.</string>
   <string name="settings_font_family">Carattere</string>
@@ -307,6 +313,9 @@
   <string name="dial_pcinfo">Info PC</string>
   <string name="dial_apm">Contatore APM</string>
   <string name="dial_custom">Modalità personalizzata</string>
+  <string name="dial_image">Immagine</string>
+  <string name="dial_timer">Timer</string>
+  <string name="dial_stopwatch">Cronometro</string>
   <string name="dial_clock_section">Tipo di orologio</string>
   <string name="dial_clock_label">Formato:</string>
   <string name="dial_clock_style_label">Stile:</string>
@@ -332,6 +341,8 @@
   <string name="dock_press_for">Premi il tasto per "{0}"…</string>
   <string name="dock_action_none">nessuna</string>
   <string name="dock_capture_matrix">Cattura matrixId…</string>
+  <string name="ev_display_key_label">Tasto Display {0}</string>
+  <string name="ev_display_key_icon_only">(icona)</string>
   <string name="dock_configure_action">Configura azione…</string>
   <string name="dock_remove_action">Rimuovi azione</string>
 
@@ -514,8 +525,8 @@
   <string name="export_profiles_title">Esporta profili</string>
   <string name="export_profiles_pick">Seleziona i profili da esportare:</string>
   <string name="export_format_section">Formato:</string>
-  <string name="export_format_bc">Compatibile Base Camp</string>
-  <string name="export_format_k2">K2 (lossless)</string>
+  <string name="export_format_bc">Base Camp</string>
+  <string name="export_format_k2">K2</string>
   <string name="export_select_at_least_one">Seleziona almeno un profilo.</string>
   <string name="export_pick_folder">Scegli una cartella per i profili esportati</string>
   <!-- Fullscreen -->

--- a/K2.Core/Strings.xml
+++ b/K2.Core/Strings.xml
@@ -144,6 +144,11 @@
   <string name="settings_bc_autostart_hint">Enables/disables the Windows autostart entries of Base Camp (same mechanism as Task Manager's Startup tab — reversible). Entries in HKLM may require running K2 as administrator.</string>
   <string name="settings_bc_autostart_none">No Base Camp autostart entry found in the registry.</string>
   <string name="settings_bc_autostart_done">Base Camp autostart: {0} entries updated.</string>
+  <string name="settings_restart_bc_on_close">Restart Base Camp when K2 closes</string>
+  <string name="settings_restart_bc_on_close_hint">When K2 closes, relaunches whatever Base Camp processes it auto-stopped (GUI, workers, Makalu monitor, the Windows service) — so Base Camp is back the way it was before K2 started. MountainDisplayPadWorker is always relaunched silently, with no window. Disabled by default: most people who enable auto-stop want Base Camp to stay stopped after closing K2.</string>
+  <string name="settings_export_log_btn">Export log…</string>
+  <string name="settings_export_log_hint">Copies the current K2.App log (and crash log, if any) to a folder you choose — handy for sharing when reporting a problem.</string>
+  <string name="settings_export_log_done">Log exported to {0}</string>
   <!-- Base Camp import prompt -->
   <string name="settings_bc_import_group">Base Camp import</string>
   <string name="settings_bc_import_btn">Import from Base Camp…</string>
@@ -161,6 +166,7 @@
   <string name="settings_general">General options</string>
   <string name="settings_close_to_tray">Close to tray instead of exiting</string>
   <string name="settings_k2_autostart">Start K2 with Windows</string>
+  <string name="settings_k2_autostart_hint">K2 now requires administrator rights (to control BaseCampService). Windows does not auto-elevate apps launched from the Run registry key at logon, so this entry alone may fail to start K2 silently — if that happens, use Task Scheduler instead (a task set to "Run with highest privileges" at logon).</string>
   <string name="settings_start_min_tray">Start directly minimized to tray</string>
   <string name="settings_start_min_tray_hint">K2 starts with its drivers active but the window hidden in the tray — open it anytime from the tray icon.</string>
   <string name="settings_font_family">Font</string>
@@ -308,6 +314,9 @@
   <string name="dial_pcinfo">PC Info</string>
   <string name="dial_apm">APM counter</string>
   <string name="dial_custom">Custom mode</string>
+  <string name="dial_image">Image</string>
+  <string name="dial_timer">Timer</string>
+  <string name="dial_stopwatch">Stopwatch</string>
   <string name="dial_clock_section">Clock type</string>
   <string name="dial_clock_label">Format:</string>
   <string name="dial_clock_style_label">Style:</string>
@@ -333,6 +342,8 @@
   <string name="dock_press_for">Press the key for "{0}"…</string>
   <string name="dock_action_none">none</string>
   <string name="dock_capture_matrix">Capture matrixId…</string>
+  <string name="ev_display_key_label">Display Key {0}</string>
+  <string name="ev_display_key_icon_only">(icon)</string>
   <string name="dock_configure_action">Configure action…</string>
   <string name="dock_remove_action">Remove action</string>
 
@@ -515,8 +526,8 @@
   <string name="export_profiles_title">Export profiles</string>
   <string name="export_profiles_pick">Select the profiles to export:</string>
   <string name="export_format_section">Format:</string>
-  <string name="export_format_bc">Base Camp compatible</string>
-  <string name="export_format_k2">K2 (lossless)</string>
+  <string name="export_format_bc">Base Camp</string>
+  <string name="export_format_k2">K2</string>
   <string name="export_select_at_least_one">Select at least one profile.</string>
   <string name="export_pick_folder">Choose a folder for the exported profiles</string>
   <!-- Fullscreen -->

--- a/K2.DisplayPad/App.xaml.cs
+++ b/K2.DisplayPad/App.xaml.cs
@@ -10,8 +10,19 @@ namespace K2.DisplayPad;
 
 public partial class App : Application
 {
-    public static readonly string LogPath = Path.Combine(
-        AppContext.BaseDirectory, "K2.DisplayPad.log");
+    // %LocalAppData%\K2.DisplayPad\, not next to the exe: K2 installs to Program
+    // Files by default (admin-write-protected), so writing there without elevation
+    // used to fail silently and drop all logging. Matches the convention already
+    // used by StateStore/CellConfigDialog/etc. in this project.
+    public static readonly string LogPath = EnsureLogPath();
+
+    private static string EnsureLogPath()
+    {
+        var dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "K2.DisplayPad");
+        try { Directory.CreateDirectory(dir); } catch { /* best-effort, same as the writers below */ }
+        return Path.Combine(dir, "K2.DisplayPad.log");
+    }
 
     // Held for the process lifetime; released automatically by the OS on exit.
     private static Mutex? _singleInstanceMutex;

--- a/K2.DisplayPad/Services/StateStore.cs
+++ b/K2.DisplayPad/Services/StateStore.cs
@@ -65,11 +65,23 @@ CREATE TABLE IF NOT EXISTS Settings (
         cmd.Parameters.AddWithValue("$b", btn);
         using var r = cmd.ExecuteReader();
         if (!r.Read()) return null;
-        return new ButtonRecord(
+        return FilterBcDefault(new ButtonRecord(
             deviceId, profile, btn,
             ImagePath:   r.IsDBNull(0) ? null : r.GetString(0),
             ActionType:  r.IsDBNull(1) ? null : r.GetString(1),
-            ActionValue: r.IsDBNull(2) ? null : r.GetString(2));
+            ActionValue: r.IsDBNull(2) ? null : r.GetString(2)));
+    }
+
+    /// <summary>
+    /// A leftover <c>bc:Default</c> action from an old Base Camp import means "no custom
+    /// binding": the button is treated as empty (record dropped), keeping only its icon
+    /// if one was imported alongside.
+    /// </summary>
+    private static ButtonRecord? FilterBcDefault(ButtonRecord b)
+    {
+        if (!string.Equals(b.ActionType, "bc:Default", StringComparison.OrdinalIgnoreCase))
+            return b;
+        return b.ImagePath is null ? null : b with { ActionType = null, ActionValue = null };
     }
 
     public IReadOnlyList<ButtonRecord> LoadProfile(int deviceId, int profile)
@@ -85,11 +97,12 @@ CREATE TABLE IF NOT EXISTS Settings (
         using var r = cmd.ExecuteReader();
         while (r.Read())
         {
-            result.Add(new ButtonRecord(
+            var rec = FilterBcDefault(new ButtonRecord(
                 deviceId, profile, r.GetInt32(0),
                 ImagePath:   r.IsDBNull(1) ? null : r.GetString(1),
                 ActionType:  r.IsDBNull(2) ? null : r.GetString(2),
                 ActionValue: r.IsDBNull(3) ? null : r.GetString(3)));
+            if (rec is not null) result.Add(rec);
         }
         return result;
     }


### PR DESCRIPTION
## Summary

**Everest numpad display keys (NDK)**
- Fix XML import: real Base Camp exports use the keyboard's own arbitrary `DLLMatrixIndex` for touch keys, never the synthetic 9001-9004 K2 invents for its own exports — every touch key (icon included) was silently dropped from a genuine BC file. NDK index is now assigned by order among `IsTouchKey` bindings, matching the DB importer's already-correct approach.
- Surface the 4 NDK entries in the Everest mapped-keys list (`LvEvKeys`) when they differ from default (custom action and/or icon), wired to the same Configure/Remove flow as the numpad canvas buttons so both stay in sync (including drag&drop swap).
- Fix NDK images/pic-slot mapping never being re-pushed to hardware on a normal profile load, app start, or device reconnect (only right after an import) — switching the Everest's firmware profile resets the on-device LCD picture slots the same way it does keys/RGB. Also fixes an off-by-one `keyIndex` bug in the bulk upload path that would have targeted the wrong physical key once this path became reachable from a normal profile load.

**Base Camp import cleanup**
- A leftover `FunctionType="Default"` (Base Camp's own "no custom binding" marker) was being preserved as a literal `bc:Default` action by the generic fallback translator, and treated as a real mapping. Now translated to no action at import time, and filtered out at load for every device store (DisplayPad, Everest, Everest 60, MacroPad) so already-imported profiles get cleaned up too.

**Also included** (uncommitted work accumulated from prior sessions, bundled into this PR per explicit request rather than split out):
- DisplayPad/Everest native USB-HID engines now default ON (previously opt-in); Settings > Debug Mode exposes them as a diagnostic opt-out.
- New "restart Base Camp on close" option (`BaseCampProcessGuard`) that puts Base Camp's service/autostart entries/DisplayPad worker back the way they normally start.
- K2.App now carries a `requireAdministrator` manifest (`app.manifest`) to control `BaseCampService` (runs as LocalSystem) — worth a closer look, since this raises the whole app's elevation requirement.
- App log/crash-dump paths moved to `%LocalAppData%\K2.App` (Program Files install is admin-write-protected); "Export log" button added to Settings.
- `MainWindow.DisplayDial.cs` revisions and a `MainWindow.Layout.cs` guard against `UpdateKeyboardLayout` flickering the numpad/dock tabs while an NDK image upload is in flight.

## Test plan
- [x] `build-check.bat` clean on both solutions (K2.DisplayPad.sln x64, K2.sln x86) — 0 warnings / 0 errors
- [x] Physical hardware: Everest NDK icons load from a real Base Camp XML export
- [x] Physical hardware: NDK icons/actions survive a profile switch and app restart
- [x] Physical hardware: `requireAdministrator` elevation prompt + BaseCampService control behave as expected
- [x] Physical hardware: "restart Base Camp on close" actually relaunches the service/worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)