### PR TITLE
1.0.2: Everest per-profile NDK images, HW-busy detection, diagnostics

### DIFF
--- a/Installer/K2Setup.iss
+++ b/Installer/K2Setup.iss
@@ -8,7 +8,9 @@
 ; leaves in place one level up (see project layout in _PROJECT_MAP.md).
 
 #define MyAppName "K2"
-#define MyAppVersion "1.0.0"
+#ifndef MyAppVersion
+  #define MyAppVersion "1.0.0"
+#endif
 #define MyAppPublisher "K2 Project (community, non-commercial)"
 #define MyAppExeName "K2.App.exe"
 
@@ -44,9 +46,13 @@ Source: "publish\K2.App\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversio
 
 [Icons]
 Name: "{group}\K2"; Filename: "{app}\{#MyAppExeName}"
-Name: "{group}\K2 DisplayPad (standalone)"; Filename: "{app}\DisplayPad\K2.DisplayPad.exe"
 Name: "{group}\Uninstall K2"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\K2"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,K2}"; Flags: nowait postinstall skipifsilent
+; shellexec (not the default CreateProcess) is required here: K2.App.exe's
+; manifest is requireAdministrator, and CreateProcess cannot elevate a child
+; process on its own — it fails with "CreateProcess failed; code 740" even
+; when the current user is an administrator. ShellExecute knows how to
+; trigger the UAC elevation dance for a manifested-elevated target.
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,K2}"; Flags: nowait postinstall skipifsilent shellexec

--- a/Installer/build-installer-ask.bat
+++ b/Installer/build-installer-ask.bat
@@ -1,0 +1,9 @@
+@echo off
+REM ============================================================
+REM  build-installer-ask.bat - double-click entry point: asks for
+REM  the version number, then calls build-installer.bat with it.
+REM  Leave blank and press Enter to use K2Setup.iss's default version.
+REM ============================================================
+cd /d "%~dp0"
+set /p VER="Numero di versione (es. 1.2.3, vuoto = default): "
+call build-installer.bat %VER%

--- a/Installer/build-installer.bat
+++ b/Installer/build-installer.bat
@@ -10,7 +10,9 @@ REM  Everything referenced lives inside K2\ except the top-level
 REM  LICENSE (one folder up - see _PROJECT_MAP.md layout).
 REM
 REM  Requires: dotnet SDK, Inno Setup 6 (ISCC.exe).
-REM  Usage: double-click, or run from anywhere.
+REM  Usage: double-click (uses K2Setup.iss's default version), or run
+REM  from anywhere with a version arg to stamp the installer/zip with it:
+REM      build-installer.bat 1.2.3
 REM ============================================================
 setlocal EnableDelayedExpansion
 cd /d "%~dp0.."
@@ -18,6 +20,7 @@ set "ROOT=%CD%"
 set "PUB=%ROOT%\Installer\publish"
 set "OUT=%ROOT%\Installer\output"
 set "ISCC=%LOCALAPPDATA%\Programs\Inno Setup 6\ISCC.exe"
+set "VER=%~1"
 
 if not exist "%ISCC%" (
     echo ERROR: Inno Setup compiler not found at "%ISCC%"
@@ -67,12 +70,18 @@ if "!LEAK!"=="1" (
 echo.
 echo [5] Compiling Inno Setup installer ...
 if not exist "%OUT%" mkdir "%OUT%"
-"%ISCC%" "%ROOT%\Installer\K2Setup.iss"
+if "%VER%"=="" (
+    "%ISCC%" "%ROOT%\Installer\K2Setup.iss"
+) else (
+    echo   Stamping version %VER%
+    "%ISCC%" /DMyAppVersion=%VER% "%ROOT%\Installer\K2Setup.iss"
+)
 if errorlevel 1 goto :fail
 
 echo.
 echo [6] Building portable ZIP (same tree as the installer) ...
-powershell -NoProfile -Command "Compress-Archive -Path '%PUB%\K2.App\*' -DestinationPath '%OUT%\K2-portable.zip' -Force"
+if "%VER%"=="" (set "ZIPVER=portable") else (set "ZIPVER=%VER%")
+powershell -NoProfile -Command "Compress-Archive -Path '%PUB%\K2.App\*' -DestinationPath '%OUT%\K2-%ZIPVER%.zip' -Force"
 
 echo.
 echo ------------------------------------------------------------

--- a/K2.App/App.xaml.cs
+++ b/K2.App/App.xaml.cs
@@ -231,6 +231,12 @@ public partial class App : Application
         WriteLog($"=== App start {DateTime.Now:O} pid={Environment.ProcessId} " +
                  $"arch={(Environment.Is64BitProcess ? "x64" : "x86")} lang={Core.Loc.CurrentLang} ===");
 
+        // Read-only snapshot (OS build + a HID-level view of every Mountain device
+        // Windows currently sees, including whether something else already holds an
+        // exclusive handle) — logged once per session, before any SDK/engine touches
+        // the hardware, so a bug-report log always carries this context.
+        Services.SystemDiagnostics.LogStartupInfo(WriteLog);
+
         // Register the resolver for non-redistributable native DLLs (e.g.
         // MacroPadSDK.dll) BEFORE any P/Invoke: so the loader finds them
         // even if they are not bundled with K2. See DISTRIBUTION.md.

--- a/K2.App/MainWindow.DisplayDial.cs
+++ b/K2.App/MainWindow.DisplayDial.cs
@@ -2,62 +2,55 @@
 // Controls the visible pages on the Everest Max rotary display
 // and clock, screensaver, auto-off, menu color settings.
 //
-// FW_EXTEND_INFO ↔ Display Dial mapping:
-//   byMMDockShowMenu  = page bitmask (bit0=Clock … bit7=Custom)
-//   byMMDockScreenSetup = NOT clock format, NOT written by K2 anymore. A real
-//                         Base Camp USB capture (_reference/usb_dumps/
-//                         evclock.pcapng, 2026-07-15) proved it stays constant
-//                         while toggling 12h/24h in Base Camp's own UI — clock
-//                         format is instead carried on every periodic
-//                         SetClockInfo call (see EverestService.UpdateClock,
-//                         _dialClockTimer below). What byMMDockScreenSetup
-//                         actually does remains unknown; left untouched.
-//   byMMDockMenuIndex = NOT WRITTEN by K2 (2026-07-15, real hardware test via
-//                       K2 itself, not just packet captures): SetExtendInfo
-//                       returned True after writing menuIndex=67 (0x43,
-//                       clock content + both enable bits packed in, per the
-//                       real Base Camp USB captures' byte layout), but the
-//                       immediately following GetExtendInfo read back
-//                       menuIndex=0 — the SDK/firmware silently discards this
-//                       field via this call even though the API reports
-//                       success. wMMDockScreenSaver/wMMDockTurnOff round-
-//                       tripped correctly in the same test (ss=2, off=30
-//                       both came back as written), so this is specific to
-//                       byMMDockMenuIndex, not a general SetExtendInfo
-//                       failure. Base Camp's own USB traffic DOES show this
-//                       byte changing and sticking within its session, so it
-//                       must be set through some other command (plausibly the
-//                       same mechanism as EverestSdkNative.SetPCInfo, whose
-//                       doc comment says it drives byMMDockMenuIndex into the
-//                       97-101/113 range as a side effect) — not yet
-//                       identified. Read-only for now: K2 shows whatever the
-//                       device reports but the "what the screensaver shows"
-//                       combo has NO device effect until that command is
-//                       found (would need a fresh raw-HID capture, not just
-//                       SetExtendInfo's blob).
-//   wMMDockScreenSaver  = screensaver timeout in seconds — CONFIRMED, including
-//                         0=disabled: real hardware test round-tripped ss=2
-//                         correctly through SetExtendInfo/GetExtendInfo.
-//   wMMDockTurnOff      = auto-off timeout in seconds — CONFIRMED, same as above
-//                         (off=30 round-tripped in the same real hardware test).
-//   MMDockColor         = menu color
+// FW_EXTEND_INFO ↔ Display Dial mapping — CONFIRMED 2026-07-16 by decompiling
+// the real BaseCamp.UI.dll (EverestOperations.SetDispalyDialDatatoHW/GetSStype,
+// via _reference/tools/dotnet_method_calls.py — no guessing, exact IL read):
 //
-// Enable/disable checkboxes for screensaver and turn-off mirror Base Camp's
-// own DB model (BaseCamp.Data.DisplayDial: EnableSecreenSaver/EnableTurnOff
-// are separate bool columns from ScreenSaverTime/TurnOffTime) — K2 has no
-// confirmed separate device-side enable flag (see byMMDockMenuIndex above:
-// the bits that looked like enable flags in the packet captures live in a
-// field K2 can't actually write), so it falls back to zeroing
-// wMMDockScreenSaver/wMMDockTurnOff for "disabled" — confirmed round-tripping
-// correctly (see above), unlike the byMMDockMenuIndex approach it replaces.
+//   byMMDockShowMenu = page bitmask, built by Base Camp as a binary string
+//                      "CustomMode APMCounter PCInfo Brightness Volume
+//                      LightingMode Profile Clock" (MSB→LSB) parsed base-2:
+//                      bit0=Clock, bit1=Profile, bit2=Lighting, bit3=Volume,
+//                      bit4=Brightness, bit5=PCInfo, bit6=APM, bit7=Custom.
+//                      An earlier version of this file had Volume/Brightness/
+//                      Lighting on the WRONG bits (0x04/0x08/0x10 swapped) —
+//                      fixed now that the real bit order is confirmed.
+//   byMMDockScreenSetup = PACKED byte: (screensaverTypeNibble << 4) | 0b00 |
+//                      (EnableTurnOff << 1) | EnableSecreenSaver. This is the
+//                      field that actually carries screensaver content type
+//                      AND enable/disable — NOT byMMDockMenuIndex (see below).
+//                      Type nibble (GetSStype, exact decompiled table):
+//                      Image=0, Clock=1(12h)/2(24h — depends on ClockType),
+//                      Stopwatch=3, Timer=4, Volume=7, Brightness=8,
+//                      PC Info-CPU=9, GPU=10, HDD=11, Internet=12, RAM=13,
+//                      APM=14. An earlier version of this file guessed this
+//                      exact table but attached it to the wrong struct field
+//                      (byMMDockMenuIndex) and used raw HID packet captures'
+//                      byte offset instead of the real field name — the wire
+//                      offset empirically lines up with byMMDockScreenSetup,
+//                      not the naive struct-offset arithmetic (Base Camp's
+//                      actual wire framing has a few more header bytes than
+//                      assumed; doesn't matter now that the field identity is
+//                      confirmed from source, not inferred from offsets).
+//   byMMDockMenuIndex = ALWAYS hardcoded to 0 by Base Camp's own apply logic
+//                      (`stfld byMMDockMenuIndex` right after `initobj`, no
+//                      DisplayDial field feeds it) — not writable through this
+//                      path, full stop. Confirmed dead end; not used at all.
+//   wMMDockScreenSaver / wMMDockTurnOff = timeout in seconds, ALWAYS sent as
+//                      the real configured value (Base Camp does NOT zero
+//                      these to represent "disabled" — that's carried
+//                      entirely by byMMDockScreenSetup's low 2 bits instead).
+//                      An earlier version of this file zeroed these fields to
+//                      express disabled state, which is why turn-off (whose
+//                      real enable bit was never touched) never engaged on
+//                      real hardware even though the seconds value round-
+//                      tripped fine.
+//   MMDockColor       = menu color
 //
 // Clock STYLE (analog/digital) is still NOT confirmed against a device field:
-// both real USB captures show ambiguous/inconclusive byte changes around the
-// clock-type UI actions (multiple candidate bytes moving together, and most
-// clicks producing byte-identical packets — possibly Base Camp itself doesn't
-// wire analog/digital to firmware, only 12h/24h). Left UI + persisted-only,
-// per the project's "don't guess the bit-layout" rule, until a cleaner
-// isolated capture (one click at a time) resolves it.
+// GetSStype/SetDispalyDialDatatoHW never reference ClockStyle/analog/digital
+// at all — Base Camp's own decompiled apply logic simply doesn't send it
+// anywhere. Left UI + persisted-only, per the project's "don't guess the
+// bit-layout" rule (there's nothing to guess here: it's confirmed unsent).
 
 using System;
 using System.Windows;
@@ -66,6 +59,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using K2.App.Services;
 using K2.Core;
+using Microsoft.Win32;
 
 namespace K2.App;
 
@@ -91,43 +85,57 @@ public partial class MainWindow
     /// startup) — see <see cref="_dialClockTimer"/>.</summary>
     private bool _dialAppliedFormat24h = true;
 
-    // ── Bit mapping for byMMDockShowMenu (to be confirmed with USB capture) ──
+    // Bit mapping for byMMDockShowMenu — confirmed order (see file header):
+    // Clock/Profile/Lighting/Volume/Brightness/PCInfo/APM/Custom.
     [Flags]
     private enum DialPage : byte
     {
         Clock      = 0x01,
         Profile    = 0x02,
-        Volume     = 0x04,
-        Brightness = 0x08,
-        Lighting   = 0x10,
+        Lighting   = 0x04,
+        Volume     = 0x08,
+        Brightness = 0x10,
         PCInfo     = 0x20,
         APM        = 0x40,
         Custom     = 0x80,
         All        = 0xFF
     }
 
-    // Screensaver-function combo entries: what the screensaver shows.
-    // Code layout confirmed against two independent real Base Camp USB
-    // captures (_reference/usb_dumps/evsettings.pcapng + evsettings2.pcapng,
-    // 2026-07-15). NOT the same list as the 8 page-visibility checkboxes
-    // above (byMMDockShowMenu, a bitmask, unrelated field): Base Camp's real
-    // combo here is image/clock/timer/stopwatch/volume/brightness/pcinfo/apm,
-    // not clock/profile/lighting/volume/brightness/pcinfo/apm/custom as
-    // previously guessed. NOT WRITTEN to the device — see file header
-    // (byMMDockMenuIndex): kept only so "Read from device" can show what the
-    // device currently reports, and so the combo/persisted choice survive a
-    // future fix once the real write command is found.
-    private static readonly (string Key, string Value, byte Code, bool IsSpecialRaw)[] DialFunctions =
+    // Screensaver-function combo entries: what the screensaver shows, encoded
+    // as byMMDockScreenSetup's high nibble — see file header for the exact
+    // decompiled table (EverestOperations.GetSStype). "clock"'s Code (2) is
+    // the 24h default; BuildScreenSetupByte overrides it to 1 when 12h is
+    // selected — GetSStype's own switch depends on ClockType for this one item.
+    private static readonly (string Key, string Value, byte Code)[] DialFunctions =
     {
-        ("dial_image",     "image",      2,   false),
-        ("dial_timer",     "timer",      3,   false),
-        ("dial_clock",     "clock",      4,   false),
-        ("dial_stopwatch", "stopwatch",  7,   false),
-        ("dial_volume",    "volume",     8,   false),
-        ("dial_brightness","brightness", 9,   false),
-        ("dial_pcinfo",    "pcinfo",     14,  false),
-        ("dial_apm",       "apm",        113, true),
+        ("dial_image",           "image",           0),
+        ("dial_clock",           "clock",            2),
+        ("dial_stopwatch",       "stopwatch",        3),
+        ("dial_timer",           "timer",            4),
+        ("dial_volume",          "volume",           7),
+        ("dial_brightness",      "brightness",       8),
+        ("dial_pcinfo_cpu",      "pcinfo_cpu",       9),
+        ("dial_pcinfo_gpu",      "pcinfo_gpu",      10),
+        ("dial_pcinfo_hdd",      "pcinfo_hdd",      11),
+        ("dial_pcinfo_internet", "pcinfo_internet", 12),
+        ("dial_pcinfo_ram",      "pcinfo_ram",      13),
+        ("dial_apm",             "apm",             14),
     };
+
+    /// <summary>Packs the selected screensaver-content code with the
+    /// screensaver/turn-off enable bits into the byte Base Camp actually
+    /// sends as <c>byMMDockScreenSetup</c> — see file header.</summary>
+    private byte BuildScreenSetupByte()
+    {
+        var fn = DialFunctions[CbDialScreenSaverFunction.SelectedIndex >= 0
+            ? CbDialScreenSaverFunction.SelectedIndex : 0];
+        byte typeCode = fn.Value == "clock" && DialClockTypeIndex == 1 ? (byte)1 : fn.Code;
+
+        byte enableBits = 0;
+        if (CkDialTurnOffEnable.IsChecked == true)     enableBits |= 0x02;
+        if (CkDialScreenSaverEnable.IsChecked == true) enableBits |= 0x01;
+        return (byte)((typeCode << 4) | enableBits);
+    }
 
     // ─────────────────────── Init ───────────────────────
 
@@ -141,7 +149,7 @@ public partial class MainWindow
     {
         // Populate screensaver-function combo (which page shows as screensaver)
         CbDialScreenSaverFunction.Items.Clear();
-        foreach (var (key, _, _, _) in DialFunctions)
+        foreach (var (key, _, _) in DialFunctions)
             CbDialScreenSaverFunction.Items.Add(Loc.Get(key));
 
         // Load saved settings (or defaults)
@@ -262,17 +270,13 @@ public partial class MainWindow
         }
 
         // Update only the fields controlled by the Display Dial panel.
-        // byMMDockScreenSetup and byMMDockMenuIndex are NOT written here — see
-        // file header for why (clock format goes through SetClockInfo instead;
-        // menuIndex writes are silently discarded by the device, confirmed on
-        // real hardware). Writing a value that's confirmed not to stick would
-        // just violate the project's "don't guess the bit-layout" rule for no
-        // benefit.
+        // byMMDockMenuIndex is NOT written — Base Camp itself always hardcodes
+        // it to 0 (see file header). Enable/disable lives in
+        // byMMDockScreenSetup's low bits now, not in zeroed seconds fields.
         info.byMMDockShowMenu = BuildPageByte();
-        info.wMMDockScreenSaver = CkDialScreenSaverEnable.IsChecked == true
-            ? ParseUshort(TxtDialScreenSaver.Text, 30) : (ushort)0;
-        info.wMMDockTurnOff = CkDialTurnOffEnable.IsChecked == true
-            ? ParseUshort(TxtDialTurnOff.Text, 0) : (ushort)0;
+        info.byMMDockScreenSetup = BuildScreenSetupByte();
+        info.wMMDockScreenSaver = ParseUshort(TxtDialScreenSaver.Text, 30);
+        info.wMMDockTurnOff = ParseUshort(TxtDialTurnOff.Text, 0);
 
         // Menu color → FWColor
         try
@@ -284,7 +288,7 @@ public partial class MainWindow
 
         bool ok = _everest.SetExtendInfo(info);
         LogEverest($"[DIAL] SetExtendInfo -> {ok}  pages=0x{info.byMMDockShowMenu:X2} " +
-                   $"menuIndex={info.byMMDockMenuIndex} " +
+                   $"screenSetup=0x{info.byMMDockScreenSetup:X2} " +
                    $"ss={info.wMMDockScreenSaver} off={info.wMMDockTurnOff}");
 
         // Clock format doesn't live in FW_EXTEND_INFO (see file header) — push
@@ -320,42 +324,29 @@ public partial class MainWindow
             CkDialCustom.IsChecked   = (pages & (byte)DialPage.Custom) != 0;
 
             // Clock format (12h/24h) is intentionally left untouched here:
-            // byMMDockScreenSetup doesn't carry it (see ApplyDialToDevice's
-            // comment) — K2's own persisted choice (_dialClockTimer/
-            // RbDialClockType_Checked) is the source of truth, not the device.
-
-            // byMMDockMenuIndex is a PACKED byte (contentNibble<<4 | enableBits)
-            // for every content type except the special-raw "apm" — see file
-            // header. Check special-raw entries first (exact match) before
-            // falling back to nibble matching, so apm's 113 (0x71) can't be
-            // mistaken for a nibble-7 ("stopwatch") + enableBits=1 combination.
-            // Display-only: K2 never writes this field (see file header), so
-            // it just reflects whatever Base Camp or the firmware itself last
-            // set it to — selecting a different option in the combo has no
-            // effect on the device.
-            byte menuIndex = info.byMMDockMenuIndex;
-            int fnIndex = Array.FindIndex(DialFunctions, f => f.IsSpecialRaw && f.Code == menuIndex);
-            if (fnIndex < 0)
-                fnIndex = Array.FindIndex(DialFunctions, f => !f.IsSpecialRaw && f.Code == (menuIndex >> 4));
+            // byMMDockScreenSetup's type nibble only reflects 12h/24h when
+            // content=Clock is selected, and clock format itself goes through
+            // SetClockInfo, not this struct — K2's own persisted choice
+            // (_dialClockTimer/RbDialClockType_Checked) is the source of
+            // truth, not the device.
+            byte screenSetup = info.byMMDockScreenSetup;
+            byte typeCode = (byte)(screenSetup >> 4);
+            int fnIndex = Array.FindIndex(DialFunctions,
+                f => f.Code == typeCode || (f.Value == "clock" && typeCode == 1));
             CbDialScreenSaverFunction.SelectedIndex = fnIndex >= 0 ? fnIndex : 0;
 
-            // The firmware only reports a timeout, not a separate enable flag
-            // (Base Camp keeps that flag DB-side, and K2's own attempt at a
-            // device-side flag via byMMDockMenuIndex was confirmed not to
-            // stick — see file header). 0 => disabled, keep the last
-            // configured seconds value in the textbox instead of overwriting it.
-            CkDialScreenSaverEnable.IsChecked = info.wMMDockScreenSaver != 0;
-            if (info.wMMDockScreenSaver != 0) TxtDialScreenSaver.Text = info.wMMDockScreenSaver.ToString();
-
-            CkDialTurnOffEnable.IsChecked = info.wMMDockTurnOff != 0;
-            if (info.wMMDockTurnOff != 0) TxtDialTurnOff.Text = info.wMMDockTurnOff.ToString();
+            byte enableBits = (byte)(screenSetup & 0x03);
+            CkDialScreenSaverEnable.IsChecked = (enableBits & 0x01) != 0;
+            CkDialTurnOffEnable.IsChecked     = (enableBits & 0x02) != 0;
+            TxtDialScreenSaver.Text = info.wMMDockScreenSaver.ToString();
+            TxtDialTurnOff.Text     = info.wMMDockTurnOff.ToString();
 
             var c = info.MMDockColor;
             BtnDialMenuColor.Background = new SolidColorBrush(
                 Color.FromRgb(c.r, c.g, c.b));
 
             LogEverest($"[DIAL] Read from device: pages=0x{pages:X2} " +
-                       $"menuIndex={info.byMMDockMenuIndex} ss={info.wMMDockScreenSaver} " +
+                       $"screenSetup=0x{screenSetup:X2} ss={info.wMMDockScreenSaver} " +
                        $"off={info.wMMDockTurnOff} color=({c.r},{c.g},{c.b})");
 
             SaveDialSettings();
@@ -438,6 +429,34 @@ public partial class MainWindow
                 Color.FromRgb(dlg.Color.R, dlg.Color.G, dlg.Color.B));
             SaveDialSettings();
         }
+    }
+
+    /// <summary>Loads/crops a 240×204 image and uploads it as the Media Dock
+    /// screensaver picture — mirrors NdkKeyConfigDialog.BtnLoadImage_Click
+    /// (Everest numpad display keys), same OpenFileDialog + ImageCropDialog flow.</summary>
+    private void BtnDialLoadImage_Click(object sender, RoutedEventArgs e)
+    {
+        const int W = 240, H = 204;
+        var dlg = new OpenFileDialog
+        {
+            Title  = Loc.Get("dial_load_image_title"),
+            Filter = "Images (*.png;*.jpg;*.jpeg;*.bmp)|*.png;*.jpg;*.jpeg;*.bmp|All files|*.*"
+        };
+        if (dlg.ShowDialog(this) != true) return;
+
+        string picked = dlg.FileName;
+        string? cropped = ImageCropDialog.Show(this, picked, W, H, Loc.Get("crop_title", W, H));
+        if (cropped is not null) picked = cropped;
+
+        if (_everest is null) return;
+        // StartPicUpdate (the SDK's picture-upload export) is synchronous and takes ~2s —
+        // same blocking contract as the Everest numpad display keys, see NdkApplyImage's
+        // doc comment (MainWindow.NumpadDisplayKeys.cs).
+        ShowHwBusy(Loc.Get("hw_busy_uploading_image"));
+        bool ok;
+        try { ok = _everest.UploadMMDockScreensaver(picked); }
+        finally { HideHwBusy(); }
+        LogEverest($"[DIAL] UploadMMDockScreensaver -> {ok}");
     }
 
     private void BtnDialApply_Click(object sender, RoutedEventArgs e) => ApplyDialToDevice();

--- a/K2.App/MainWindow.DisplayPad.cs
+++ b/K2.App/MainWindow.DisplayPad.cs
@@ -286,7 +286,19 @@ public partial class MainWindow
         bool ok = result?.GetBool("ok") ?? false;
         LblStatus.Text = ok ? Loc.Get("dp_driver_opened") : Loc.Get("dp_driver_open_failed");
         DpLog($"Open -> {ok}");
-        if (ok) DpRefreshDevices();
+        if (ok)
+        {
+            DpRefreshDevices();
+        }
+        else
+        {
+            // DpRefreshDevices (the only place that adds "dp_*" tabs to TcDevices) is never
+            // reached when Open fails — so without this line, "no DisplayPad tab" shows up in
+            // the log as nothing at all, indistinguishable from "DpRefreshDevices ran and found
+            // zero devices". Spelling it out here turns a silent no-op into a diagnosable fact.
+            DpLog("Open failed — DisplayPad tab will NOT be created this session " +
+                  "(DpRefreshDevices/device enumeration never runs without a successful Open)");
+        }
     }
 
     private void BtnDpRefresh_Click(object sender, RoutedEventArgs e) => DpRefreshDevices();
@@ -963,10 +975,7 @@ public partial class MainWindow
             var root = doc.Root;
             if (root is null) return;
 
-            // Slot (1-5) from <Id>; profile display name from <ProfileName>
-            int slot = 1;
-            if (int.TryParse(root.Element("Id")?.Value, out var n) && n >= 1 && n <= 5)
-                slot = n;
+            // Profile display name from <ProfileName>
             string profileName = root.Element("ProfileName")?.Value
                                  ?? Path.GetFileNameWithoutExtension(dlg.FileName);
 
@@ -975,6 +984,17 @@ public partial class MainWindow
             if (bindings.Count == 0)
             {
                 DpLog("[IMP-XML] No DisplayPadLayerBidings found in XML.");
+                return;
+            }
+
+            // Always land in a FRESH slot — the XML's own <Id> is just wherever the
+            // profile happened to live on the machine it was exported from (see
+            // BaseCampDbImporter.FindFreeSlot's doc comment).
+            int slot = BaseCampDbImporter.FindFreeSlot(_dpStore.GetExistingProfiles(id));
+            if (slot == 0)
+            {
+                MessageBox.Show(this, Loc.Get("import_no_free_slot", profileName),
+                    Loc.Get("dp_open_bc_profile"), MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -1220,6 +1240,7 @@ public partial class MainWindow
         int importedProfiles = 0;
         int selectedDevId = DpSelectedDeviceId() ?? -1;
         int selectedSlot = -1;
+        int skippedNoSlot = 0;
 
         foreach (var (bcDevId, profiles) in bcDevices)
         {
@@ -1230,33 +1251,41 @@ public partial class MainWindow
             // APEnable=false required before SetIconPic (UploadImageToProfile)
             _dpClient.APEnable(bcDevId, false);
 
+            // Always land in a FRESH slot per device — see BaseCampDbImporter.FindFreeSlot's
+            // doc comment; track slots claimed so far in this batch too.
+            var usedSlots = new HashSet<int>(_dpStore.GetExistingProfiles(bcDevId));
+
             foreach (var profile in profiles)
             {
                 try
                 {
+                    int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
+                    if (targetSlot == 0) { skippedNoSlot++; continue; }
+                    usedSlots.Add(targetSlot);
+
                     int n = BaseCampDbImporter.ImportProfile(
-                        dbPath, profile, bcDevId, _dpStore);
+                        dbPath, profile, bcDevId, _dpStore, targetSlot);
 
                     // Upload root-page images only (folder pages are uploaded on navigation)
-                    var buttons = _dpStore.LoadPage(bcDevId, profile.Slot, 0);
+                    var buttons = _dpStore.LoadPage(bcDevId, targetSlot, 0);
                     foreach (var btn in buttons)
                     {
                         if (!string.IsNullOrEmpty(btn.ImagePath) && File.Exists(btn.ImagePath))
                         {
                             bool ok = _dpClient.UploadImageToProfile(bcDevId, btn.ImagePath,
-                                btn.ButtonIndex, profile.Slot, rotation);
+                                btn.ButtonIndex, targetSlot, rotation);
                             if (!ok)
                                 _dpClient.UploadImage(bcDevId, btn.ImagePath, btn.ButtonIndex, rotation);
                         }
                     }
 
-                    DpLog($"[IMP-BC] dev#{bcDevId} {profile.Name} (slot {profile.Slot}): {n} keys");
+                    DpLog($"[IMP-BC] dev#{bcDevId} {profile.Name} (BC slot {profile.Slot} -> K2 slot {targetSlot}): {n} keys");
                     totalButtons += n;
                     importedProfiles++;
 
                     // Track the active profile for the currently selected device
                     if (profile.IsSelected && bcDevId == selectedDevId)
-                        selectedSlot = profile.Slot;
+                        selectedSlot = targetSlot;
                 }
                 catch (Exception ex)
                 {
@@ -1264,6 +1293,10 @@ public partial class MainWindow
                 }
             }
         }
+
+        if (skippedNoSlot > 0)
+            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
+                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
 
         // 5. Activate the profile that was selected in BC for the current device
         if (selectedSlot > 0 && selectedDevId > 0)
@@ -1737,7 +1770,14 @@ public partial class MainWindow
         foreach (var id in ids)
         {
             bool plugged = _dpClient.IsPlugged(id);
-            if (!plugged) continue;   // skip devices not physically connected
+            if (!plugged)
+            {
+                // Silently skipping used to leave no trace of *why* an SDK-reported id never
+                // became a tab — a phantom slot and a real-but-momentarily-unplugged device
+                // looked identical in the log (nothing at all).
+                DpLog($"Device {id}: reported by SDK but IsPlugged=false — skipped, no tab");
+                continue;
+            }
             string fw = _dpClient.FirmwareVersion(id);
             int br = _dpClient.GetBrightness(id);
             // Use custom name if set, otherwise default progressive label
@@ -1805,6 +1845,9 @@ public partial class MainWindow
         }
 
         RefreshHomeTiles(); // DisplayPad tabs are added/removed outright, not toggled via SetDeviceTabVisible
+        DpLog(items.Count > 0
+            ? $"{items.Count} DisplayPad tab(s) created: [{string.Join(", ", items.Select(x => x.SdkId))}]"
+            : "0 DisplayPad tabs created (SDK reported no plugged device)");
     }
 
     private int DpCurrentProfile() => CbDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : 1;
@@ -2285,6 +2328,13 @@ public partial class MainWindow
         if (string.IsNullOrEmpty(imgPath) || !File.Exists(imgPath)) return;
         if (DpGifAnimator.IsAnimatedGif(imgPath)) return;
         if (_dpFullscreenByDevice.TryGetValue(id, out bool fs) && fs) return;
+        // While a full repaint (profile/page switch: blank + batch upload) is queued or
+        // running, skip the bounce entirely: imgPath was captured from the PRE-switch key
+        // state, so chaining it here would land a stale old-profile icon in the middle of
+        // (or after) the new profile's batch — observed in real logs as "old icons overlap
+        // the new profile". The batch itself repaints this key with the correct icon anyway;
+        // all that's lost is the shrink effect on the very press that triggered the switch.
+        if (_dpRepaintBusy.GetValueOrDefault(id)) return;
 
         var previous = _dpUploadChain.TryGetValue(id, out var p) ? p : Task.CompletedTask;
         var next = previous.ContinueWith(_ => _dpClient.UploadImage(id, imgPath, btnIndex, rotation, pressed),

--- a/K2.App/MainWindow.Everest.cs
+++ b/K2.App/MainWindow.Everest.cs
@@ -1392,14 +1392,13 @@ public partial class MainWindow
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) continue;
             try
             {
-                // Matches NdkApplyImage's first (and usually successful) attempt:
-                // 0-based keyIndex, picSlot=0 — the combo already confirmed to work on
-                // real hardware there. (The old i+1/1-based call here was a separate,
-                // never-hit bug: it only ever ran right after an import, and would have
-                // targeted the wrong physical key — or, for i=3, an out-of-range one.)
-                bool ok = _everest.UploadNumpadImage(path, i, picSlot: 0);
+                // Same (picSlot, subItem) fallback chain as the single-key dialog flow
+                // (UploadNdkImageWithFallback, MainWindow.NumpadDisplayKeys.cs) — this
+                // used to call UploadNumpadImage directly with a single fixed combo,
+                // which silently failed on any hardware where a later attempt is the one
+                // that actually works (the wire mapping was never confirmed via capture).
+                bool ok = UploadNdkImageWithFallback(i, path);
                 any |= ok;
-                LogEverest($"[NDK] ndk.{i} uploaded: {System.IO.Path.GetFileName(path)} -> {ok}");
             }
             catch (Exception ex)
             {

--- a/K2.App/MainWindow.Everest.cs
+++ b/K2.App/MainWindow.Everest.cs
@@ -1790,7 +1790,14 @@ public partial class MainWindow
 
         _everest.SwitchProfile(next);
         _evStore.SetCurrentProfile(next);
+        // EvSelectProfileSlot suppresses CbEvProfile_SelectionChanged (avoids re-entrant
+        // handling while this method is already mid-switch) — which means it does NOT
+        // call ReloadEverestProfile on its own. Call it explicitly so the key list AND
+        // the NDK hardware re-upload (see ReloadEverestProfile's doc comment) actually
+        // run on a profile switch triggered from the keyboard itself, not just from the
+        // UI combo.
         EvSelectProfileSlot(next);
+        ReloadEverestProfile();
         LogEverest($"[EXEC] profile -> {next}");
     }
 

--- a/K2.App/MainWindow.Everest.cs
+++ b/K2.App/MainWindow.Everest.cs
@@ -1065,7 +1065,7 @@ public partial class MainWindow
         ApplyCurrentEffect();
         ApplyEverestSettingsToDevice();
         StartLedPreview();
-        EvUploadNdkImages(); // display keys are device-global: re-push on every fresh connect
+        EvUploadNdkImages(); // resync current profile's NDK pictures in case this is a different/reset device
 
         // Restore custom device name if previously set
         var savedName = _evStore.GetSetting("device.name");
@@ -1103,7 +1103,7 @@ public partial class MainWindow
             ApplyCurrentEffect();
             ApplyEverestSettingsToDevice();
             StartLedPreview();
-            EvUploadNdkImages(); // display keys are device-global: re-push on every fresh connect
+            EvUploadNdkImages(); // resync current profile's NDK pictures in case this is a different/reset device
         }
     }
 
@@ -1159,11 +1159,20 @@ public partial class MainWindow
             var root = doc.Root;
             if (root is null) return;
 
-            int slot = 1;
-            if (int.TryParse(root.Element("Id")?.Value, out var n) && n >= 1 && n <= 5)
-                slot = n;
             string profileName = root.Element("ProfileName")?.Value
                                  ?? System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
+
+            // Always land in a FRESH slot — the XML's own <Id> is just wherever the
+            // profile happened to live on the machine it was exported from, and reusing
+            // it here would silently overwrite whatever K2 profile already occupies that
+            // slot number (see BaseCampDbImporter.FindFreeSlot's doc comment).
+            int slot = BaseCampDbImporter.FindFreeSlot(_evStore.GetExistingProfiles());
+            if (slot == 0)
+            {
+                MessageBox.Show(this, Loc.Get("import_no_free_slot", profileName),
+                    Loc.Get("dp_open_bc_profile"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
 
             // Real Base Camp XML exports the EverestKeyBindings navigation property as
             // a wrapper containing <KeyboardBinding> items (item element = the real
@@ -1209,8 +1218,9 @@ public partial class MainWindow
                 regular++;
             }
 
-            // NDK 0-3 (numpad LCD display keys, device-global in K2): assigned by ORDER
-            // among the touch-key bindings, not by DLLMatrixIndex value. K2's own exports
+            // NDK 0-3 (numpad LCD display keys, per-profile — see UploadNdkImage's doc
+            // comment): assigned by ORDER among the touch-key bindings, not by
+            // DLLMatrixIndex value. K2's own exports
             // use synthetic KeyIds 9001-9004 in ascending order (see EvProfileExporter),
             // but a genuine Base Camp XML export uses BC's own real, arbitrary KeyId for
             // these — matching by "matrixId - 9001" silently dropped every touch key
@@ -1233,19 +1243,19 @@ public partial class MainWindow
                         {
                             string dir = System.IO.Path.Combine(
                                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                                "K2.App", "imported_xml_ev");
+                                "K2.App", "imported_xml_ev", $"slot{slot}");
                             System.IO.Directory.CreateDirectory(dir);
                             string file = System.IO.Path.Combine(dir, $"ndk_{ndkIndex}.png");
                             System.IO.File.WriteAllBytes(file, bytes);
-                            _evStore.SetSetting($"ndk.{ndkIndex}.imagePath", file);
+                            _evStore.SetSetting($"ndk.{slot}.{ndkIndex}.imagePath", file);
                         }
                     }
                     catch (Exception ex) { LogEverest($"[IMP-XML] ndk #{ndkIndex} image decode failed: {ex.Message}"); }
                 }
                 if (actionType is not null)
                 {
-                    _evStore.SetSetting($"ndk.{ndkIndex}.actionType", actionType);
-                    _evStore.SetSetting($"ndk.{ndkIndex}.actionValue", actionValue ?? "");
+                    _evStore.SetSetting($"ndk.{slot}.{ndkIndex}.actionType", actionType);
+                    _evStore.SetSetting($"ndk.{slot}.{ndkIndex}.actionValue", actionValue ?? "");
                 }
                 touch++;
                 ndkIndex++;
@@ -1254,8 +1264,10 @@ public partial class MainWindow
             _evStore.SetCurrentProfile(slot);
             EvRefreshProfiles();
             EvSelectProfileSlot(slot);
-            ReloadEverestProfile(); // also re-uploads NDK images to hardware when connected
-            if (touch > 0) LoadNdkState(); // refresh canvas thumbnails with the imported icons
+            ReloadEverestProfile(); // refreshes NDK canvas thumbnails for the imported slot
+            // A freshly imported profile's pictures have never reached THIS physical device —
+            // push them now (ReloadEverestProfile no longer does this on every plain switch).
+            if (touch > 0 && _everest.IsOpen) EvUploadNdkImages();
 
             LogEverest($"[IMP-XML] '{profileName}' -> slot {slot}: {regular} keys, {touch} display keys");
             LblStatus.Text = Loc.Get("dp_imported_xml", profileName, slot);
@@ -1334,26 +1346,44 @@ public partial class MainWindow
 
         int totalRegular = 0, totalTouch = 0;
         int activeSlot = -1;
+        int skippedNoSlot = 0;
+
+        // Each imported profile lands in a FRESH slot, never profile.Slot verbatim (see
+        // BaseCampDbImporter.FindFreeSlot's doc comment) — track slots claimed so far in
+        // THIS batch too, so importing 3 profiles in one go doesn't pick the same free
+        // slot for all of them.
+        var usedSlots = new HashSet<int>(_evStore.GetExistingProfiles());
 
         foreach (var profile in allProfiles)
         {
             try
             {
-                var (reg, touch) = BaseCampDbImporter.ImportEverestProfile(dbPath, profile, _evStore);
+                int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
+                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                usedSlots.Add(targetSlot);
+
+                var (reg, touch) = BaseCampDbImporter.ImportEverestProfile(dbPath, profile, _evStore, targetSlot);
                 totalRegular += reg;
                 totalTouch   += touch;
-                LogEverest($"[IMP-BC] slot {profile.Slot} '{profile.Name}': {reg} keys, {touch} display keys");
-                // NDK images are device-global (not per-profile): no need to re-upload
-                // inside this per-profile loop — ReloadEverestProfile() below does it
-                // once, after every profile has been imported.
+                LogEverest($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: {reg} keys, {touch} display keys");
+                // Each profile's NDK pictures live in their own firmware slot (see
+                // UploadNdkImage's doc comment) and have never reached THIS physical
+                // device — push them now, per imported profile, while the "please wait"
+                // overlay is up. Same behavior real Base Camp shows during a DB/profile
+                // import (see K2/_reference/usb_dumps analysis, 2026-07-16).
+                if (touch > 0 && _everest.IsOpen) EvUploadNdkImages(targetSlot);
 
-                if (profile.IsSelected) activeSlot = profile.Slot;
+                if (profile.IsSelected) activeSlot = targetSlot;
             }
             catch (Exception ex)
             {
                 LogEverest($"[IMP-BC] Error slot {profile.Slot}: {ex.Message}");
             }
         }
+
+        if (skippedNoSlot > 0)
+            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
+                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
 
         // Switch to the active BC profile and reload UI
         if (activeSlot > 0)
@@ -1374,37 +1404,40 @@ public partial class MainWindow
     }
 
     /// <summary>
-    /// Pushes the current NDK (numpad LCD display key) images to hardware and tells the
-    /// firmware which pic slot maps to which physical key (<see cref="NdkRefreshDevicePicSlots"/>).
-    /// NDK state is device-global (EverestStore's <c>ndk.{i}.*</c> settings), not
-    /// per-profile — but switching the Everest's active FIRMWARE profile (<c>_everest.
-    /// SwitchProfile</c>) resets the on-device LCD picture slots the same way it does
-    /// regular keys/RGB, so this must run any time a profile is (re)loaded or the device
-    /// is freshly opened — not just right after a BC/XML import, which is all that
-    /// called it before.
+    /// Re-pushes the CURRENT profile's NDK (numpad LCD display key) images to hardware and
+    /// tells the firmware which pic slot maps to which physical key
+    /// (<see cref="NdkRefreshDevicePicSlots"/>). Each firmware profile stores its own 4 NDK
+    /// pictures separately (confirmed via USB capture, see <see cref="UploadNdkImage"/>'s
+    /// doc comment), so switching between already-configured profiles needs no re-upload at
+    /// all — this only runs right after a BC/XML import (the images may never have reached
+    /// THIS physical device yet) and on a fresh device connect (EvAutoOpen/BtnEvOpen_Click),
+    /// as a resync safety net in case a different/factory-reset unit is plugged in.
+    /// Shows the blocking "please wait" overlay for the whole batch, same as a single-key
+    /// edit — each image is its own ~2s synchronous SDK call.
     /// </summary>
-    private void EvUploadNdkImages()
+    private void EvUploadNdkImages(int? forProfile = null)
     {
+        int profile = forProfile ?? EvCurrentProfile();
         bool any = false;
-        for (int i = 0; i < 4; i++)
+        ShowHwBusy(Loc.Get("hw_busy_uploading_image"));
+        try
         {
-            var path = _evStore.GetSetting($"ndk.{i}.imagePath");
-            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) continue;
-            try
+            for (int i = 0; i < 4; i++)
             {
-                // Same (picSlot, subItem) fallback chain as the single-key dialog flow
-                // (UploadNdkImageWithFallback, MainWindow.NumpadDisplayKeys.cs) — this
-                // used to call UploadNumpadImage directly with a single fixed combo,
-                // which silently failed on any hardware where a later attempt is the one
-                // that actually works (the wire mapping was never confirmed via capture).
-                bool ok = UploadNdkImageWithFallback(i, path);
-                any |= ok;
-            }
-            catch (Exception ex)
-            {
-                LogEverest($"[NDK] ndk.{i} upload failed: {ex.Message}");
+                var path = _evStore.GetSetting($"ndk.{profile}.{i}.imagePath");
+                if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) continue;
+                try
+                {
+                    bool ok = UploadNdkImage(i, path, profile);
+                    any |= ok;
+                }
+                catch (Exception ex)
+                {
+                    LogEverest($"[NDK] ndk.{profile}.{i} upload failed: {ex.Message}");
+                }
             }
         }
+        finally { HideHwBusy(); }
         if (any) NdkRefreshDevicePicSlots();
     }
 
@@ -1578,31 +1611,31 @@ public partial class MainWindow
             _evKeys.Add(k);
             _evByMatrix[r.KeyMatrix] = k;
         }
+        // Refreshes the 4 NDK buttons' thumbnails/actions for this profile — no hardware
+        // I/O, since each profile's pictures already live in their own firmware slot once
+        // uploaded (see UploadNdkImage's doc comment). A switch only needs the on-screen
+        // state to catch up with what's actually resident on the device.
+        LoadNdkState();
         EvAddNdkEntriesToKeyList();
-        // Re-push the (device-global) NDK images/pic-slot mapping any time a profile is
-        // (re)loaded — see EvUploadNdkImages's doc comment for why this can't be limited
-        // to just the import flows that originally called it.
-        if (_everest.IsOpen) EvUploadNdkImages();
         LogEverest($"[DB  ] profile {profile}: loaded {_evKeys.Count} keys");
     }
 
     /// <summary>
-    /// Surfaces the 4 numpad LCD "display keys" (NDK) in the same mapped-keys list as
-    /// regular keys, but only when a key differs from its default (empty) state — i.e.
-    /// carries a custom action and/or a custom icon. NDK state is device-global (not
-    /// per-profile, see MainWindow.NumpadDisplayKeys.cs), so the same entries show up
-    /// regardless of which profile is selected. KeyMatrix is a negative placeholder
-    /// (display keys have no real matrix code) and these entries are deliberately kept
-    /// OUT of _evByMatrix — BtnEvConfig/BtnEvRemove branch on NdkIndex before touching
-    /// any KeyMatrix-keyed persistence.
+    /// Surfaces the current profile's 4 numpad LCD "display keys" (NDK) in the same
+    /// mapped-keys list as regular keys, but only when a key differs from its default
+    /// (empty) state — i.e. carries a custom action and/or a custom icon. KeyMatrix is a
+    /// negative placeholder (display keys have no real matrix code) and these entries are
+    /// deliberately kept OUT of _evByMatrix — BtnEvConfig/BtnEvRemove branch on NdkIndex
+    /// before touching any KeyMatrix-keyed persistence.
     /// </summary>
     private void EvAddNdkEntriesToKeyList()
     {
+        int profile = EvCurrentProfile();
         for (int i = 0; i < NdkCount; i++)
         {
-            string? at  = _evStore.GetSetting($"ndk.{i}.actionType");
-            string? av  = _evStore.GetSetting($"ndk.{i}.actionValue");
-            string? img = _evStore.GetSetting($"ndk.{i}.imagePath");
+            string? at  = _evStore.GetSetting($"ndk.{profile}.{i}.actionType");
+            string? av  = _evStore.GetSetting($"ndk.{profile}.{i}.actionValue");
+            string? img = _evStore.GetSetting($"ndk.{profile}.{i}.imagePath");
             bool hasImg = !string.IsNullOrEmpty(img) && System.IO.File.Exists(img);
             bool hasAct = !string.IsNullOrEmpty(at);
             if (!hasImg && !hasAct) continue; // default/empty display key — omit

--- a/K2.App/MainWindow.Everest60.cs
+++ b/K2.App/MainWindow.Everest60.cs
@@ -359,17 +359,27 @@ public partial class MainWindow
 
         int totalKeys = 0;
         int activeSlot = -1;
+        int skippedNoSlot = 0;
+        var usedSlots = new HashSet<int>(_ev60Store.GetExistingProfiles());
         foreach (var profile in allProfiles)
         {
             try
             {
-                int keys = BaseCampDbImporter.ImportEverest60Profile(dbPath, profile, _ev60Store);
+                int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
+                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                usedSlots.Add(targetSlot);
+
+                int keys = BaseCampDbImporter.ImportEverest60Profile(dbPath, profile, _ev60Store, targetSlot);
                 totalKeys += keys;
-                if (profile.IsSelected) activeSlot = profile.Slot;
-                LogEverest60($"[IMP-BC] slot {profile.Slot} '{profile.Name}': keys={keys}");
+                if (profile.IsSelected) activeSlot = targetSlot;
+                LogEverest60($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: keys={keys}");
             }
             catch (Exception ex) { LogEverest60($"[IMP-BC] slot {profile.Slot} error: {ex.Message}"); }
         }
+
+        if (skippedNoSlot > 0)
+            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
+                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
 
         if (activeSlot > 0) _ev60Store.SetCurrentProfile(activeSlot);
         Ev60RefreshProfiles();
@@ -398,10 +408,17 @@ public partial class MainWindow
             var root = doc.Root;
             if (root is null) return;
 
-            int slot = 1;
-            if (int.TryParse(root.Element("Id")?.Value, out var n) && n >= 1 && n <= 5) slot = n;
             string profileName = root.Element("ProfileName")?.Value
                                   ?? System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
+
+            // Always land in a FRESH slot — see BaseCampDbImporter.FindFreeSlot's doc comment.
+            int slot = BaseCampDbImporter.FindFreeSlot(_ev60Store.GetExistingProfiles());
+            if (slot == 0)
+            {
+                MessageBox.Show(this, Loc.Get("import_no_free_slot", profileName),
+                    Loc.Get("dp_open_bc_profile"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
 
             int imported = 0;
             foreach (var b in root.Descendants("Everest60KeyBidings"))

--- a/K2.App/MainWindow.HwBusy.cs
+++ b/K2.App/MainWindow.HwBusy.cs
@@ -1,0 +1,35 @@
+// MainWindow.HwBusy.cs — partial class: blocking hardware-write overlay.
+//
+// StartPicUpdate (the Mountain SDK's picture-upload export) is synchronous and takes ~2s per
+// image (see K2/_reference/usb_dumps analysis, 2026-07-16): the whole header+chunked-transfer
+// USB dance runs on the calling thread before it returns. Base Camp shows a blocking "please
+// wait" message for the duration instead of leaving the app looking frozen — this mirrors that.
+
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace K2.App;
+
+public partial class MainWindow
+{
+    private Cursor? _hwBusyPrevCursor;
+
+    /// <summary>Shows the blocking overlay with <paramref name="message"/> and forces an
+    /// immediate render pass — otherwise WPF wouldn't paint it until the UI thread yields,
+    /// which never happens since the caller blocks it right after this call returns.</summary>
+    private void ShowHwBusy(string message)
+    {
+        TxtHwBusyMessage.Text = message;
+        PnlHwBusy.Visibility = Visibility.Visible;
+        _hwBusyPrevCursor = Mouse.OverrideCursor;
+        Mouse.OverrideCursor = Cursors.Wait;
+        Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
+    }
+
+    private void HideHwBusy()
+    {
+        PnlHwBusy.Visibility = Visibility.Collapsed;
+        Mouse.OverrideCursor = _hwBusyPrevCursor;
+    }
+}

--- a/K2.App/MainWindow.Keys.cs
+++ b/K2.App/MainWindow.Keys.cs
@@ -674,9 +674,6 @@ public partial class MainWindow
             var root = doc.Root;
             if (root is null) return;
 
-            int slot = 1;
-            if (int.TryParse(root.Element("Id")?.Value, out var n) && n >= 1 && n <= 5)
-                slot = n;
             string profileName = root.Element("ProfileName")?.Value
                                  ?? Path.GetFileNameWithoutExtension(dlg.FileName);
 
@@ -684,6 +681,15 @@ public partial class MainWindow
             if (bindings.Count == 0)
             {
                 Log("[IMP-XML] No MakaluKeyBindings found in XML.");
+                return;
+            }
+
+            // Always land in a FRESH slot — see BaseCampDbImporter.FindFreeSlot's doc comment.
+            int slot = BaseCampDbImporter.FindFreeSlot(_store.GetExistingProfiles(id));
+            if (slot == 0)
+            {
+                MessageBox.Show(this, Loc.Get("import_no_free_slot", profileName),
+                    Loc.Get("dp_open_bc_profile"), MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 
@@ -815,21 +821,31 @@ public partial class MainWindow
 
         int totalKeys = 0;
         int activeSlot = -1;
+        int skippedNoSlot = 0;
+        var usedSlots = new HashSet<int>(_store.GetExistingProfiles(k2DeviceId));
 
         foreach (var profile in profiles)
         {
             try
             {
-                int n = BaseCampDbImporter.ImportMacroPadProfile(dbPath, profile, k2DeviceId, _store);
+                int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
+                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                usedSlots.Add(targetSlot);
+
+                int n = BaseCampDbImporter.ImportMacroPadProfile(dbPath, profile, k2DeviceId, _store, targetSlot);
                 totalKeys += n;
-                Log($"[IMP-BC] slot {profile.Slot} '{profile.Name}': {n} keys");
-                if (profile.IsSelected) activeSlot = profile.Slot;
+                Log($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: {n} keys");
+                if (profile.IsSelected) activeSlot = targetSlot;
             }
             catch (Exception ex)
             {
                 Log($"[IMP-BC] Error slot {profile.Slot}: {ex.Message}");
             }
         }
+
+        if (skippedNoSlot > 0)
+            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
+                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
 
         // Switch to active BC profile and reload UI
         int slotToShow = activeSlot > 0 ? activeSlot : CurrentProfile();

--- a/K2.App/MainWindow.Makalu.cs
+++ b/K2.App/MainWindow.Makalu.cs
@@ -223,17 +223,27 @@ public partial class MainWindow
 
         int totalRemap = 0;
         int activeSlot = -1;
+        int skippedNoSlot = 0;
+        var usedSlots = new HashSet<int>(_mkStore.GetExistingProfiles());
         foreach (var profile in allProfiles)
         {
             try
             {
-                var (remap, lighting, settings) = BaseCampDbImporter.ImportMakaluProfile(dbPath, profile, _mkStore);
+                int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
+                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                usedSlots.Add(targetSlot);
+
+                var (remap, lighting, settings) = BaseCampDbImporter.ImportMakaluProfile(dbPath, profile, _mkStore, targetSlot);
                 totalRemap += remap;
-                if (profile.IsSelected) activeSlot = profile.Slot;
-                LogMakalu($"[IMP-BC] slot {profile.Slot} '{profile.Name}': remap={remap} lighting={lighting} settings={settings}");
+                if (profile.IsSelected) activeSlot = targetSlot;
+                LogMakalu($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: remap={remap} lighting={lighting} settings={settings}");
             }
             catch (Exception ex) { LogMakalu($"[IMP-BC] slot {profile.Slot} error: {ex.Message}"); }
         }
+
+        if (skippedNoSlot > 0)
+            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
+                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
 
         if (activeSlot > 0) _mkStore.SetCurrentProfile(activeSlot);
         MkRefreshProfiles();
@@ -264,10 +274,17 @@ public partial class MainWindow
             var root = doc.Root;
             if (root is null) return;
 
-            int slot = 1;
-            if (int.TryParse(root.Element("Id")?.Value, out var n) && n >= 1 && n <= 5) slot = n;
             string profileName = root.Element("ProfileName")?.Value
                                   ?? System.IO.Path.GetFileNameWithoutExtension(dlg.FileName);
+
+            // Always land in a FRESH slot — see BaseCampDbImporter.FindFreeSlot's doc comment.
+            int slot = BaseCampDbImporter.FindFreeSlot(_mkStore.GetExistingProfiles());
+            if (slot == 0)
+            {
+                MessageBox.Show(this, Loc.Get("import_no_free_slot", profileName),
+                    Loc.Get("dp_open_bc_profile"), MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
 
             int remapped = 0;
             foreach (var b in root.Descendants("MakaluKeyBindings"))

--- a/K2.App/MainWindow.NumpadDisplayKeys.cs
+++ b/K2.App/MainWindow.NumpadDisplayKeys.cs
@@ -144,9 +144,20 @@ public partial class MainWindow
     {
         try
         {
+            // Load from bytes into a MemoryStream, NOT BitmapImage.UriSource: every NDK
+            // slot always reuses the same fixed filename (ndk_{index}.png, whether written
+            // by XML import, BC-DB import, or NdkApplyImage), and WPF's imaging pipeline
+            // caches a UriSource-loaded BitmapImage by that URI — re-importing/overwriting
+            // the same file left the canvas thumbnail showing the stale (or, after a prior
+            // failed load, blank) cached bitmap instead of the new content, even though
+            // NdkKeyConfigDialog's own preview (RefreshImagePreview, same byte-stream
+            // approach) showed the correct new icon from the very same path. Mirrors that
+            // dialog's loading code exactly so both stay in sync.
+            byte[] bytes = File.ReadAllBytes(imagePath);
+            using var ms = new MemoryStream(bytes);
             var bi = new BitmapImage();
             bi.BeginInit();
-            bi.UriSource = new Uri(imagePath, UriKind.Absolute);
+            bi.StreamSource = ms;
             bi.DecodePixelWidth = 72;
             bi.CacheOption = BitmapCacheOption.OnLoad;
             bi.EndInit();
@@ -322,37 +333,7 @@ public partial class MainWindow
         Mouse.OverrideCursor = Cursors.Wait;
         try
         {
-            // Upload to device — try parameter combinations for debugging.
-            // SDK: targetDev=1, targetPic=picSlot, targetSubItem=keyIndex.
-            // Try different (picSlot, keyIndex) combinations to find which
-            // mapping works for all 4 display keys.
-            bool ok = false;
-
-            // Attempt 1: picSlot=0, subItem=keyIndex (all on the same slot)
-            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: 0);
-            LogEverest($"[NDK] Upload key={keyIndex} try1(pic=0,sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-
-            if (!ok)
-            {
-                // Attempt 2: picSlot=keyIndex, subItem=keyIndex
-                ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)keyIndex);
-                LogEverest($"[NDK] Upload key={keyIndex} try2(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-            }
-
-            if (!ok)
-            {
-                // Attempt 3: picSlot=keyIndex+1, subItem=keyIndex
-                ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)(keyIndex + 1));
-                LogEverest($"[NDK] Upload key={keyIndex} try3(pic={keyIndex + 1},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-            }
-
-            if (!ok)
-            {
-                // Attempt 4: strip mode (targetDev=0, targetPic=2+keyIndex)
-                ok = _everest.UploadNumpadImageStrip(imagePath, keyIndex, picSlot: (byte)keyIndex);
-                LogEverest($"[NDK] Upload key={keyIndex} try4-strip(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-            }
-
+            bool ok = UploadNdkImageWithFallback(keyIndex, imagePath);
             if (ok)
             {
                 _ndkImagePaths[keyIndex] = imagePath;
@@ -375,6 +356,48 @@ public partial class MainWindow
             _ndkUploadBusy = false;
             UpdateKeyboardLayout();
         }
+    }
+
+    /// <summary>
+    /// Uploads <paramref name="imagePath"/> to display key <paramref name="keyIndex"/>,
+    /// trying the same (picSlot, subItem) parameter combinations in the same order as the
+    /// original single-key dialog flow — the exact wire mapping was never confirmed via
+    /// USB capture, so which attempt actually succeeds can vary by firmware/hardware.
+    /// Shared by <see cref="NdkApplyImage"/> (single-key edit) and
+    /// <see cref="EvUploadNdkImages"/> (bulk re-upload on profile load/reconnect, see
+    /// MainWindow.Everest.cs) — the bulk path used to call only "Attempt 1" directly,
+    /// which silently failed on any hardware where a later attempt is the one that
+    /// actually works. Does not touch <see cref="_ndkImagePaths"/>/UI state; the caller
+    /// decides what to do with the result.
+    /// </summary>
+    private bool UploadNdkImageWithFallback(int keyIndex, string imagePath)
+    {
+        // Attempt 1: picSlot=0, subItem=keyIndex (all on the same slot)
+        bool ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: 0);
+        LogEverest($"[NDK] Upload key={keyIndex} try1(pic=0,sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+
+        if (!ok)
+        {
+            // Attempt 2: picSlot=keyIndex, subItem=keyIndex
+            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)keyIndex);
+            LogEverest($"[NDK] Upload key={keyIndex} try2(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+        }
+
+        if (!ok)
+        {
+            // Attempt 3: picSlot=keyIndex+1, subItem=keyIndex
+            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)(keyIndex + 1));
+            LogEverest($"[NDK] Upload key={keyIndex} try3(pic={keyIndex + 1},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+        }
+
+        if (!ok)
+        {
+            // Attempt 4: strip mode (targetDev=0, targetPic=2+keyIndex)
+            ok = _everest.UploadNumpadImageStrip(imagePath, keyIndex, picSlot: (byte)keyIndex);
+            LogEverest($"[NDK] Upload key={keyIndex} try4-strip(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
+        }
+
+        return ok;
     }
 
     /// <summary>Set while <see cref="NdkApplyImage"/> is writing a picture to the device —

--- a/K2.App/MainWindow.NumpadDisplayKeys.cs
+++ b/K2.App/MainWindow.NumpadDisplayKeys.cs
@@ -2,7 +2,11 @@
 // Unified interface (matches DisplayPad): a single click opens NdkKeyConfigDialog,
 // which combines image + action in one window. Right-click keeps quick "remove"
 // shortcuts only. Images are uploaded via EverestImageUploader (72×72 RGB565) and
-// actions are saved in EverestStore as "ndk.{keyIndex}.imagePath"/"actionType" etc.
+// actions are saved in EverestStore as "ndk.{profile}.{keyIndex}.imagePath"/"actionType"
+// etc. — PER PROFILE (see UploadNdkImage's doc comment: confirmed via USB capture
+// 2026-07-16 that the firmware itself stores each profile's 4 NDK pictures separately,
+// which is also why switching the active firmware profile is instant on real hardware —
+// no image re-transfer needed, just EverestService.SwitchProfile).
 
 using System;
 using System.IO;
@@ -115,27 +119,41 @@ public partial class MainWindow
 
     // ─────────────────────── Persistence ───────────────────────
 
+    /// <summary>(Re)loads the 4 NDK buttons' thumbnails/actions for the CURRENT Everest
+    /// profile (<see cref="EvCurrentProfile"/>) — called at startup and every time
+    /// <see cref="ReloadEverestProfile"/> switches profile. No hardware I/O: the pictures
+    /// were already pushed to that profile's firmware slot whenever they were assigned
+    /// (see <see cref="UploadNdkImage"/>), so a profile switch only needs to refresh what
+    /// the on-screen buttons display, matching what's actually resident on the device.
+    /// Guarded for the one call before <see cref="InitNumpadDisplayKeys"/> has built the
+    /// buttons yet (InitEverestModule's ReloadEverestProfile runs first).</summary>
     private void LoadNdkState()
     {
+        if (_ndkButtons[0] is null) return;
+        int profile = EvCurrentProfile();
         for (int i = 0; i < NdkCount; i++)
         {
-            _ndkImagePaths[i] = _evStore.GetSetting($"ndk.{i}.imagePath");
+            _ndkImagePaths[i] = _evStore.GetSetting($"ndk.{profile}.{i}.imagePath");
             _ndkActions[i] = (
-                _evStore.GetSetting($"ndk.{i}.actionType"),
-                _evStore.GetSetting($"ndk.{i}.actionValue")
+                _evStore.GetSetting($"ndk.{profile}.{i}.actionType"),
+                _evStore.GetSetting($"ndk.{profile}.{i}.actionValue")
             );
 
-            // Show thumbnail if the file exists
             if (!string.IsNullOrEmpty(_ndkImagePaths[i]) && File.Exists(_ndkImagePaths[i]))
                 NdkSetThumbnail(i, _ndkImagePaths[i]!);
+            else
+                NdkClearThumbnail(i);
         }
     }
 
+    /// <summary>Persists display key <paramref name="index"/>'s image/action for the
+    /// CURRENT Everest profile.</summary>
     private void SaveNdkKey(int index)
     {
-        _evStore.SetSetting($"ndk.{index}.imagePath", _ndkImagePaths[index] ?? "");
-        _evStore.SetSetting($"ndk.{index}.actionType", _ndkActions[index].Type ?? "");
-        _evStore.SetSetting($"ndk.{index}.actionValue", _ndkActions[index].Value ?? "");
+        int profile = EvCurrentProfile();
+        _evStore.SetSetting($"ndk.{profile}.{index}.imagePath", _ndkImagePaths[index] ?? "");
+        _evStore.SetSetting($"ndk.{profile}.{index}.actionType", _ndkActions[index].Type ?? "");
+        _evStore.SetSetting($"ndk.{profile}.{index}.actionValue", _ndkActions[index].Value ?? "");
     }
 
     // ─────────────────────── Thumbnail ───────────────────────
@@ -312,12 +330,12 @@ public partial class MainWindow
     /// <summary>
     /// Uploads <paramref name="imagePath"/> (already 72×72 — either user-cropped or
     /// auto-generated, both via <see cref="NdkKeyConfigDialog"/>) to display key
-    /// <paramref name="keyIndex"/>, persists it, and refreshes the thumbnail.
-    /// While the upload + device-side refresh (<see cref="NdkRefreshDevicePicSlots"/>) run,
-    /// all 4 NDK buttons are disabled and the wait cursor is shown — same "block until the
-    /// hardware reload settles" contract Base Camp uses, and the same intent as DisplayPad's
-    /// <c>_dpRepaintBusy</c> guard (see MainWindow.DisplayPad.cs), just synchronous here since
-    /// the SDK calls themselves are blocking.
+    /// <paramref name="keyIndex"/> of the CURRENT Everest profile, persists it, and
+    /// refreshes the thumbnail. <see cref="EverestSdkNative.StartPicUpdate"/> is
+    /// synchronous and takes ~2s (confirmed via USB capture, K2/_reference/usb_dumps,
+    /// 2026-07-16), so a full-window "please wait" overlay (<see cref="ShowHwBusy"/>) is
+    /// shown for the duration — mirrors Base Camp, which blocks its own UI the same way
+    /// while pushing NDK/Display Dial pictures.
     /// </summary>
     private void NdkApplyImage(int keyIndex, string imagePath)
     {
@@ -329,11 +347,10 @@ public partial class MainWindow
 
         NdkSetButtonsEnabled(false);
         _ndkUploadBusy = true;
-        var oldCursor = Mouse.OverrideCursor;
-        Mouse.OverrideCursor = Cursors.Wait;
+        ShowHwBusy(Loc.Get("hw_busy_uploading_image"));
         try
         {
-            bool ok = UploadNdkImageWithFallback(keyIndex, imagePath);
+            bool ok = UploadNdkImage(keyIndex, imagePath, EvCurrentProfile());
             if (ok)
             {
                 _ndkImagePaths[keyIndex] = imagePath;
@@ -346,7 +363,7 @@ public partial class MainWindow
         }
         finally
         {
-            Mouse.OverrideCursor = oldCursor;
+            HideHwBusy();
             NdkSetButtonsEnabled(true);
             // The firmware reports the numpad/dock as unplugged (byNumpadPlug/byMMDockPlug
             // == 0) while it's busy writing the new NDK picture to flash — UpdateKeyboardLayout
@@ -359,44 +376,25 @@ public partial class MainWindow
     }
 
     /// <summary>
-    /// Uploads <paramref name="imagePath"/> to display key <paramref name="keyIndex"/>,
-    /// trying the same (picSlot, subItem) parameter combinations in the same order as the
-    /// original single-key dialog flow — the exact wire mapping was never confirmed via
-    /// USB capture, so which attempt actually succeeds can vary by firmware/hardware.
-    /// Shared by <see cref="NdkApplyImage"/> (single-key edit) and
-    /// <see cref="EvUploadNdkImages"/> (bulk re-upload on profile load/reconnect, see
-    /// MainWindow.Everest.cs) — the bulk path used to call only "Attempt 1" directly,
-    /// which silently failed on any hardware where a later attempt is the one that
-    /// actually works. Does not touch <see cref="_ndkImagePaths"/>/UI state; the caller
-    /// decides what to do with the result.
+    /// Uploads <paramref name="imagePath"/> to display key <paramref name="keyIndex"/> of
+    /// firmware profile <paramref name="profile"/> (1..5). Wire mapping confirmed via USB
+    /// capture while sniffing real Base Camp (K2/_reference/usb_dumps/evicone.pcapng,
+    /// 2026-07-16): the SDK's <c>StartPicUpdate</c> header encodes
+    /// <c>byTargetPic = firmware profile number</c>, NOT the key index as originally
+    /// guessed — a single manual D1 upload used targetPic=01 (profile 1 was active), while
+    /// loading profile 2's 4 icons used targetPic=02 constant with byTargetSubItem=0..3 as
+    /// the key index. This is also why switching the active firmware profile is instant on
+    /// real hardware: each profile's 4 pictures live in its own flash slot, so nothing needs
+    /// re-transferring on switch — only on an actual edit, which is what this method is for.
+    /// Shared by <see cref="NdkApplyImage"/> (single-key edit, current profile) and
+    /// <see cref="EvUploadNdkImages"/> (re-sync on fresh device connect, see
+    /// MainWindow.Everest.cs). Does not touch <see cref="_ndkImagePaths"/>/UI state; the
+    /// caller decides what to do with the result.
     /// </summary>
-    private bool UploadNdkImageWithFallback(int keyIndex, string imagePath)
+    private bool UploadNdkImage(int keyIndex, string imagePath, int profile)
     {
-        // Attempt 1: picSlot=0, subItem=keyIndex (all on the same slot)
-        bool ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: 0);
-        LogEverest($"[NDK] Upload key={keyIndex} try1(pic=0,sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-
-        if (!ok)
-        {
-            // Attempt 2: picSlot=keyIndex, subItem=keyIndex
-            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)keyIndex);
-            LogEverest($"[NDK] Upload key={keyIndex} try2(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-        }
-
-        if (!ok)
-        {
-            // Attempt 3: picSlot=keyIndex+1, subItem=keyIndex
-            ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)(keyIndex + 1));
-            LogEverest($"[NDK] Upload key={keyIndex} try3(pic={keyIndex + 1},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-        }
-
-        if (!ok)
-        {
-            // Attempt 4: strip mode (targetDev=0, targetPic=2+keyIndex)
-            ok = _everest.UploadNumpadImageStrip(imagePath, keyIndex, picSlot: (byte)keyIndex);
-            LogEverest($"[NDK] Upload key={keyIndex} try4-strip(pic={keyIndex},sub={keyIndex}) -> {(ok ? "OK" : "FAIL")}");
-        }
-
+        bool ok = _everest.UploadNumpadImage(imagePath, keyIndex, picSlot: (byte)profile);
+        LogEverest($"[NDK] Upload profile={profile} key={keyIndex} -> {(ok ? "OK" : "FAIL")}");
         return ok;
     }
 

--- a/K2.App/MainWindow.xaml
+++ b/K2.App/MainWindow.xaml
@@ -718,6 +718,21 @@
                 </StackPanel>
             </Grid>
 
+            <!-- Hardware-busy overlay — shown while a blocking device write (NDK/Display Dial
+                 picture upload, etc.) is in flight, so the app reads as "waiting", not frozen.
+                 Toggled via ShowHwBusy/HideHwBusy (MainWindow.HwBusy.cs). Semi-transparent
+                 (unlike PnlLoading) since it's a transient few-second wait, not a full page swap. -->
+            <Grid x:Name="PnlHwBusy" Grid.RowSpan="3" Panel.ZIndex="9" Background="#CC1A1A1E"
+                  Visibility="Collapsed">
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <TextBlock x:Name="TxtHwBusyMessage" FontSize="15" Foreground="White"
+                               HorizontalAlignment="Center" TextAlignment="Center" MaxWidth="360"
+                               TextWrapping="Wrap"/>
+                    <ProgressBar IsIndeterminate="True" Width="280" Height="3"
+                                 Margin="0,14,0,0" Foreground="#900000" Background="#2A2A32"/>
+                </StackPanel>
+            </Grid>
+
             <!-- Content panels: one visible at a time -->
             <Grid Grid.Row="2">
 
@@ -1147,6 +1162,13 @@
                                                             <CheckBox x:Name="CkDialCustom"   Style="{StaticResource K2ToggleRow}" Tag="&#xE765;" Content="{loc:Get dial_custom}"     Click="CkDial_Click"/>
                                                         </StackPanel>
                                                     </Grid>
+
+                                                    <WrapPanel Orientation="Horizontal" Margin="0,12,0,0">
+                                                        <TextBlock Text="{loc:Get dial_menu_color}" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                                        <Button x:Name="BtnDialMenuColor" Width="40" Height="22"
+                                                                Background="#F3CC23" BorderThickness="2"
+                                                                BorderBrush="#3A3A40" Click="BtnDialMenuColor_Click"/>
+                                                    </WrapPanel>
                                                 </StackPanel>
 
                                                 <!-- Right: clock type, screensaver, turn-off, menu color, actions -->
@@ -1199,9 +1221,23 @@
                                                         <TextBlock Grid.Row="0" Grid.Column="2" Text="{loc:Get unit_seconds}" VerticalAlignment="Center"/>
                                                         <TextBlock Grid.Row="0" Grid.Column="3" Text="{loc:Get dial_screensaver_function_label}"
                                                                    VerticalAlignment="Center" Margin="6,0,6,0"/>
-                                                        <ComboBox Grid.Row="0" Grid.Column="4" x:Name="CbDialScreenSaverFunction"
-                                                                  HorizontalAlignment="Left" Width="150"
-                                                                  SelectionChanged="CbDialScreenSaverFunction_SelectionChanged"/>
+                                                        <StackPanel Grid.Row="0" Grid.RowSpan="2" Grid.Column="4"
+                                                                    HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                            <ComboBox x:Name="CbDialScreenSaverFunction" Width="150"
+                                                                      SelectionChanged="CbDialScreenSaverFunction_SelectionChanged"/>
+                                                            <Button x:Name="BtnDialLoadImage" Content="{loc:Get dial_load_image}"
+                                                                    Padding="8,2" Margin="0,4,0,0" Click="BtnDialLoadImage_Click"
+                                                                    Style="{StaticResource K2IconButton}" Tag="&#xE91B;"/>
+                                                            <Button x:Name="BtnDialApply" Content="{loc:Get apply_to_device}"
+                                                                    Padding="8,2" Margin="0,8,0,4" Click="BtnDialApply_Click"
+                                                                    Style="{StaticResource K2IconAccentButton}" Tag="&#xE73E;"/>
+                                                            <Button x:Name="BtnDialRead" Content="{loc:Get read_from_device}"
+                                                                    Padding="8,2" Margin="0,0,0,4" Click="BtnDialRead_Click"
+                                                                    Style="{StaticResource K2IconButton}" Tag="&#xE72C;"/>
+                                                            <Button x:Name="BtnDialReset" Content="{loc:Get reset_display_dial}"
+                                                                    Padding="8,2" Click="BtnDialReset_Click"
+                                                                    Style="{StaticResource K2IconButton}" Tag="&#xE777;"/>
+                                                        </StackPanel>
 
                                                         <CheckBox Grid.Row="1" Grid.Column="0" x:Name="CkDialTurnOffEnable"
                                                                   Content="{loc:Get dial_autooff}" VerticalAlignment="Center" Margin="0,8,0,0"
@@ -1212,25 +1248,6 @@
                                                         <TextBlock Grid.Row="1" Grid.Column="2" Text="{loc:Get unit_seconds}"
                                                                    VerticalAlignment="Center" Margin="0,8,0,0"/>
                                                     </Grid>
-
-                                                    <WrapPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                                        <TextBlock Text="{loc:Get dial_menu_color}" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                                                        <Button x:Name="BtnDialMenuColor" Width="40" Height="22"
-                                                                Background="#F3CC23" BorderThickness="2"
-                                                                BorderBrush="#3A3A40" Click="BtnDialMenuColor_Click"/>
-                                                    </WrapPanel>
-
-                                                    <WrapPanel Orientation="Horizontal">
-                                                        <Button x:Name="BtnDialApply" Content="{loc:Get apply_to_device}"
-                                                                Padding="8,2" Margin="0,0,4,0" Click="BtnDialApply_Click"
-                                                                Style="{StaticResource K2IconAccentButton}" Tag="&#xE73E;"/>
-                                                        <Button x:Name="BtnDialRead" Content="{loc:Get read_from_device}"
-                                                                Padding="8,2" Margin="0,0,4,0" Click="BtnDialRead_Click"
-                                                                Style="{StaticResource K2IconButton}" Tag="&#xE72C;"/>
-                                                        <Button x:Name="BtnDialReset" Content="{loc:Get reset_display_dial}"
-                                                                Padding="8,2" Click="BtnDialReset_Click"
-                                                                Style="{StaticResource K2IconButton}" Tag="&#xE777;"/>
-                                                    </WrapPanel>
                                                 </StackPanel>
                                             </Grid>
                                         </StackPanel>

--- a/K2.App/Services/BaseCampDbImporter.cs
+++ b/K2.App/Services/BaseCampDbImporter.cs
@@ -23,6 +23,21 @@ namespace K2.App.Services;
 /// </summary>
 public sealed class BaseCampDbImporter
 {
+    /// <summary>Lowest profile slot (1..<paramref name="maxSlots"/>) not present in
+    /// <paramref name="existingSlots"/>, or 0 if all are taken. Used by every device's
+    /// import flow so an imported profile lands in a fresh slot instead of overwriting
+    /// whatever K2 profile already occupies the source's own slot number (BC DB's
+    /// <c>Profiles.Id</c> / XML's <c>&lt;Id&gt;</c>) — that source number has no meaning
+    /// on this K2 install, it's just whichever slot the profile happened to occupy on
+    /// the machine it was exported from.</summary>
+    public static int FindFreeSlot(IEnumerable<int> existingSlots, int maxSlots = 5)
+    {
+        var used = new HashSet<int>(existingSlots);
+        for (int s = 1; s <= maxSlots; s++)
+            if (!used.Contains(s)) return s;
+        return 0;
+    }
+
     // KeyId/DLLMatrixIndex → button index (0-11) for DisplayPad and MacroPad
     internal static readonly Dictionary<int, int> KeyIdToIndex = new()
     {
@@ -165,7 +180,10 @@ public sealed class BaseCampDbImporter
     }
 
     /// <summary>
-    /// Imports a Base Camp profile into the K2 store for a specific device.
+    /// Imports a Base Camp profile into the K2 store for a specific device, into
+    /// <paramref name="targetSlot"/> (a fresh slot picked by the caller via
+    /// <see cref="FindFreeSlot"/> — NOT necessarily <c>profile.Slot</c>, which is only
+    /// where it happened to live on the source Base Camp install).
     /// Saves the base64 images to disk and the translated actions.
     /// Returns the number of keys imported.
     /// </summary>
@@ -173,10 +191,11 @@ public sealed class BaseCampDbImporter
         string dbPath,
         BcProfile profile,
         int k2DeviceId,
-        DisplayPadStore store)
+        DisplayPadStore store,
+        int targetSlot)
     {
         var buttons = ReadButtons(dbPath, profile.ProfileId);
-        int slot = profile.Slot;
+        int slot = targetSlot;
         int imported = 0;
 
         // Directory for the imported images
@@ -450,14 +469,17 @@ public sealed class BaseCampDbImporter
     /// Imports an Everest profile into <see cref="EverestStore"/>.
     /// Regular keys (IsTouchKey=false) → Keys table by DLLMatrixIndex.
     /// Touch keys (IsTouchKey=true, LCD display keys) → image saved to disk, path+action
-    /// stored in Settings as <c>ndk.{i}.imagePath</c> / <c>ndk.{i}.actionType</c> etc.
-    /// Returns (regularKeys, touchKeys) counts.
+    /// stored in Settings as <c>ndk.{slot}.{i}.imagePath</c> / <c>ndk.{slot}.{i}.actionType</c>
+    /// etc. — PER PROFILE (each firmware profile stores its own 4 NDK pictures, confirmed via
+    /// USB capture — see MainWindow.NumpadDisplayKeys.cs's UploadNdkImage doc comment).
+    /// Returns (regularKeys, touchKeys) counts. <paramref name="targetSlot"/> is a fresh
+    /// slot picked by the caller via <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.
     /// </summary>
     public static (int Regular, int Touch) ImportEverestProfile(
-        string dbPath, BcProfile profile, EverestStore store)
+        string dbPath, BcProfile profile, EverestStore store, int targetSlot)
     {
         var bindings = ReadKeyBindings(dbPath, profile.ProfileId);
-        int slot = profile.Slot;
+        int slot = targetSlot;
         int regular = 0, touch = 0;
 
         // Split: regular keys (actions) vs touch keys (LCD images)
@@ -500,7 +522,7 @@ public sealed class BaseCampDbImporter
                 catch { /* corrupted image — skip */ }
             }
 
-            string prefix = $"ndk.{i}";
+            string prefix = $"ndk.{slot}.{i}";
             if (imagePath is not null)
                 store.SetSetting($"{prefix}.imagePath", imagePath);
 
@@ -591,12 +613,14 @@ public sealed class BaseCampDbImporter
     /// <summary>
     /// Imports a MacroPad profile into <see cref="MacroPadStore"/>, reading the
     /// real MakaluKeyBindings table. Returns the number of keys imported.
+    /// <paramref name="targetSlot"/> is a fresh slot picked by the caller via
+    /// <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.
     /// </summary>
     public static int ImportMacroPadProfile(
-        string dbPath, BcProfile profile, int k2DeviceId, MacroPadStore store)
+        string dbPath, BcProfile profile, int k2DeviceId, MacroPadStore store, int targetSlot)
     {
         var bindings = ReadMakaluBindings(dbPath, profile.ProfileId);
-        int slot = profile.Slot;
+        int slot = targetSlot;
         int imported = 0;
 
         foreach (var b in bindings)
@@ -952,11 +976,12 @@ public sealed class BaseCampDbImporter
 
     /// <summary>Imports a Makalu mouse profile: lighting + DPI + settings +
     /// button remap into MakaluStore. Returns (remapped button count, lighting
-    /// imported, settings imported).</summary>
+    /// imported, settings imported). <paramref name="targetSlot"/> is a fresh slot
+    /// picked by the caller via <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.</summary>
     public static (int Remap, bool Lighting, bool Settings) ImportMakaluProfile(
-        string dbPath, BcProfile profile, MakaluStore store)
+        string dbPath, BcProfile profile, MakaluStore store, int targetSlot)
     {
-        int slot = profile.Slot;
+        int slot = targetSlot;
         store.ClearProfile(slot);
         store.SetProfileName(slot, profile.Name);
 
@@ -1104,10 +1129,11 @@ public sealed class BaseCampDbImporter
     /// <summary>Imports an Everest 60 profile: lighting (high confidence) +
     /// key bindings (via the shared <see cref="TranslateAction"/> vocabulary,
     /// see class-level doc comment) into Everest60Store. Returns the number
-    /// of key bindings imported.</summary>
-    public static int ImportEverest60Profile(string dbPath, BcProfile profile, Everest60Store store)
+    /// of key bindings imported. <paramref name="targetSlot"/> is a fresh slot
+    /// picked by the caller via <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.</summary>
+    public static int ImportEverest60Profile(string dbPath, BcProfile profile, Everest60Store store, int targetSlot)
     {
-        int slot = profile.Slot;
+        int slot = targetSlot;
         store.ClearProfile(slot);
         store.SetProfileName(slot, profile.Name);
 

--- a/K2.App/Services/EvProfileExporter.cs
+++ b/K2.App/Services/EvProfileExporter.cs
@@ -31,11 +31,11 @@ namespace K2.App.Services;
 /// <c>MainWindow.Everest.cs</c>'s <c>BtnEvImportXml_Click</c>).
 ///
 /// Includes both the regular keys (KeyMatrix stored in <see cref="EverestStore"/>)
-/// and the 4 numpad LCD keys (NDK). Note: in K2, NDK images/actions are
-/// GLOBAL device settings (not per-profile — see
-/// <c>EverestStore</c>/<c>ndk.{i}.*</c>), so every exported profile will show the
-/// same NDK content: this is a simplification of K2's current data model, not
-/// a Base Camp limitation. The 4 synthetic KeyIds used for the NDKs (9001-9004) are
+/// and the 4 numpad LCD keys (NDK), PER PROFILE (<c>EverestStore</c>'s
+/// <c>ndk.{slot}.{i}.*</c> settings — confirmed via USB capture against real Base Camp
+/// that each firmware profile stores its own 4 NDK pictures, see
+/// MainWindow.NumpadDisplayKeys.cs's UploadNdkImage doc comment). The 4 synthetic
+/// KeyIds used for the NDKs (9001-9004) are
 /// a K2 invention (no real DLLMatrixIndex known) — that's why the NDKs are
 /// exported ONLY in K2 mode (never in Base Camp compatible mode).
 /// </summary>
@@ -108,12 +108,12 @@ public static class EvProfileExporter
                 isAssigned, isTouchKey: false, functionType, subType, funcValue, imageB64: null));
         }
 
-        // ---- Numpad LCD keys (NDK), 0-3 — device-global in K2 ----
+        // ---- Numpad LCD keys (NDK), 0-3 — per-profile ----
         for (int i = 0; i < 4; i++)
         {
-            string? imagePath = store.GetSetting($"ndk.{i}.imagePath");
-            string? ndkType   = store.GetSetting($"ndk.{i}.actionType");
-            string? ndkValue  = store.GetSetting($"ndk.{i}.actionValue");
+            string? imagePath = store.GetSetting($"ndk.{slot}.{i}.imagePath");
+            string? ndkType   = store.GetSetting($"ndk.{slot}.{i}.actionType");
+            string? ndkValue  = store.GetSetting($"ndk.{slot}.{i}.actionValue");
             bool hasImage = !string.IsNullOrEmpty(imagePath) && File.Exists(imagePath);
             bool hasAction = !string.IsNullOrEmpty(ndkType);
             if (!hasImage && !hasAction) continue;

--- a/K2.App/Services/Everest60Store.cs
+++ b/K2.App/Services/Everest60Store.cs
@@ -145,6 +145,46 @@ ON CONFLICT(Key) DO UPDATE SET Value=excluded.Value";
     public void SetProfileName(int slot, string name) =>
         SetSetting($"profile.{slot}.name", name.Trim());
 
+    /// <summary>Profile slots that are actually configured — mirrors EverestStore's
+    /// GetExistingProfiles, used so imports can find a free slot instead of overwriting
+    /// whatever profile already occupies the source's slot number. A slot counts as
+    /// existing if it has a key binding, a custom name, saved lighting, or the "exists"
+    /// marker set by <see cref="MarkProfileExists"/> for brand-new empty profiles.</summary>
+    public List<int> GetExistingProfiles()
+    {
+        var result = new SortedSet<int>();
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT DISTINCT Profile FROM Keys";
+            using var r = cmd.ExecuteReader();
+            while (r.Read()) result.Add(r.GetInt32(0));
+        }
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = @"SELECT Key, Value FROM Settings
+                                WHERE Key LIKE 'profile.%.name' OR Key LIKE 'profile.%.exists'
+                                   OR Key LIKE 'profile.%.lighting'";
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                string key = r.GetString(0);
+                string value = r.IsDBNull(1) ? "" : r.GetString(1);
+                if (string.IsNullOrEmpty(value)) continue;
+                var parts = key.Split('.');
+                if (parts.Length == 3 && int.TryParse(parts[1], out int slot))
+                    result.Add(slot);
+            }
+        }
+
+        return new List<int>(result);
+    }
+
+    /// <summary>Marks an otherwise-empty profile as "existing" so it shows up in the
+    /// profile combo / counts as occupied for import slot-picking purposes.</summary>
+    public void MarkProfileExists(int profile) => SetSetting($"profile.{profile}.exists", "1");
+
     // ---------- lighting ----------
 
     public Ev60LightingRecord? LoadLighting(int slot)

--- a/K2.App/Services/EverestService.cs
+++ b/K2.App/Services/EverestService.cs
@@ -957,8 +957,11 @@ public sealed class EverestService : IDisposable
     /// Uploads an image to a numpad display key (square format 72×72).
     /// </summary>
     /// <param name="imagePathOrBase64">Path or base64 string.</param>
-    /// <param name="keyIndex">Display key index (0-3).</param>
-    /// <param name="picSlot">Firmware image slot (used as byTargetPic).</param>
+    /// <param name="keyIndex">Display key index (0-3), sent as byTargetSubItem.</param>
+    /// <param name="picSlot">Firmware PROFILE number (1-5), sent as byTargetPic — confirmed
+    /// via USB capture against real Base Camp (K2/_reference/usb_dumps/evicone.pcapng,
+    /// 2026-07-16): each profile stores its own 4 NDK pictures in flash, which is also why
+    /// switching the active profile is instant on real hardware (no image re-transfer).</param>
     public bool UploadNumpadImage(string imagePathOrBase64, int keyIndex, byte picSlot = 0)
     {
         lock (_sdkLock)

--- a/K2.App/Services/EverestStore.cs
+++ b/K2.App/Services/EverestStore.cs
@@ -222,6 +222,7 @@ ON CONFLICT(Profile, KeyMatrix) DO UPDATE SET
         // from the profile combo (see GetExistingProfiles) until reused.
         SetSetting($"profile.{profile}.name", "");
         SetSetting($"profile.{profile}.exists", "");
+        ClearNdkSettings(profile);
     }
 
     /// <summary>Deletes only this profile's key bindings — unlike <see cref="ClearProfile"/>,
@@ -237,6 +238,24 @@ ON CONFLICT(Profile, KeyMatrix) DO UPDATE SET
         // Keep the slot visible in the profile combo — this clears content, not
         // identity/existence (unlike ClearProfile/delete).
         MarkProfileExists(profile);
+        ClearNdkSettings(profile);
+    }
+
+    /// <summary>Clears this profile's 4 NDK (numpad display key) settings — image path and
+    /// action — from local storage. Each firmware profile keeps its own 4 pictures in flash
+    /// (see MainWindow.NumpadDisplayKeys.cs's UploadNdkImage doc comment), but there's no SDK
+    /// call to blank an individual picture slot on the device, so the stale image stays
+    /// resident on hardware until the user assigns a new one — matching the same limitation
+    /// as regular keys, which are also only cleared locally here (no per-profile hardware
+    /// reset call exists either).</summary>
+    private void ClearNdkSettings(int profile)
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            SetSetting($"ndk.{profile}.{i}.imagePath", "");
+            SetSetting($"ndk.{profile}.{i}.actionType", "");
+            SetSetting($"ndk.{profile}.{i}.actionValue", "");
+        }
     }
 
     /// <summary>Wipes every profile, key binding, setting and keycap override — used by the

--- a/K2.App/Services/MakaluStore.cs
+++ b/K2.App/Services/MakaluStore.cs
@@ -97,6 +97,48 @@ ON CONFLICT(Key) DO UPDATE SET Value=excluded.Value";
     public void SetProfileName(int slot, string name) =>
         SetSetting($"profile.{slot}.name", name.Trim());
 
+    /// <summary>Profile slots that are actually configured — mirrors EverestStore's
+    /// GetExistingProfiles, used so imports can find a free slot instead of overwriting
+    /// whatever profile already occupies the source's slot number. A slot counts as
+    /// existing if it has a remapped button, a custom name, saved lighting/DPI/device
+    /// settings, or the "exists" marker set by <see cref="MarkProfileExists"/> for
+    /// brand-new empty profiles.</summary>
+    public List<int> GetExistingProfiles()
+    {
+        var result = new SortedSet<int>();
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT DISTINCT Profile FROM Remap";
+            using var r = cmd.ExecuteReader();
+            while (r.Read()) result.Add(r.GetInt32(0));
+        }
+
+        using (var cmd = _conn.CreateCommand())
+        {
+            cmd.CommandText = @"SELECT Key, Value FROM Settings
+                                WHERE Key LIKE 'profile.%.name' OR Key LIKE 'profile.%.exists'
+                                   OR Key LIKE 'profile.%.lighting' OR Key LIKE 'profile.%.dpi'
+                                   OR Key LIKE 'profile.%.settings'";
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                string key = r.GetString(0);
+                string value = r.IsDBNull(1) ? "" : r.GetString(1);
+                if (string.IsNullOrEmpty(value)) continue;
+                var parts = key.Split('.');
+                if (parts.Length == 3 && int.TryParse(parts[1], out int slot))
+                    result.Add(slot);
+            }
+        }
+
+        return new List<int>(result);
+    }
+
+    /// <summary>Marks an otherwise-empty profile as "existing" so it shows up in the
+    /// profile combo / counts as occupied for import slot-picking purposes.</summary>
+    public void MarkProfileExists(int profile) => SetSetting($"profile.{profile}.exists", "1");
+
     // ---------- lighting ----------
 
     public MakaluLightingRecord? LoadLighting(int slot)

--- a/K2.App/Services/SystemDiagnostics.cs
+++ b/K2.App/Services/SystemDiagnostics.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32;
+
+namespace K2.App.Services;
+
+/// <summary>
+/// Read-only startup diagnostics logged once per session: OS build (to tell Windows 10
+/// from 11 reliably — <see cref="Environment.OSVersion"/> alone is not enough without the
+/// app.manifest supportedOS entries already in place) and a HID-level snapshot of every
+/// Mountain device (VID 0x3282) Windows currently sees, independent of which SDK/engine
+/// K2 ends up using to talk to it.
+///
+/// The exclusive-open probe answers a question no vendor SDK return code can: is some
+/// OTHER process already holding this device's HID handle right now? A query-only open
+/// (used elsewhere in this codebase, e.g. DpHidNative.Enumerate) always succeeds even
+/// when a rival process has the device open exclusively; only a GENERIC_READ|WRITE +
+/// non-shared CreateFile attempt reveals a pre-existing exclusive claim (ERROR_SHARING_
+/// VIOLATION / ERROR_ACCESS_DENIED). The probe handle is closed immediately either way,
+/// so it never itself becomes the rival claimant for the app's real open that follows.
+/// </summary>
+internal static class SystemDiagnostics
+{
+    private const ushort MountainVID = 0x3282;
+
+    private static string DeviceLabel(ushort pid) => pid switch
+    {
+        0x0001 => "Everest Max",
+        0x0005 => "Everest 60 (ANSI)",
+        0x0006 => "Everest 60 (ISO)",
+        0x0009 => "DisplayPad",
+        0x0002 => "Makalu Max",
+        0x0003 => "Makalu 67",
+        _ => $"unknown PID 0x{pid:X4}",
+    };
+
+    public static void LogStartupInfo(Action<string> log)
+    {
+        try { LogOsInfo(log); } catch (Exception ex) { log($"[SysInfo] OS info failed: {ex.Message}"); }
+        try { LogMountainHidDevices(log); } catch (Exception ex) { log($"[SysInfo] HID scan failed: {ex.Message}"); }
+    }
+
+    private static void LogOsInfo(Action<string> log)
+    {
+        var os = Environment.OSVersion.Version;
+        string productName = "?", displayVersion = "?";
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+            productName = key?.GetValue("ProductName") as string ?? "?";
+            displayVersion = key?.GetValue("DisplayVersion") as string
+                              ?? key?.GetValue("ReleaseId") as string ?? "?";
+        }
+        catch { /* best-effort */ }
+
+        // Build >= 22000 is Windows 11 even though ProductName on some images still says "Windows 10".
+        string family = os.Build >= 22000 ? "Windows 11" : "Windows 10";
+        log($"[SysInfo] OS: {productName} ({family}) build {os.Build}.{os.Revision} " +
+            $"version {displayVersion}, {(Environment.Is64BitOperatingSystem ? "x64" : "x86")} OS");
+    }
+
+    private static void LogMountainHidDevices(Action<string> log)
+    {
+        HidD_GetHidGuid(out Guid hidGuid);
+        IntPtr devs = SetupDiGetClassDevsW(ref hidGuid, null, IntPtr.Zero, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (devs == INVALID_HANDLE_VALUE) { log("[SysInfo] HID class enumeration unavailable"); return; }
+
+        int found = 0;
+        try
+        {
+            var ifData = new SP_DEVICE_INTERFACE_DATA { cbSize = Marshal.SizeOf<SP_DEVICE_INTERFACE_DATA>() };
+            for (uint i = 0; SetupDiEnumDeviceInterfaces(devs, IntPtr.Zero, ref hidGuid, i, ref ifData); i++)
+            {
+                string? path = GetInterfacePath(devs, ref ifData);
+                if (path is null) continue;
+
+                using var qh = CreateFileW(path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE, IntPtr.Zero,
+                                            OPEN_EXISTING, 0, IntPtr.Zero);
+                if (qh.IsInvalid) continue;
+
+                var attrs = new HIDD_ATTRIBUTES { Size = Marshal.SizeOf<HIDD_ATTRIBUTES>() };
+                if (!HidD_GetAttributes(qh, ref attrs) || attrs.VendorID != MountainVID) continue;
+                qh.Dispose();
+                found++;
+
+                // Exclusive probe: share flags = 0. If some other process already holds this
+                // interface open (any share mode short of full read+write sharing), this fails.
+                using var eh = CreateFileW(path, GENERIC_READ | GENERIC_WRITE, 0, IntPtr.Zero,
+                                            OPEN_EXISTING, 0, IntPtr.Zero);
+                bool exclusiveOk = !eh.IsInvalid;
+                int err = exclusiveOk ? 0 : Marshal.GetLastWin32Error();
+                eh.Dispose();
+
+                string shortPath = path.Length > 90 ? path[..90] + "…" : path;
+                log($"[SysInfo] HID {DeviceLabel(attrs.ProductID)} (PID 0x{attrs.ProductID:X4}) " +
+                    $"exclusiveOpen={(exclusiveOk ? "OK" : $"FAIL win32={err}")} path={shortPath}");
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(devs); }
+
+        if (found == 0) log("[SysInfo] No Mountain (VID 0x3282) HID devices found by Windows");
+    }
+
+    private static string? GetInterfacePath(IntPtr devs, ref SP_DEVICE_INTERFACE_DATA ifData)
+    {
+        var devInfo = new SP_DEVINFO_DATA { cbSize = Marshal.SizeOf<SP_DEVINFO_DATA>() };
+        SetupDiGetDeviceInterfaceDetailW(devs, ref ifData, IntPtr.Zero, 0, out int size, ref devInfo);
+        if (size <= 0) return null;
+        IntPtr detail = Marshal.AllocHGlobal(size);
+        try
+        {
+            Marshal.WriteInt32(detail, IntPtr.Size == 8 ? 8 : 6);
+            if (!SetupDiGetDeviceInterfaceDetailW(devs, ref ifData, detail, size, out _, ref devInfo))
+                return null;
+            return Marshal.PtrToStringUni(detail + 4);
+        }
+        finally { Marshal.FreeHGlobal(detail); }
+    }
+
+    // ================================================================
+    // P/Invoke (minimal subset, independent of DpHidNative's private ones)
+    // ================================================================
+
+    private static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+    private const uint DIGCF_PRESENT = 0x02, DIGCF_DEVICEINTERFACE = 0x10;
+    private const uint GENERIC_READ = 0x80000000, GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_READ = 1, FILE_SHARE_WRITE = 2;
+    private const uint OPEN_EXISTING = 3;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SP_DEVICE_INTERFACE_DATA
+    { public int cbSize; public Guid InterfaceClassGuid; public int Flags; public IntPtr Reserved; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SP_DEVINFO_DATA
+    { public int cbSize; public Guid ClassGuid; public uint DevInst; public IntPtr Reserved; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HIDD_ATTRIBUTES
+    { public int Size; public ushort VendorID; public ushort ProductID; public ushort VersionNumber; }
+
+    [DllImport("hid.dll")]
+    private static extern void HidD_GetHidGuid(out Guid hidGuid);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    private static extern bool HidD_GetAttributes(Microsoft.Win32.SafeHandles.SafeFileHandle h, ref HIDD_ATTRIBUTES attrs);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr SetupDiGetClassDevsW(ref Guid gClass, string? enumerator, IntPtr hwnd, uint flags);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiEnumDeviceInterfaces(IntPtr devs, IntPtr devInfo, ref Guid gClass,
+        uint index, ref SP_DEVICE_INTERFACE_DATA ifData);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool SetupDiGetDeviceInterfaceDetailW(IntPtr devs, ref SP_DEVICE_INTERFACE_DATA ifData,
+        IntPtr detail, int detailSize, out int required, ref SP_DEVINFO_DATA devInfo);
+
+    [DllImport("setupapi.dll")]
+    private static extern bool SetupDiDestroyDeviceInfoList(IntPtr devs);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern Microsoft.Win32.SafeHandles.SafeFileHandle CreateFileW(
+        string filename, uint access, uint share, IntPtr security,
+        uint disposition, uint flags, IntPtr template);
+}

--- a/K2.Core/Strings.it.xml
+++ b/K2.Core/Strings.it.xml
@@ -185,6 +185,7 @@
   <string name="ev_driver_open_failed">Apertura driver Everest FALLITA.</string>
   <string name="ev_driver_closed">Driver Everest chiuso.</string>
   <string name="loading_drivers">Inizializzazione driver in corso…</string>
+  <string name="hw_busy_uploading_image">Caricamento immagine sul dispositivo, attendere…</string>
   <string name="ev_crash_recovering">Driver in crash — tentativo di recovery tra 3 s…</string>
   <string name="ev_crash_recovered">Driver recuperato — LED preview riavviata.</string>
   <string name="ev_crash_recovery_failed">Recovery fallita — riavviare K2.App.</string>
@@ -316,6 +317,13 @@
   <string name="dial_image">Immagine</string>
   <string name="dial_timer">Timer</string>
   <string name="dial_stopwatch">Cronometro</string>
+  <string name="dial_pcinfo_cpu">Info PC - CPU</string>
+  <string name="dial_pcinfo_gpu">Info PC - GPU</string>
+  <string name="dial_pcinfo_hdd">Info PC - HDD</string>
+  <string name="dial_pcinfo_internet">Info PC - Internet</string>
+  <string name="dial_pcinfo_ram">Info PC - RAM</string>
+  <string name="dial_load_image">Carica immagine</string>
+  <string name="dial_load_image_title">Scegli l'immagine per lo screensaver (240×204 px)</string>
   <string name="dial_clock_section">Tipo di orologio</string>
   <string name="dial_clock_label">Formato:</string>
   <string name="dial_clock_style_label">Stile:</string>
@@ -553,6 +561,8 @@
   <string name="delete_profile">Elimina profilo</string>
   <string name="delete_profile_confirm">Eliminare il profilo '{0}'? Tutte le associazioni tasti di questo profilo verranno rimosse.</string>
   <string name="delete_profile_last">Impossibile eliminare l'ultimo profilo.</string>
+  <string name="import_no_free_slot">Tutti e 5 gli slot profilo sono già occupati — elimina o libera uno slot prima di importare "{0}".</string>
+  <string name="import_some_skipped_no_slot">{0} profilo/i saltato/i: nessuno slot libero rimasto (tutti e 5 sono occupati).</string>
   <string name="ev_no_profiles_in_bc">Nessun profilo Everest trovato nel database Base Camp.</string>
   <string name="ev_imported_bc">Importati {0} profili Everest ({1} tasti) da Base Camp.</string>
   <string name="mp_no_profiles_in_bc">Nessun profilo MacroPad trovato nel database Base Camp.</string>

--- a/K2.Core/Strings.xml
+++ b/K2.Core/Strings.xml
@@ -186,6 +186,7 @@
   <string name="ev_driver_open_failed">Everest driver open FAILED.</string>
   <string name="ev_driver_closed">Everest driver closed.</string>
   <string name="loading_drivers">Initializing drivers…</string>
+  <string name="hw_busy_uploading_image">Uploading image to the device, please wait…</string>
   <string name="ev_crash_recovering">Driver crashed — attempting auto-recovery in 3 s…</string>
   <string name="ev_crash_recovered">Driver recovered — LED preview restarted.</string>
   <string name="ev_crash_recovery_failed">Driver recovery failed — please restart K2.App.</string>
@@ -317,6 +318,13 @@
   <string name="dial_image">Image</string>
   <string name="dial_timer">Timer</string>
   <string name="dial_stopwatch">Stopwatch</string>
+  <string name="dial_pcinfo_cpu">PC Info - CPU</string>
+  <string name="dial_pcinfo_gpu">PC Info - GPU</string>
+  <string name="dial_pcinfo_hdd">PC Info - HDD</string>
+  <string name="dial_pcinfo_internet">PC Info - Internet</string>
+  <string name="dial_pcinfo_ram">PC Info - RAM</string>
+  <string name="dial_load_image">Load image</string>
+  <string name="dial_load_image_title">Choose screensaver image (240×204 px)</string>
   <string name="dial_clock_section">Clock type</string>
   <string name="dial_clock_label">Format:</string>
   <string name="dial_clock_style_label">Style:</string>
@@ -554,6 +562,8 @@
   <string name="delete_profile">Delete profile</string>
   <string name="delete_profile_confirm">Delete profile '{0}'? All key bindings in this profile will be removed.</string>
   <string name="delete_profile_last">Cannot delete the last profile.</string>
+  <string name="import_no_free_slot">All 5 profile slots are already used — delete or free one before importing "{0}".</string>
+  <string name="import_some_skipped_no_slot">{0} profile(s) skipped: no free slot left (all 5 are used).</string>
   <!-- Everest import -->
   <string name="ev_no_profiles_in_bc">No Everest profiles found in the Base Camp database.</string>
   <string name="ev_imported_bc">Imported {0} Everest profiles ({1} keys) from Base Camp.</string>

--- a/K2.DisplayPad.Satellite/Program.cs
+++ b/K2.DisplayPad.Satellite/Program.cs
@@ -40,6 +40,7 @@ internal static class Program
         string pipeName  = args.Length > 0 ? args[0] : "K2_DisplayPad_Pipe";
         int    parentPid = args.Length > 1 && int.TryParse(args[1], out int p) ? p : -1;
         Log($"Satellite started, pipe={pipeName}, PID={Environment.ProcessId}, parentPID={parentPid}");
+        LogSdkDllInfo();
 
         // WPF Application needed for the message pump (the SDK posts WM_* to the
         // hidden window for plug/key/progress callbacks).
@@ -143,6 +144,32 @@ internal static class Program
     {
         byte[] bytes = Encoding.UTF8.GetBytes(json + "\n");
         lock (_writeLock) { pipe.Write(bytes); pipe.Flush(); }
+    }
+
+    /// <summary>
+    /// Logs file version/size/timestamp of both the native DisplayPadSDK.dll (x64) and
+    /// its managed wrapper DisplayPad.SDK.dll — rules out "wrong/corrupt/mismatched DLL
+    /// on this particular install" before blaming the Open() call itself.
+    /// </summary>
+    private static void LogSdkDllInfo()
+    {
+        string dir = AppContext.BaseDirectory;
+        foreach (string name in new[] { "DisplayPadSDK.dll", "DisplayPad.SDK.dll" })
+        {
+            string path = Path.Combine(dir, name);
+            try
+            {
+                if (!File.Exists(path)) { Log($"[SdkDll] {name}: NOT FOUND at {path}"); continue; }
+                var fi = new FileInfo(path);
+                var ver = FileVersionInfo.GetVersionInfo(path);
+                Log($"[SdkDll] {name}: size={fi.Length} modified={fi.LastWriteTime:yyyy-MM-dd HH:mm:ss} " +
+                    $"fileVersion={ver.FileVersion} productVersion={ver.ProductVersion}");
+            }
+            catch (Exception ex)
+            {
+                Log($"[SdkDll] {name}: version read failed: {ex.Message}");
+            }
+        }
     }
 
     internal static void Log(string msg)

--- a/K2.DisplayPad.Satellite/SdkHandler.cs
+++ b/K2.DisplayPad.Satellite/SdkHandler.cs
@@ -108,7 +108,11 @@ internal sealed class SdkHandler : IDisposable
         var hStr = hwnd.ToInt64().ToString();
         Program.Log($"[Open] DisplayPadOpenUSBDriver(\"{hStr}\")");
         bool ok = _helper.DisplayPadOpenUSBDriver(hStr);
-        Program.Log($"[Open] -> {ok}");
+        // Best-effort: only meaningful if DisplayPadHelper's last native call set the Win32
+        // last-error and nothing else ran a Win32/COM call in between — not guaranteed, but
+        // free to log and occasionally the only hint we get (5=ACCESS_DENIED, 32=SHARING_VIOLATION).
+        int win32Err = ok ? 0 : System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+        Program.Log($"[Open] -> {ok}" + (ok ? "" : $" (lastWin32Error={win32Err}, best-effort)"));
         _opened = ok;
         return new { ok };
     }
@@ -293,13 +297,16 @@ internal sealed class SdkHandler : IDisposable
     private static readonly object _sdkLock = new();
 
     /// <summary>
-    /// Settle delay after each icon transfer. Kept at 400ms even after switching to the native
-    /// SetIconPacket path below — the wrapper turned out to be the real suspect (corruption
-    /// persisted through 100ms and 400ms alike while still going through UploadImage/
-    /// UploadImageBySetIconPic), but a small settle margin after a raw 31-packet USB transfer is
-    /// still cheap insurance and matches BC's own delays elsewhere.
+    /// Settle delay after each icon transfer. History: 400ms was chosen while the uploads still
+    /// went through the SDK wrapper (UploadImage/UploadImageBySetIconPic), where corruption
+    /// persisted through 100ms and 400ms alike — the wrapper itself was the real culprit. The
+    /// native SetIconPacket path below is handshake-confirmed by the device (READY/DONE), so a
+    /// long settle buys nothing beyond insurance while costing ~5s per 12-key profile load
+    /// (~430ms cadence per icon, dominated by this sleep, not the 17ms transfer). Reduced to
+    /// 120ms 2026-07-16 to make profile switches feel immediate — to be verified on hardware:
+    /// if icon corruption reappears on rapid profile switching, raise this first.
     /// </summary>
-    private const int IconSettleDelayMs = 400;
+    private const int IconSettleDelayMs = 120;
 
     private object CmdUploadImage(JsonElement root)
     {

--- a/K2.DisplayPad.Satellite/SdkHandler.cs
+++ b/K2.DisplayPad.Satellite/SdkHandler.cs
@@ -131,7 +131,23 @@ internal sealed class SdkHandler : IDisposable
         bool ok;
         lock (_sdkLock)
         {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             ok = _helper.DisplayPadResetPicture(id);
+            sw.Stop();
+            // Was missing both logging AND a settle delay — unlike every icon transfer
+            // above (IconSettleDelayMs), which always got both. DpReloadCurrentProfile's
+            // "blankFirst" path (K2.App's MainWindow.DisplayPad.cs) relies on this single
+            // call to blank EVERY button before immediately queuing the new profile's
+            // per-key uploads right behind it on the same background chain — with no
+            // settle here, those uploads could reach the firmware while it's still
+            // processing "reset all pictures", so a key that has NO new image (and so
+            // gets no upload of its own to overwrite it) could be left showing the
+            // PREVIOUS profile's icon instead of blank. A full-panel reset plausibly
+            // needs at least as much settle time as a single icon transfer, so this
+            // reuses IconSettleDelayMs as a baseline — not independently verified on
+            // hardware for this specific operation.
+            Program.Log($"[ResetPictures/native] dev={id} nativeCallMs={sw.ElapsedMilliseconds} ok={ok}");
+            Thread.Sleep(IconSettleDelayMs);
         }
         return new { ok = true, result = ok };
     }

--- a/K2.DisplayPad/App.xaml.cs
+++ b/K2.DisplayPad/App.xaml.cs
@@ -46,6 +46,33 @@ public partial class App : Application
         TaskScheduler.UnobservedTaskException += OnUnobservedTask;
 
         WriteLog($"=== App start {DateTime.Now:O} pid={Environment.ProcessId} lang={Core.Loc.CurrentLang} ===");
+        WriteLog($"[SysInfo] OS build {Environment.OSVersion.Version.Build}, " +
+                 $"{(Environment.Is64BitOperatingSystem ? "x64" : "x86")} OS");
+        LogSdkDllInfo();
+    }
+
+    /// <summary>Logs file version/size/timestamp of both the native DisplayPadSDK.dll (x64)
+    /// and its managed wrapper DisplayPad.SDK.dll — rules out "wrong/corrupt/mismatched DLL
+    /// on this particular install" before blaming the Open() call itself.</summary>
+    private static void LogSdkDllInfo()
+    {
+        string dir = AppContext.BaseDirectory;
+        foreach (string name in new[] { "DisplayPadSDK.dll", "DisplayPad.SDK.dll" })
+        {
+            string path = Path.Combine(dir, name);
+            try
+            {
+                if (!File.Exists(path)) { WriteLog($"[SdkDll] {name}: NOT FOUND at {path}"); continue; }
+                var fi = new FileInfo(path);
+                var ver = System.Diagnostics.FileVersionInfo.GetVersionInfo(path);
+                WriteLog($"[SdkDll] {name}: size={fi.Length} modified={fi.LastWriteTime:yyyy-MM-dd HH:mm:ss} " +
+                         $"fileVersion={ver.FileVersion} productVersion={ver.ProductVersion}");
+            }
+            catch (Exception ex)
+            {
+                WriteLog($"[SdkDll] {name}: version read failed: {ex.Message}");
+            }
+        }
     }
 
     protected override void OnStartup(StartupEventArgs e)

--- a/K2.DisplayPad/Services/DisplayPadService.cs
+++ b/K2.DisplayPad/Services/DisplayPadService.cs
@@ -60,7 +60,11 @@ public sealed class DisplayPadService : IDisposable
         var hStr = hWnd.ToInt64().ToString();
         App.WriteLog($"[Open] DisplayPadOpenUSBDriver(\"{hStr}\")");
         bool ok = _helper.DisplayPadOpenUSBDriver(hStr);
-        App.WriteLog($"[Open] -> {ok}");
+        // Best-effort: only meaningful if DisplayPadHelper's last native call set the Win32
+        // last-error and nothing else ran a Win32/COM call in between — not guaranteed, but
+        // free to log and occasionally the only hint we get (5=ACCESS_DENIED, 32=SHARING_VIOLATION).
+        int win32Err = ok ? 0 : System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+        App.WriteLog($"[Open] -> {ok}" + (ok ? "" : $" (lastWin32Error={win32Err}, best-effort)"));
         _opened = ok;
         return ok;
     }


### PR DESCRIPTION
## Summary
- Everest NDK display-key pictures/actions are now per-profile instead of device-global; imports always land in a fresh slot and re-push pictures to hardware per profile.
- Add `SystemDiagnostics` (read-only HID snapshot logged at startup, for bug reports).
- Add `MainWindow.HwBusy.cs` for handling a device already held by another process.
- Assorted accumulated fixes across DisplayPad/Everest/Everest60/Makalu/Numpad key handling, installer scripts, and EN/IT strings.

## Test plan
- [ ] `build-check.bat` clean build (x64 + x86 solutions)
- [ ] Hardware: import a Base Camp profile with NDK touch keys, verify pictures land per-slot and re-upload correctly on a fresh device connect
- [ ] Hardware: verify busy-device detection surfaces correctly when another app holds the Everest handle
- [ ] Check startup log contains the new HID diagnostics snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)