### PR TITLE
1.0.3: Everest NDK diagnostics, HW-busy detection, and BC device import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 # --- Junk locale (scorciatoie Windows, file temporanei) --------------------
 *.lnk
 *.tmp
+*_wpftmp.csproj
 
 # --- Artefatti di build dell'installer (ricreati da build-installer.bat) --
 Installer/publish/

--- a/Installer/K2Setup.iss
+++ b/Installer/K2Setup.iss
@@ -1,4 +1,4 @@
-; K2Setup.iss - Inno Setup script for K2.
+﻿; K2Setup.iss - Inno Setup script for K2.
 ;
 ; Do NOT run ISCC on this file directly: it expects the self-contained
 ; publish output already staged under Installer\publish\K2.App by
@@ -32,8 +32,156 @@ Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
 
+; Two or more [Languages] entries make Inno show its language-picker
+; dialog at setup startup automatically (ShowLanguageDialog defaults to
+; "auto" - one language would just skip it silently, so no explicit
+; directive is needed here). Matches the languages K2 itself ships
+; (K2.Core/Strings.*.xml), minus Chinese: Inno Setup has no official
+; Simplified Chinese translation of its own built-in wizard text
+; (Welcome/License/Ready/... pages), and a from-scratch one is out of
+; scope here - a Chinese-speaking user can still pick Chinese as K2's
+; own UI language after install, from the Settings tab.
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
+Name: "german"; MessagesFile: "compiler:Languages\German.isl"
+Name: "french"; MessagesFile: "compiler:Languages\French.isl"
+Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
+Name: "polish"; MessagesFile: "compiler:Languages\Polish.isl"
+Name: "brazilianportuguese"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
+Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
+Name: "korean"; MessagesFile: "compiler:Languages\Korean.isl"
+
+; This file is saved as UTF-8 with a BOM (required so Inno Setup parses
+; the Japanese/Korean text below correctly instead of falling back to
+; the OS ANSI codepage - without a BOM those two would turn to mojibake,
+; and non-ASCII Western European accents would be at risk too).
+[CustomMessages]
+english.BcPageCaption=Base Camp Components
+english.BcPageDescription=K2 talks to some of your devices through three DLL files that are contained inside Base Camp installation folder. Tell K2 where to find them - you can change this later from K2's Settings tab.
+english.BcRadioDetect=Use the Base Camp installation found on this PC:
+english.BcNotFound=No Base Camp installation was detected automatically. Choose "Specify a folder manually" below and browse to the folder that contains the DLL files (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - for example, a Base Camp install on another drive, or a folder where you copied just the DLLs.
+english.BcRadioManual=Specify a folder manually:
+english.BcBrowse=Browse...
+english.BcBrowsePrompt=Select the folder containing the Base Camp DLL files
+english.BcNoDllConfirm=No Base Camp DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) was found in that folder. Continue anyway?
+english.BehaviorPageCaption=Base Camp Startup Behavior
+english.BehaviorPageSubCaption=Choose how K2 interacts with Base Camp automatically. Both can be changed later from K2's Settings tab.
+english.BehaviorPageDescription=These affect every K2 startup and shutdown, not just this install.
+english.CkAutoStop=Close Base Camp automatically when K2 starts
+english.CkRestartOnClose=Restart Base Camp automatically when K2 closes
+
+italian.BcPageCaption=Componenti di Base Camp
+italian.BcPageDescription=K2 comunica con alcuni dei tuoi dispositivi tramite tre file DLL contenuti nella cartella di installazione di Base Camp. Indica a K2 dove trovarle - puoi cambiare questa scelta in seguito dalla scheda Impostazioni di K2.
+italian.BcRadioDetect=Usa l'installazione di Base Camp trovata su questo PC:
+italian.BcNotFound=Nessuna installazione di Base Camp è stata rilevata automaticamente. Seleziona "Specifica una cartella manualmente" qui sotto e sfoglia fino alla cartella che contiene i file DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - ad esempio un'installazione di Base Camp su un altro disco, oppure una cartella in cui hai copiato solo le DLL.
+italian.BcRadioManual=Specifica una cartella manualmente:
+italian.BcBrowse=Sfoglia...
+italian.BcBrowsePrompt=Seleziona la cartella contenente i file DLL di Base Camp
+italian.BcNoDllConfirm=In quella cartella non è stata trovata nessuna DLL di Base Camp (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll). Continuare comunque?
+italian.BehaviorPageCaption=Comportamento all'avvio di Base Camp
+italian.BehaviorPageSubCaption=Scegli come K2 deve interagire automaticamente con Base Camp. Entrambe le opzioni si possono cambiare in seguito dalla scheda Impostazioni di K2.
+italian.BehaviorPageDescription=Queste opzioni valgono per ogni avvio e chiusura di K2, non solo per questa installazione.
+italian.CkAutoStop=Chiudi automaticamente Base Camp all'avvio di K2
+italian.CkRestartOnClose=Riavvia automaticamente Base Camp alla chiusura di K2
+
+german.BcPageCaption=Base-Camp-Komponenten
+german.BcPageDescription=K2 kommuniziert mit einigen deiner Geräte über drei DLL-Dateien, die sich im Installationsordner von Base Camp befinden. Sag K2, wo es sie findet - du kannst das später in den K2-Einstellungen ändern.
+german.BcRadioDetect=Die auf diesem PC gefundene Base-Camp-Installation verwenden:
+german.BcNotFound=Es wurde keine Base-Camp-Installation automatisch erkannt. Wähle unten "Ordner manuell angeben" und navigiere zum Ordner mit den DLL-Dateien (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - zum Beispiel eine Base-Camp-Installation auf einem anderen Laufwerk oder ein Ordner, in den du nur die DLLs kopiert hast.
+german.BcRadioManual=Ordner manuell angeben:
+german.BcBrowse=Durchsuchen...
+german.BcBrowsePrompt=Wähle den Ordner mit den Base-Camp-DLL-Dateien
+german.BcNoDllConfirm=In diesem Ordner wurde keine Base-Camp-DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) gefunden. Trotzdem fortfahren?
+german.BehaviorPageCaption=Base-Camp-Verhalten beim Start
+german.BehaviorPageSubCaption=Wähle, wie K2 automatisch mit Base Camp interagiert. Beide Optionen lassen sich später in den K2-Einstellungen ändern.
+german.BehaviorPageDescription=Diese Optionen gelten für jeden Start und jedes Beenden von K2, nicht nur für diese Installation.
+german.CkAutoStop=Base Camp beim Start von K2 automatisch schließen
+german.CkRestartOnClose=Base Camp beim Beenden von K2 automatisch neu starten
+
+french.BcPageCaption=Composants Base Camp
+french.BcPageDescription=K2 communique avec certains de vos périphériques via trois fichiers DLL contenus dans le dossier d'installation de Base Camp. Indiquez à K2 où les trouver - vous pourrez modifier ce choix plus tard dans l'onglet Paramètres de K2.
+french.BcRadioDetect=Utiliser l'installation de Base Camp trouvée sur ce PC :
+french.BcNotFound=Aucune installation de Base Camp n'a été détectée automatiquement. Choisissez "Indiquer un dossier manuellement" ci-dessous et parcourez jusqu'au dossier contenant les fichiers DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - par exemple une installation de Base Camp sur un autre disque, ou un dossier où vous avez copié uniquement les DLL.
+french.BcRadioManual=Indiquer un dossier manuellement :
+french.BcBrowse=Parcourir...
+french.BcBrowsePrompt=Sélectionnez le dossier contenant les fichiers DLL de Base Camp
+french.BcNoDllConfirm=Aucune DLL de Base Camp (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) n'a été trouvée dans ce dossier. Continuer quand même ?
+french.BehaviorPageCaption=Comportement de Base Camp au démarrage
+french.BehaviorPageSubCaption=Choisissez comment K2 interagit automatiquement avec Base Camp. Les deux options peuvent être modifiées plus tard dans l'onglet Paramètres de K2.
+french.BehaviorPageDescription=Ces options s'appliquent à chaque démarrage et fermeture de K2, pas seulement à cette installation.
+french.CkAutoStop=Fermer automatiquement Base Camp au démarrage de K2
+french.CkRestartOnClose=Redémarrer automatiquement Base Camp à la fermeture de K2
+
+spanish.BcPageCaption=Componentes de Base Camp
+spanish.BcPageDescription=K2 se comunica con algunos de tus dispositivos mediante tres archivos DLL contenidos en la carpeta de instalación de Base Camp. Indica a K2 dónde encontrarlos - puedes cambiarlo más tarde en la pestaña Configuración de K2.
+spanish.BcRadioDetect=Usar la instalación de Base Camp encontrada en este PC:
+spanish.BcNotFound=No se detectó automáticamente ninguna instalación de Base Camp. Elige "Especificar una carpeta manualmente" abajo y busca la carpeta que contiene los archivos DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - por ejemplo, una instalación de Base Camp en otra unidad, o una carpeta donde copiaste solo las DLL.
+spanish.BcRadioManual=Especificar una carpeta manualmente:
+spanish.BcBrowse=Examinar...
+spanish.BcBrowsePrompt=Selecciona la carpeta que contiene los archivos DLL de Base Camp
+spanish.BcNoDllConfirm=No se encontró ninguna DLL de Base Camp (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) en esa carpeta. ¿Continuar de todas formas?
+spanish.BehaviorPageCaption=Comportamiento de Base Camp al iniciar
+spanish.BehaviorPageSubCaption=Elige cómo interactúa K2 automáticamente con Base Camp. Ambas opciones se pueden cambiar más tarde en la pestaña Configuración de K2.
+spanish.BehaviorPageDescription=Estas opciones afectan a cada inicio y cierre de K2, no solo a esta instalación.
+spanish.CkAutoStop=Cerrar Base Camp automáticamente al iniciar K2
+spanish.CkRestartOnClose=Reiniciar Base Camp automáticamente al cerrar K2
+
+polish.BcPageCaption=Składniki Base Camp
+polish.BcPageDescription=K2 komunikuje się z niektórymi Twoimi urządzeniami za pomocą trzech plików DLL znajdujących się w folderze instalacyjnym Base Camp. Wskaż K2, gdzie je znaleźć - możesz to później zmienić w zakładce Ustawienia K2.
+polish.BcRadioDetect=Użyj instalacji Base Camp znalezionej na tym komputerze:
+polish.BcNotFound=Nie wykryto automatycznie żadnej instalacji Base Camp. Wybierz poniżej "Wskaż folder ręcznie" i przejdź do folderu zawierającego pliki DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - na przykład instalację Base Camp na innym dysku lub folder, do którego skopiowano tylko pliki DLL.
+polish.BcRadioManual=Wskaż folder ręcznie:
+polish.BcBrowse=Przeglądaj...
+polish.BcBrowsePrompt=Wybierz folder zawierający pliki DLL Base Camp
+polish.BcNoDllConfirm=W tym folderze nie znaleziono żadnej biblioteki DLL Base Camp (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll). Kontynuować mimo to?
+polish.BehaviorPageCaption=Zachowanie Base Camp przy uruchamianiu
+polish.BehaviorPageSubCaption=Wybierz, jak K2 ma automatycznie współdziałać z Base Camp. Obie opcje można później zmienić w zakładce Ustawienia K2.
+polish.BehaviorPageDescription=Te opcje dotyczą każdego uruchomienia i zamknięcia K2, nie tylko tej instalacji.
+polish.CkAutoStop=Automatycznie zamykaj Base Camp przy uruchamianiu K2
+polish.CkRestartOnClose=Automatycznie uruchamiaj ponownie Base Camp przy zamykaniu K2
+
+brazilianportuguese.BcPageCaption=Componentes do Base Camp
+brazilianportuguese.BcPageDescription=O K2 se comunica com alguns dos seus dispositivos por meio de três arquivos DLL contidos na pasta de instalação do Base Camp. Diga ao K2 onde encontrá-los - você pode alterar isso depois na aba Configurações do K2.
+brazilianportuguese.BcRadioDetect=Usar a instalação do Base Camp encontrada neste PC:
+brazilianportuguese.BcNotFound=Nenhuma instalação do Base Camp foi detectada automaticamente. Escolha "Especificar uma pasta manualmente" abaixo e navegue até a pasta que contém os arquivos DLL (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) - por exemplo, uma instalação do Base Camp em outra unidade, ou uma pasta onde você copiou apenas as DLLs.
+brazilianportuguese.BcRadioManual=Especificar uma pasta manualmente:
+brazilianportuguese.BcBrowse=Procurar...
+brazilianportuguese.BcBrowsePrompt=Selecione a pasta que contém os arquivos DLL do Base Camp
+brazilianportuguese.BcNoDllConfirm=Nenhuma DLL do Base Camp (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) foi encontrada nessa pasta. Continuar mesmo assim?
+brazilianportuguese.BehaviorPageCaption=Comportamento do Base Camp na inicialização
+brazilianportuguese.BehaviorPageSubCaption=Escolha como o K2 deve interagir automaticamente com o Base Camp. Ambas as opções podem ser alteradas depois na aba Configurações do K2.
+brazilianportuguese.BehaviorPageDescription=Essas opções valem para cada inicialização e fechamento do K2, não apenas para esta instalação.
+brazilianportuguese.CkAutoStop=Fechar o Base Camp automaticamente ao iniciar o K2
+brazilianportuguese.CkRestartOnClose=Reiniciar o Base Camp automaticamente ao fechar o K2
+
+japanese.BcPageCaption=Base Camp コンポーネント
+japanese.BcPageDescription=K2は一部のデバイスと、Base Campのインストールフォルダー内にある3つのdllファイルを通じて通信します。K2にその場所を教えてください。この設定は後でK2の設定タブから変更できます。
+japanese.BcRadioDetect=このPCで見つかったBase Campのインストールを使用する:
+japanese.BcNotFound=Base Campのインストールは自動的に検出されませんでした。下の「フォルダーを手動で指定する」を選択し、DLLファイル(MacroPadSDK.dll、SDKDLL.dll、Everest360_USB.dll)が入っているフォルダーを参照してください。例えば、別のドライブにあるBase Campのインストール、またはDLLだけをコピーしたフォルダーです。
+japanese.BcRadioManual=フォルダーを手動で指定する:
+japanese.BcBrowse=参照...
+japanese.BcBrowsePrompt=Base CampのDLLファイルが入っているフォルダーを選択してください
+japanese.BcNoDllConfirm=そのフォルダーにはBase CampのDLL(MacroPadSDK.dll、SDKDLL.dll、Everest360_USB.dll)が見つかりませんでした。続行しますか?
+japanese.BehaviorPageCaption=起動時のBase Campの動作
+japanese.BehaviorPageSubCaption=K2がBase Campと自動的にどのように連携するかを選択してください。どちらも後でK2の設定タブから変更できます。
+japanese.BehaviorPageDescription=これらの設定はK2の起動と終了のたびに適用され、このインストールだけに限りません。
+japanese.CkAutoStop=K2の起動時にBase Campを自動的に終了する
+japanese.CkRestartOnClose=K2の終了時にBase Campを自動的に再起動する
+
+korean.BcPageCaption=Base Camp 구성 요소
+korean.BcPageDescription=K2는 일부 장치와 Base Camp 설치 폴더 안에 있는 3개의 DLL 파일을 통해 통신합니다. K2에 해당 파일의 위치를 알려주세요. 이 설정은 나중에 K2의 설정 탭에서 변경할 수 있습니다.
+korean.BcRadioDetect=이 PC에서 찾은 Base Camp 설치를 사용:
+korean.BcNotFound=Base Camp 설치가 자동으로 감지되지 않았습니다. 아래에서 "폴더를 수동으로 지정"을 선택하고 DLL 파일(MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll)이 있는 폴더를 찾아보세요. 예를 들어 다른 드라이브에 설치된 Base Camp나 DLL만 복사해 둔 폴더입니다.
+korean.BcRadioManual=폴더를 수동으로 지정:
+korean.BcBrowse=찾아보기...
+korean.BcBrowsePrompt=Base Camp DLL 파일이 있는 폴더를 선택하세요
+korean.BcNoDllConfirm=해당 폴더에서 Base Camp DLL(MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll)을 찾을 수 없습니다. 계속하시겠습니까?
+korean.BehaviorPageCaption=시작 시 Base Camp 동작
+korean.BehaviorPageSubCaption=K2가 Base Camp와 자동으로 상호 작용하는 방식을 선택하세요. 두 옵션 모두 나중에 K2의 설정 탭에서 변경할 수 있습니다.
+korean.BehaviorPageDescription=이 설정은 이번 설치뿐 아니라 K2를 시작하고 종료할 때마다 적용됩니다.
+korean.CkAutoStop=K2 시작 시 Base Camp를 자동으로 종료
+korean.CkRestartOnClose=K2 종료 시 Base Camp를 자동으로 다시 시작
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
@@ -56,3 +204,283 @@ Name: "{autodesktop}\K2"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 ; when the current user is an administrator. ShellExecute knows how to
 ; trigger the UAC elevation dance for a manifested-elevated target.
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,K2}"; Flags: nowait postinstall skipifsilent shellexec
+
+[Code]
+var
+  BcPage: TWizardPage;
+  RbBcDetected, RbBcManual: TNewRadioButton;
+  LblBcPath: TNewStaticText;
+  EdBcFolder: TNewEdit;
+  BtnBcBrowse: TNewButton;
+  DetectedBcDir: String;
+
+  BehaviorPage: TInputOptionWizardPage;
+
+{ True if any of the known Base Camp native DLLs (MacroPadSDK.dll,
+  SDKDLL.dll, Everest360_USB.dll - same list as K2.App's
+  NativeDependencyResolver.BaseCampNativeDlls) sits directly in Dir. }
+function DllExistsInDir(const Dir: String): Boolean;
+var
+  Base: String;
+begin
+  Result := False;
+  if Dir = '' then Exit;
+  Base := AddBackslash(Dir);
+  Result := FileExists(Base + 'MacroPadSDK.dll') or
+            FileExists(Base + 'SDKDLL.dll') or
+            FileExists(Base + 'Everest360_USB.dll');
+end;
+
+{ Collects InstallLocation values from uninstall registry keys whose
+  DisplayName mentions "Base Camp" - same signal
+  K2.App's NativeDependencyResolver.RegistryInstallLocations() uses at
+  runtime, ported to Pascal Script for the wizard's default guess. }
+procedure CollectFromUninstallKey(const RootKey: Integer; const UninstallKey: String; List: TStringList);
+var
+  Names: TArrayOfString;
+  I: Integer;
+  SubKey, DisplayName, InstallLoc: String;
+begin
+  if RegGetSubkeyNames(RootKey, UninstallKey, Names) then
+  begin
+    for I := 0 to GetArrayLength(Names) - 1 do
+    begin
+      SubKey := UninstallKey + '\' + Names[I];
+      if RegQueryStringValue(RootKey, SubKey, 'DisplayName', DisplayName) then
+        if Pos('Base Camp', DisplayName) > 0 then
+          if RegQueryStringValue(RootKey, SubKey, 'InstallLocation', InstallLoc) then
+            if InstallLoc <> '' then
+              List.Add(InstallLoc);
+    end;
+  end;
+end;
+
+{ Best-effort auto-detection of an existing Base Camp install, checked
+  against the same typical paths + registry uninstall keys as
+  NativeDependencyResolver.BaseCampDirectories() in K2.App (not a
+  byte-for-byte port - this only seeds the wizard's default choice; the
+  app does its own, authoritative detection at runtime regardless of
+  what is picked here). Returns '' if nothing was found. }
+function DetectBaseCampDir(): String;
+var
+  Candidates, RegLocations: TStringList;
+  I: Integer;
+begin
+  Result := '';
+  Candidates := TStringList.Create;
+  try
+    Candidates.Add(ExpandConstant('{pf}\Mountain\Base Camp'));
+    Candidates.Add(ExpandConstant('{pf}\Base Camp'));
+    Candidates.Add(ExpandConstant('{pf32}\Mountain\Base Camp'));
+    Candidates.Add(ExpandConstant('{pf32}\Base Camp'));
+    Candidates.Add(ExpandConstant('{localappdata}\Programs\Base Camp'));
+    Candidates.Add(ExpandConstant('{localappdata}\Programs\base-camp'));
+
+    RegLocations := TStringList.Create;
+    try
+      CollectFromUninstallKey(HKLM, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall', RegLocations);
+      CollectFromUninstallKey(HKLM, 'SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall', RegLocations);
+      CollectFromUninstallKey(HKCU, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall', RegLocations);
+      for I := 0 to RegLocations.Count - 1 do
+        Candidates.Add(RegLocations[I]);
+    finally
+      RegLocations.Free;
+    end;
+
+    for I := 0 to Candidates.Count - 1 do
+      if DllExistsInDir(Candidates[I]) then
+      begin
+        Result := Candidates[I];
+        Exit;
+      end;
+  finally
+    Candidates.Free;
+  end;
+end;
+
+procedure UpdateBcControls;
+begin
+  EdBcFolder.Enabled := RbBcManual.Checked;
+  BtnBcBrowse.Enabled := RbBcManual.Checked;
+end;
+
+procedure BcRadioClick(Sender: TObject);
+begin
+  UpdateBcControls;
+end;
+
+procedure BcBrowseClick(Sender: TObject);
+var
+  Dir: String;
+begin
+  Dir := EdBcFolder.Text;
+  if BrowseForFolder(CustomMessage('BcBrowsePrompt'), Dir, False) then
+    EdBcFolder.Text := Dir;
+end;
+
+{ Keeps "restart Base Camp on close" enabled/checkable only while
+  "close Base Camp on startup" is on, per explicit request: the second
+  behavior only makes sense paired with the first. }
+procedure BehaviorCheckClick(Sender: TObject);
+begin
+  if not BehaviorPage.Values[0] then
+  begin
+    BehaviorPage.Values[1] := False;
+    BehaviorPage.CheckListBox.ItemEnabled[1] := False;
+  end
+  else
+    BehaviorPage.CheckListBox.ItemEnabled[1] := True;
+end;
+
+procedure InitializeWizard;
+var
+  RowH, Gap: Integer;
+  Y: Integer;
+begin
+  RowH := ScaleY(17);
+  Gap := ScaleY(8);
+
+  DetectedBcDir := DetectBaseCampDir();
+
+  BcPage := CreateCustomPage(wpSelectTasks, CustomMessage('BcPageCaption'), CustomMessage('BcPageDescription'));
+
+  Y := 0;
+
+  RbBcDetected := TNewRadioButton.Create(BcPage);
+  RbBcDetected.Parent := BcPage.Surface;
+  RbBcDetected.Left := 0;
+  RbBcDetected.Top := Y;
+  RbBcDetected.Width := BcPage.SurfaceWidth;
+  RbBcDetected.Height := RowH;
+  RbBcDetected.Caption := CustomMessage('BcRadioDetect');
+  RbBcDetected.Enabled := DetectedBcDir <> '';
+  RbBcDetected.Checked := DetectedBcDir <> '';
+  RbBcDetected.OnClick := @BcRadioClick;
+  Y := Y + RowH + ScaleY(2);
+
+  LblBcPath := TNewStaticText.Create(BcPage);
+  LblBcPath.Parent := BcPage.Surface;
+  LblBcPath.Left := ScaleX(20);
+  LblBcPath.Top := Y;
+  LblBcPath.Width := BcPage.SurfaceWidth - ScaleX(20);
+  LblBcPath.AutoSize := False;
+  LblBcPath.WordWrap := True;
+  if DetectedBcDir <> '' then
+  begin
+    LblBcPath.Caption := DetectedBcDir;
+    LblBcPath.Height := ScaleY(17);
+  end
+  else
+  begin
+    LblBcPath.Caption := CustomMessage('BcNotFound');
+    LblBcPath.Height := ScaleY(48);
+  end;
+  Y := Y + LblBcPath.Height + Gap;
+
+  RbBcManual := TNewRadioButton.Create(BcPage);
+  RbBcManual.Parent := BcPage.Surface;
+  RbBcManual.Left := 0;
+  RbBcManual.Top := Y;
+  RbBcManual.Width := BcPage.SurfaceWidth;
+  RbBcManual.Height := RowH;
+  RbBcManual.Caption := CustomMessage('BcRadioManual');
+  RbBcManual.Checked := DetectedBcDir = '';
+  RbBcManual.OnClick := @BcRadioClick;
+  Y := Y + RowH + Gap;
+
+  BtnBcBrowse := TNewButton.Create(BcPage);
+  BtnBcBrowse.Parent := BcPage.Surface;
+  BtnBcBrowse.Width := ScaleX(80);
+  BtnBcBrowse.Height := ScaleY(23);
+  BtnBcBrowse.Left := BcPage.SurfaceWidth - BtnBcBrowse.Width;
+  BtnBcBrowse.Top := Y;
+  BtnBcBrowse.Caption := CustomMessage('BcBrowse');
+  BtnBcBrowse.OnClick := @BcBrowseClick;
+
+  EdBcFolder := TNewEdit.Create(BcPage);
+  EdBcFolder.Parent := BcPage.Surface;
+  EdBcFolder.Left := ScaleX(20);
+  EdBcFolder.Top := Y + ScaleY(2);
+  EdBcFolder.Width := BtnBcBrowse.Left - ScaleX(10) - EdBcFolder.Left;
+  EdBcFolder.Text := '';
+
+  UpdateBcControls;
+
+  BehaviorPage := CreateInputOptionPage(BcPage.ID,
+    CustomMessage('BehaviorPageCaption'), CustomMessage('BehaviorPageDescription'),
+    CustomMessage('BehaviorPageSubCaption'), False, False);
+  BehaviorPage.Add(CustomMessage('CkAutoStop'));
+  BehaviorPage.Add(CustomMessage('CkRestartOnClose'));
+  BehaviorPage.Values[0] := True;
+  BehaviorPage.Values[1] := False;
+  BehaviorPage.CheckListBox.ItemEnabled[1] := True;
+  BehaviorPage.CheckListBox.OnClickCheck := @BehaviorCheckClick;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if (CurPageID = BcPage.ID) and RbBcManual.Checked and (Trim(EdBcFolder.Text) <> '')
+     and not DllExistsInDir(EdBcFolder.Text) then
+  begin
+    Result := MsgBox(CustomMessage('BcNoDllConfirm'), mbConfirmation, MB_YESNO) = IDYES;
+  end;
+end;
+
+{ Seeds K2's app_settings.json with the choices made on the two pages
+  above. Only runs on a fresh install: if the file already exists (repair/
+  upgrade over a previous K2 install) it is left untouched, so a returning
+  user's own Settings-tab choices are never clobbered by wizard defaults. }
+procedure WriteAppSettingsJson;
+var
+  Dir, Path, FolderEscaped: String;
+  Lines: TStringList;
+  Json: String;
+  I: Integer;
+begin
+  Path := ExpandConstant('{localappdata}\K2\app_settings.json');
+  if FileExists(Path) then Exit;
+
+  Dir := ExpandConstant('{localappdata}\K2');
+  ForceDirectories(Dir);
+
+  Lines := TStringList.Create;
+  try
+    if RbBcManual.Checked and (Trim(EdBcFolder.Text) <> '') then
+    begin
+      FolderEscaped := EdBcFolder.Text;
+      StringChange(FolderEscaped, '\', '\\');
+      Lines.Add('  "BaseCampDllFolder": "' + FolderEscaped + '"');
+    end;
+
+    if BehaviorPage.Values[0] then
+      Lines.Add('  "AutoStopBaseCamp": true')
+    else
+      Lines.Add('  "AutoStopBaseCamp": false');
+
+    if BehaviorPage.Values[1] then
+      Lines.Add('  "RestartBaseCampOnClose": true')
+    else
+      Lines.Add('  "RestartBaseCampOnClose": false');
+
+    Json := '{' + #13#10;
+    for I := 0 to Lines.Count - 1 do
+    begin
+      Json := Json + Lines[I];
+      if I < Lines.Count - 1 then
+        Json := Json + ',';
+      Json := Json + #13#10;
+    end;
+    Json := Json + '}' + #13#10;
+
+    SaveStringToFile(Path, Json, False);
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+    WriteAppSettingsJson;
+end;

--- a/K2.App/BcDevicePickerDialog.xaml
+++ b/K2.App/BcDevicePickerDialog.xaml
@@ -1,0 +1,47 @@
+<Window x:Class="K2.App.BcDevicePickerDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:K2.Core;assembly=K2.Core"
+        Title="{loc:Get bc_pick_device_title}"
+        Width="380" SizeToContent="Height"
+        MinWidth="340"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        Style="{DynamicResource K2WindowStyle}">
+
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>  <!-- text -->
+            <RowDefinition Height="6"/>
+            <RowDefinition Height="Auto"/>  <!-- device list -->
+            <RowDefinition Height="14"/>
+            <RowDefinition Height="Auto"/>  <!-- buttons -->
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   x:Name="TxtPrompt"
+                   TextWrapping="Wrap"
+                   FontSize="13" FontWeight="SemiBold"/>
+
+        <ScrollViewer Grid.Row="2" MaxHeight="220" VerticalScrollBarVisibility="Auto">
+            <ListBox x:Name="LstDevices" BorderThickness="0"
+                     SelectionMode="Single"
+                     DisplayMemberPath="Label"/>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="4"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button Content="{loc:Get ok}"
+                    IsDefault="True"
+                    MinWidth="72"
+                    Style="{StaticResource K2IconAccentButton}"
+                    Click="BtnOk_Click"
+                    Margin="0,0,8,0"/>
+            <Button Content="{loc:Get cancel}"
+                    IsCancel="True"
+                    MinWidth="72"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/K2.App/BcDevicePickerDialog.xaml.cs
+++ b/K2.App/BcDevicePickerDialog.xaml.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using K2.Core;
+
+namespace K2.App;
+
+/// <summary>
+/// Lets the user pick which Base Camp device (by its BC-internal DeviceId) to import
+/// from, when the DB contains profiles for more than one device of the same type.
+/// Shown by every device's BaseCamp-import flow (see MainWindow.{Device}.cs's
+/// BtnXxImportBc_Click) whenever <c>bcDevices.Count &gt; 1</c> — skipped entirely when
+/// there's only one candidate, since there's nothing to choose.
+/// </summary>
+public partial class BcDevicePickerDialog : Window
+{
+    public sealed class Item(int bcDeviceId, string label)
+    {
+        public int BcDeviceId { get; } = bcDeviceId;
+        public string Label { get; } = label;
+    }
+
+    public int? SelectedBcDeviceId { get; private set; }
+
+    public BcDevicePickerDialog(string k2DeviceLabel, IReadOnlyList<(int BcDeviceId, string Label)> devices)
+    {
+        InitializeComponent();
+        TxtPrompt.Text = Loc.Get("bc_pick_device_text", k2DeviceLabel);
+        LstDevices.ItemsSource = devices.Select(d => new Item(d.BcDeviceId, d.Label)).ToList();
+        LstDevices.SelectedIndex = 0;
+    }
+
+    private void BtnOk_Click(object sender, RoutedEventArgs e)
+    {
+        if (LstDevices.SelectedItem is not Item item)
+        {
+            MessageBox.Show(this, Loc.Get("bc_pick_device_none"), Loc.Get("bc_pick_device_title"),
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+        SelectedBcDeviceId = item.BcDeviceId;
+        DialogResult = true;
+    }
+}

--- a/K2.App/DisplayPadActionHost.cs
+++ b/K2.App/DisplayPadActionHost.cs
@@ -18,8 +18,11 @@ internal sealed class DisplayPadActionHost : IActionHost
     Dispatcher IActionHost.Dispatcher => _win.Dispatcher;
     void IActionHost.Log(string message) => _win.Dispatcher.Invoke(() => _win.DpLogPublic(message));
     int IActionHost.CurrentDevice => _win._activeDpDeviceId ?? 0;
-    int IActionHost.CurrentProfile => _win.CbDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : 1;
-    int IActionHost.ProfileCount => 5;
+    int IActionHost.CurrentProfile => _win.LstDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : 1;
+    // See DisplayPadBackgroundActionHost.ProfileCount below for the rationale.
+    int IActionHost.ProfileCount => _win._activeDpDeviceId is int id
+        ? System.Math.Max(5, _win._dpStore.GetExistingProfiles(id).DefaultIfEmpty(0).Max())
+        : 5;
     int IActionHost.ButtonCount => 12;
     int IActionHost.SdkVersion => 0; // not relevant over IPC
     string? IActionHost.ConfiguredPythonPath => null;
@@ -90,7 +93,11 @@ internal sealed class DisplayPadBackgroundActionHost : IActionHost
     void IActionHost.Log(string message) => _win.Dispatcher.Invoke(() => _win.DpLogPublic($"[bg {_deviceId}] {message}"));
     int IActionHost.CurrentDevice => _deviceId;
     int IActionHost.CurrentProfile => _win._dpStore.GetCurrentProfile(_deviceId);
-    int IActionHost.ProfileCount => 5;
+    // No firmware slot cap for DisplayPad (see DpSwitchProfile's doc comment) — reflect
+    // however many profiles actually exist, floored at 5 for parity with the other
+    // devices' real firmware limit, so the "switch to profile N" action picker
+    // (ButtonActionDialog.Profile.cs) always offers at least the classic 5.
+    int IActionHost.ProfileCount => System.Math.Max(5, _win._dpStore.GetExistingProfiles(_deviceId).DefaultIfEmpty(0).Max());
     int IActionHost.ButtonCount => 12;
     int IActionHost.SdkVersion => 0;
     string? IActionHost.ConfiguredPythonPath => null;

--- a/K2.App/DpKeyConfigDialog.xaml.cs
+++ b/K2.App/DpKeyConfigDialog.xaml.cs
@@ -311,7 +311,7 @@ public partial class DpKeyConfigDialog : Window
             "command" => $"Command: {val}",
             "macro"   => $"Macro: {val}",
             "pyscript"=> "Python script",
-            _         => $"{ActionType}: {val}",
+            _         => ActionTypeHelper.IsUnrecognized(ActionType) ? Loc.Get("act_unrecognized") : $"{ActionType}: {val}",
         };
     }
 

--- a/K2.App/MainWindow.DisplayDial.cs
+++ b/K2.App/MainWindow.DisplayDial.cs
@@ -162,7 +162,13 @@ public partial class MainWindow
         {
             _dialLoading = false;
         }
-        _dialAppliedFormat24h = DialClockTypeIndex == 0;
+        // Inverted on purpose: real hardware test (2026-07-16) showed
+        // SetClockInfo's format24h parameter behaves opposite to its name —
+        // the "24h" button only produces a 24-hour clock on the device when
+        // format24h is sent as false (DialClockTypeIndex==1, i.e. what the UI
+        // calls "12h"). Trusting the hardware result over the SDK's own
+        // parameter name.
+        _dialAppliedFormat24h = DialClockTypeIndex == 1;
 
         if (_dialClockTimer is null)
         {
@@ -293,7 +299,13 @@ public partial class MainWindow
 
         // Clock format doesn't live in FW_EXTEND_INFO (see file header) — push
         // it separately, on the same "Apply to device" trigger as everything else.
-        _dialAppliedFormat24h = DialClockTypeIndex == 0;
+        // Inverted on purpose: real hardware test (2026-07-16) showed
+        // SetClockInfo's format24h parameter behaves opposite to its name —
+        // the "24h" button only produces a 24-hour clock on the device when
+        // format24h is sent as false (DialClockTypeIndex==1, i.e. what the UI
+        // calls "12h"). Trusting the hardware result over the SDK's own
+        // parameter name.
+        _dialAppliedFormat24h = DialClockTypeIndex == 1;
         LogEverest($"[DIAL] UpdateClock(format24h={_dialAppliedFormat24h}) -> " +
                    $"{_everest.UpdateClock(_dialAppliedFormat24h)}");
 

--- a/K2.App/MainWindow.DisplayPad.cs
+++ b/K2.App/MainWindow.DisplayPad.cs
@@ -176,7 +176,9 @@ public partial class MainWindow
             };
 
         LvDpDevices.ItemsSource = _dpDevices;
-        // DP device tabs are added to TcDevices by DpRefreshDevices; CbDpProfile by DpRefreshProfiles
+        // DP device tabs are added to TcDevices by DpRefreshDevices; LstDpProfile by DpRefreshProfiles
+        LstDpProfile.ContextMenu = DpBuildProfileContextMenu();
+        BtnDpProfileMenu.ContextMenu = DpBuildProfileMenuNoEdit();
 
         LstDpPages.ItemsSource = _dpPages;
 
@@ -413,7 +415,7 @@ public partial class MainWindow
     private void BtnDpRenameProfile_Click(object sender, RoutedEventArgs e)
     {
         if (DpSelectedDeviceId() is not int id) return;
-        if (CbDpProfile.SelectedItem is not DpProfileItem pi || pi.IsNew) return;
+        if (LstDpProfile.SelectedItem is not DpProfileItem pi || pi.IsNew) return;
         int slot = pi.Slot;
         string current = _dpStore.GetProfileName(id, slot) ?? Loc.Get("profile_n", slot);
         string? name = ShowRenameDialog(current,
@@ -429,7 +431,7 @@ public partial class MainWindow
     private void BtnDpDeleteProfile_Click(object sender, RoutedEventArgs e)
     {
         if (DpSelectedDeviceId() is not int id) return;
-        if (CbDpProfile.SelectedItem is not DpProfileItem pi || pi.IsNew) return;
+        if (LstDpProfile.SelectedItem is not DpProfileItem pi || pi.IsNew) return;
         int slot = pi.Slot;
         // Cannot delete the last real profile
         var existing = _dpStore.GetExistingProfiles(id);
@@ -446,11 +448,20 @@ public partial class MainWindow
             MessageBoxButton.OKCancel,
             MessageBoxImage.Warning);
         if (res != MessageBoxResult.OK) return;
-        _dpStore.ClearProfile(id, slot);
-        _dpStore.SetSetting($"profile.{id}.{slot}.name", "");
+        DpDeleteProfileSlot(id, slot);
         DpLog($"[UI] Profile {slot} deleted.");
         DpRefreshProfiles(id);
-        // CbDpProfile_SelectionChanged will reload the key grid automatically
+        // LstDpProfile_SelectionChanged will reload the key grid automatically
+    }
+
+    /// <summary>Clears one profile slot's buttons+name — no "last profile" guard
+    /// (that's the button handler's job). Also used by the Base Camp wipe-before-import
+    /// flow (<see cref="DpImportBcForDevice"/>), which intentionally clears every slot
+    /// including the last one, since fresh profiles replace them right after.</summary>
+    private void DpDeleteProfileSlot(int deviceId, int slot)
+    {
+        _dpStore.ClearProfile(deviceId, slot);
+        _dpStore.SetSetting($"profile.{deviceId}.{slot}.name", "");
     }
 
     /// <summary>Resets the currently selected profile's button icons/actions/pages back
@@ -775,9 +786,9 @@ public partial class MainWindow
         int cur;
         if (isActive)
         {
-            if (CbDpProfile.ItemsSource is not List<DpProfileItem> items) return;
+            if (LstDpProfile.ItemsSource is not List<DpProfileItem> items) return;
             real = items.Where(x => !x.IsNew).Select(x => x.Slot).ToList();
-            cur  = CbDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : (real.Count > 0 ? real[0] : 1);
+            cur  = LstDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : (real.Count > 0 ? real[0] : 1);
         }
         else
         {
@@ -837,8 +848,8 @@ public partial class MainWindow
         _dpSuppressProfile = true;
         try
         {
-            if (CbDpProfile.ItemsSource is List<DpProfileItem> items)
-                CbDpProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
+            if (LstDpProfile.ItemsSource is List<DpProfileItem> items)
+                LstDpProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
         }
         finally { _dpSuppressProfile = false; }
     }
@@ -858,26 +869,28 @@ public partial class MainWindow
                 string name = _dpStore.GetProfileName(deviceId, slot) ?? Loc.Get("profile_n", slot);
                 items.Add(new DpProfileItem(slot, name));
             }
-            // Find the next free slot (1-5)
-            int nextFree = Enumerable.Range(1, 5).FirstOrDefault(s => !existing.Contains(s));
+            // Find the next free slot — DisplayPad profiles are pure K2-side bookkeeping
+            // (see DpSwitchProfile's doc comment), no firmware slot cap, so this is
+            // uncapped (999 is just a generous sanity ceiling, not a real limit).
+            int nextFree = BaseCampDbImporter.FindFreeSlot(existing, maxSlots: 999);
             if (nextFree > 0)
                 items.Add(new DpProfileItem(nextFree, Loc.Get("new_profile")));
 
-            CbDpProfile.DisplayMemberPath = nameof(DpProfileItem.Label);
-            CbDpProfile.ItemsSource = items;
+            LstDpProfile.DisplayMemberPath = nameof(DpProfileItem.Label);
+            LstDpProfile.ItemsSource = items;
 
             int current = _dpStore.GetCurrentProfile(deviceId);
             var match = items.Find(x => x.Slot == current && !x.IsNew);
-            CbDpProfile.SelectedItem = match ?? items[0];
+            LstDpProfile.SelectedItem = match ?? items[0];
         }
         finally { _dpSuppressProfile = false; }
     }
 
-    private void CbDpProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void LstDpProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_dpSuppressProfile) return;
         if (DpSelectedDeviceId() is not int id) return;
-        if (CbDpProfile.SelectedItem is not DpProfileItem pi) return;
+        if (LstDpProfile.SelectedItem is not DpProfileItem pi) return;
         int profile = pi.Slot;
 
         if (pi.IsNew)
@@ -892,8 +905,8 @@ public partial class MainWindow
             _dpSuppressProfile = true;
             try
             {
-                var items = CbDpProfile.ItemsSource as List<DpProfileItem>;
-                CbDpProfile.SelectedItem = items?.Find(x => x.Slot == profile && !x.IsNew);
+                var items = LstDpProfile.ItemsSource as List<DpProfileItem>;
+                LstDpProfile.SelectedItem = items?.Find(x => x.Slot == profile && !x.IsNew);
             }
             finally { _dpSuppressProfile = false; }
         }
@@ -1008,6 +1021,14 @@ public partial class MainWindow
             int rotation = _dpStore.GetRotation(id);
             int imported = 0;
 
+            // Existing K2 macro names, used by TranslateAction to auto-match a Base Camp
+            // named-macro reference ("Default" FunctionType) against the user's own macro
+            // library — see BaseCampDbImporter.TranslateDefaultAction's doc comment.
+            var macroNames = _macroStore?.GetAll()
+                .Select(m => m.Name)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToList();
+
             foreach (var b in bindings)
             {
                 bool isAssigned = b.Element("IsKeyAssigned")?.Value
@@ -1107,7 +1128,7 @@ public partial class MainWindow
                 }
                 else
                 {
-                    (actionType, actionValue) = BaseCampDbImporter.TranslateAction(funcType, subType, funcValue);
+                    (actionType, actionValue) = BaseCampDbImporter.TranslateAction(funcType, subType, funcValue, macroNames);
                 }
 
                 _dpStore.SaveButton(id, slot, pageId, btnIndex, imagePath, actionType, actionValue);
@@ -1150,7 +1171,7 @@ public partial class MainWindow
         var profiles = _dpStore.GetExistingProfiles(id)
             .Select(slot => (Slot: slot, Name: _dpStore.GetProfileName(id, slot) ?? Loc.Get("profile_n", slot)))
             .ToList();
-        int? currentSlot = CbDpProfile.SelectedItem is DpProfileItem pi && !pi.IsNew ? pi.Slot : null;
+        int? currentSlot = LstDpProfile.SelectedItem is DpProfileItem pi && !pi.IsNew ? pi.Slot : null;
         string deviceLabel = _dpDeviceLabels.GetValueOrDefault(id, $"DisplayPad {id}");
 
         ExportProfileHelper.Run(
@@ -1175,7 +1196,33 @@ public partial class MainWindow
 
     private void BtnDpImportBc_Click(object sender, RoutedEventArgs e)
     {
-        // 1. Locate the database
+        // Per-tab button: only ever touches the currently open tab's device — the
+        // "overall import" cascade (Settings) instead calls DpImportBcForAllDevices,
+        // which repeats this same per-device flow once per connected pad.
+        if (DpSelectedDeviceId() is not int id) return;
+        DpImportBcForDevice(id);
+    }
+
+    /// <summary>Runs the Base Camp import once per currently connected DisplayPad
+    /// (used by the "Import from Base Camp" cascade in Settings, MainWindow.Settings.cs) —
+    /// if Base Camp's DB has profiles for more than one physical device, the picker in
+    /// <see cref="DpImportBcForDevice"/> is shown once per connected pad here.</summary>
+    private void DpImportBcForAllDevices()
+    {
+        foreach (var id in _dpDeviceIds.ToList())
+            DpImportBcForDevice(id);
+    }
+
+    /// <summary>
+    /// Imports Base Camp profiles into ONE K2 DisplayPad device (<paramref name="k2DeviceId"/>).
+    /// If the DB has profiles for more than one physical device, prompts the user to choose
+    /// which one via <see cref="BcDevicePickerDialog"/> (skipped when there's only one
+    /// candidate — nothing to choose). Unlike the old free-slot-seeking import, this always
+    /// WIPES every existing K2 profile on the target device first (<see cref="DpDeleteProfileSlot"/>)
+    /// so the import replaces rather than appends.
+    /// </summary>
+    private void DpImportBcForDevice(int k2DeviceId)
+    {
         string? dbPath = BaseCampDbImporter.FindBaseCampDb();
         if (dbPath is null)
         {
@@ -1183,9 +1230,7 @@ public partial class MainWindow
             LblStatus.Text = Loc.Get("dp_bc_db_not_found");
             return;
         }
-        DpLog($"[IMP-BC] DB found: {dbPath}");
 
-        // 2. Read profiles grouped by device
         Dictionary<int, List<BaseCampDbImporter.BcProfile>> bcDevices;
         try { bcDevices = BaseCampDbImporter.ReadProfiles(dbPath); }
         catch (Exception ex)
@@ -1201,115 +1246,114 @@ public partial class MainWindow
             return;
         }
 
-        // 3. Auto-mapping: BC and K2 use the same SDK → DeviceIds match.
-        //    Show a summary with the automatic mapping.
-        var k2Devices = new HashSet<int>(_dpDeviceIds);
+        string deviceLabel = _dpDeviceLabels.GetValueOrDefault(k2DeviceId, $"DisplayPad {k2DeviceId}");
+
+        List<BaseCampDbImporter.BcProfile> profiles;
+        if (bcDevices.Count == 1)
+        {
+            profiles = bcDevices.Values.First();
+        }
+        else
+        {
+            var options = bcDevices.Select(kv => (
+                BcDeviceId: kv.Key,
+                Label: Loc.Get("bc_pick_device_label", kv.Key, kv.Value.Count,
+                    string.Join(", ", kv.Value.Select(p => p.Name)))
+            )).ToList();
+            var picker = new BcDevicePickerDialog(deviceLabel, options) { Owner = this };
+            if (picker.ShowDialog() != true) return;
+            profiles = bcDevices[picker.SelectedBcDeviceId!.Value];
+        }
+
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Automatic Base Camp → K2 mapping:\n");
-
-        int matchedDevices = 0;
-        int totalProfiles = 0;
-        foreach (var (bcDevId, profiles) in bcDevices)
-        {
-            bool hasK2 = k2Devices.Contains(bcDevId);
-            string status = hasK2 ? "→ K2 connected" : "→ NOT connected (skip)";
-            sb.AppendLine($"  DisplayPad #{bcDevId}  {status}");
-            foreach (var p in profiles)
-            {
-                string sel = p.IsSelected ? " [ACTIVE]" : "";
-                sb.AppendLine($"    Slot {p.Slot}: {p.Name}{sel}");
-            }
-            if (hasK2) { matchedDevices++; totalProfiles += profiles.Count; }
-        }
-
-        if (matchedDevices == 0)
-        {
-            sb.AppendLine("\nNo connected device matches the profiles in the DB.");
-            MessageBox.Show(this, sb.ToString(), "Import from Base Camp",
-                MessageBoxButton.OK, MessageBoxImage.Warning);
-            return;
-        }
-
-        sb.AppendLine($"\nImport {totalProfiles} profiles to {matchedDevices} devices?");
+        sb.AppendLine($"Import {profiles.Count} profile(s) into \"{deviceLabel}\"?\n");
+        foreach (var p in profiles)
+            sb.AppendLine($"  {(p.IsSelected ? "[ACTIVE] " : "")}{p.Name}");
+        sb.AppendLine();
+        sb.AppendLine(Loc.Get("bc_import_will_wipe", deviceLabel));
         if (MessageBox.Show(this, sb.ToString(), "Import from Base Camp",
-                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
             return;
 
-        // 4. Import: each profile goes to the K2 device with the same ID as BC
-        int totalButtons = 0;
-        int importedProfiles = 0;
-        int selectedDevId = DpSelectedDeviceId() ?? -1;
-        int selectedSlot = -1;
-        int skippedNoSlot = 0;
+        // Wipe: replace, don't append (see DpDeleteProfileSlot's doc comment).
+        foreach (var slot in _dpStore.GetExistingProfiles(k2DeviceId))
+            DpDeleteProfileSlot(k2DeviceId, slot);
 
-        foreach (var (bcDevId, profiles) in bcDevices)
+        int rotation = _dpStore.GetRotation(k2DeviceId);
+        // APEnable=false required before SetIconPic (UploadImageToProfile)
+        _dpClient.APEnable(k2DeviceId, false);
+
+        var usedSlots = new HashSet<int>();
+        int totalButtons = 0, importedProfiles = 0;
+
+        // Existing K2 macro names, used by TranslateAction to auto-match a Base Camp
+        // named-macro reference ("Default" FunctionType) against the user's own macro
+        // library — same lookup the XML import path already uses (BaseCampDbImporter.
+        // TranslateDefaultAction's doc comment), previously missing here so BC.db imports
+        // never resolved named macros even when the library had a matching name.
+        var macroNames = _macroStore?.GetAll()
+            .Select(m => m.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
+
+        foreach (var profile in profiles)
         {
-            if (!k2Devices.Contains(bcDevId)) continue;
-
-            // Rotation for this device
-            int rotation = _dpStore.GetRotation(bcDevId);
-            // APEnable=false required before SetIconPic (UploadImageToProfile)
-            _dpClient.APEnable(bcDevId, false);
-
-            // Always land in a FRESH slot per device — see BaseCampDbImporter.FindFreeSlot's
-            // doc comment; track slots claimed so far in this batch too.
-            var usedSlots = new HashSet<int>(_dpStore.GetExistingProfiles(bcDevId));
-
-            foreach (var profile in profiles)
+            try
             {
-                try
+                int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots, maxSlots: 999);
+                if (targetSlot == 0) continue; // sanity ceiling only, practically unreachable
+                usedSlots.Add(targetSlot);
+
+                int n = BaseCampDbImporter.ImportProfile(dbPath, profile, k2DeviceId, _dpStore, targetSlot, macroNames);
+
+                // Upload root-page images only (folder pages are uploaded on navigation)
+                var buttons = _dpStore.LoadPage(k2DeviceId, targetSlot, 0);
+                foreach (var btn in buttons)
                 {
-                    int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
-                    if (targetSlot == 0) { skippedNoSlot++; continue; }
-                    usedSlots.Add(targetSlot);
-
-                    int n = BaseCampDbImporter.ImportProfile(
-                        dbPath, profile, bcDevId, _dpStore, targetSlot);
-
-                    // Upload root-page images only (folder pages are uploaded on navigation)
-                    var buttons = _dpStore.LoadPage(bcDevId, targetSlot, 0);
-                    foreach (var btn in buttons)
+                    if (!string.IsNullOrEmpty(btn.ImagePath) && File.Exists(btn.ImagePath))
                     {
-                        if (!string.IsNullOrEmpty(btn.ImagePath) && File.Exists(btn.ImagePath))
-                        {
-                            bool ok = _dpClient.UploadImageToProfile(bcDevId, btn.ImagePath,
-                                btn.ButtonIndex, targetSlot, rotation);
-                            if (!ok)
-                                _dpClient.UploadImage(bcDevId, btn.ImagePath, btn.ButtonIndex, rotation);
-                        }
+                        bool ok = _dpClient.UploadImageToProfile(k2DeviceId, btn.ImagePath,
+                            btn.ButtonIndex, targetSlot, rotation);
+                        if (!ok)
+                            _dpClient.UploadImage(k2DeviceId, btn.ImagePath, btn.ButtonIndex, rotation);
                     }
-
-                    DpLog($"[IMP-BC] dev#{bcDevId} {profile.Name} (BC slot {profile.Slot} -> K2 slot {targetSlot}): {n} keys");
-                    totalButtons += n;
-                    importedProfiles++;
-
-                    // Track the active profile for the currently selected device
-                    if (profile.IsSelected && bcDevId == selectedDevId)
-                        selectedSlot = targetSlot;
                 }
-                catch (Exception ex)
-                {
-                    DpLog($"[IMP-BC] Import error dev#{bcDevId}/{profile.Name}: {ex.Message}");
-                }
+
+                DpLog($"[IMP-BC] {profile.Name} -> K2 dev#{k2DeviceId} slot {targetSlot}: {n} keys");
+                totalButtons += n;
+                importedProfiles++;
+            }
+            catch (Exception ex)
+            {
+                DpLog($"[IMP-BC] Import error {profile.Name}: {ex.Message}");
             }
         }
 
-        if (skippedNoSlot > 0)
-            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
-                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
+        // Always land on the FIRST imported profile and force a reload — simpler and
+        // safer than trying to restore whatever was active in Base Camp (user request:
+        // a plain, predictable refresh after import beats guessing at BC's own state).
+        int activateSlot = usedSlots.DefaultIfEmpty(0).Min();
+        bool isActive = k2DeviceId == DpSelectedDeviceId();
 
-        // 5. Activate the profile that was selected in BC for the current device
-        if (selectedSlot > 0 && selectedDevId > 0)
+        // DpRefreshProfiles/DpSelectProfileSlot (foreground-only, see their own doc
+        // comments) MUST run BEFORE DpRequestRepaint below: the repaint's foreground path
+        // (DpReloadAndPreloadProfile -> DpCurrentProfile()) reads the profile straight off
+        // LstDpProfile.SelectedItem, not the store — repainting first left the UI showing
+        // "Profile 1" selected while the panel kept whatever profile was selected BEFORE
+        // the import (e.g. Profile 2), since the list hadn't been moved to slot 1 yet.
+        if (isActive)
         {
-            // No native SwitchProfile — see DpSwitchProfile.
-            _dpStore.SetCurrentProfile(selectedDevId, selectedSlot);
-            ResetDpNavigation();
-            DpRefreshProfiles(selectedDevId);
-            DpSelectProfileSlot(selectedSlot);
-            DpRequestRepaint(selectedDevId);
+            DpRefreshProfiles(k2DeviceId);
+            if (activateSlot > 0) DpSelectProfileSlot(activateSlot);
+        }
+        if (activateSlot > 0)
+        {
+            _dpStore.SetCurrentProfile(k2DeviceId, activateSlot);
+            if (isActive) ResetDpNavigation();
+            DpRequestRepaint(k2DeviceId);
         }
 
-        DpLog($"[IMP-BC] Done: {totalButtons} keys across {importedProfiles} profiles / {matchedDevices} devices");
+        DpLog($"[IMP-BC] Done: {totalButtons} keys across {importedProfiles} profile(s) on device #{k2DeviceId}");
         LblStatus.Text = Loc.Get("dp_imported", importedProfiles, totalButtons);
     }
 
@@ -1461,6 +1505,64 @@ public partial class MainWindow
     // ================================================================
     // Context menu
     // ================================================================
+
+    /// <summary>Right-click menu for LstDpProfile rows — replaces the old standalone
+    /// Rename/Delete/Import/Export buttons (see MainWindow.xaml's Profile group).
+    /// A single ContextMenu is shared by every row; K2SideProfileItemStyle's
+    /// PreviewMouseRightButtonDown EventSetter (ProfileItem_PreviewRightClick, in
+    /// MainWindow.xaml.cs) selects the right-clicked row first, so every handler below
+    /// (already written to read LstDpProfile.SelectedItem) works unmodified.</summary>
+    private ContextMenu DpBuildProfileContextMenu()
+    {
+        var menu = new ContextMenu();
+        var miRename = new MenuItem { Header = Loc.Get("rename_profile") };
+        miRename.Click += BtnDpRenameProfile_Click;
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnDpImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("dp_import_bc") };
+        miImportBc.Click += BtnDpImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnDpExportProfiles_Click;
+        var miDelete = new MenuItem { Header = Loc.Get("delete_profile") };
+        miDelete.Click += BtnDpDeleteProfile_Click;
+        menu.Items.Add(miRename);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miDelete);
+        return menu;
+    }
+
+    /// <summary>Same items as <see cref="DpBuildProfileContextMenu"/> minus Rename/Delete —
+    /// opened from the small "…" button in the Profile header (BtnDpProfileMenu_Click),
+    /// which is not tied to a specific row so renaming/deleting a specific profile
+    /// wouldn't make sense there.</summary>
+    private ContextMenu DpBuildProfileMenuNoEdit()
+    {
+        var menu = new ContextMenu();
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnDpImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("dp_import_bc") };
+        miImportBc.Click += BtnDpImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnDpExportProfiles_Click;
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        return menu;
+    }
+
+    private void BtnDpProfileMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu is ContextMenu cm)
+        {
+            cm.PlacementTarget = btn;
+            cm.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            cm.IsOpen = true;
+        }
+    }
 
     private ContextMenu BuildDpKeyContextMenu()
     {
@@ -1727,8 +1829,39 @@ public partial class MainWindow
     /// only updates the UI/store above; without this the old icon stays on-screen
     /// until the next full repaint (profile switch, reconnect, ...).
     /// </summary>
-    private void DpClearKeyOnDevice(int id, int btnIndex) =>
-        _dpClient.TryUploadRawBgr(id, new byte[DpHidNative.IconBytes], btnIndex);
+    private void DpClearKeyOnDevice(int id, int btnIndex)
+    {
+        if (_dpClient.TryUploadRawBgr(id, new byte[DpHidNative.IconBytes], btnIndex)) return;
+        // Satellite/SDK backend: TryUploadRawBgr is a hard "false" there (no raw-buffer
+        // command over the pipe), so this method used to be a silent no-op on that
+        // backend — combined with DisplayPadResetPicture failing on some machines
+        // (observed 2026-07-16, satellite log "[ResetPictures/native] ok=False" on every
+        // profile switch), NOTHING could ever blank a key and stale icons survived every
+        // switch. Fall back to uploading a solid-black PNG through the normal path,
+        // which those same logs show always works.
+        _dpClient.UploadImage(id, DpBlackIconPath(), btnIndex, 0);
+    }
+
+    private static string? _dpBlackIconPath;
+
+    /// <summary>Path of a solid-black 102×102 PNG, generated once on first use (blank-key
+    /// fallback for backends without raw-buffer uploads — see <see cref="DpClearKeyOnDevice"/>).</summary>
+    private static string DpBlackIconPath()
+    {
+        if (_dpBlackIconPath is string cached && File.Exists(cached)) return cached;
+        string dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "K2.DisplayPad");
+        Directory.CreateDirectory(dir);
+        string path = Path.Combine(dir, "blank_black_102.png");
+        if (!File.Exists(path))
+        {
+            using var bmp = new System.Drawing.Bitmap(DpHidNative.IconSize, DpHidNative.IconSize);
+            using (var g = System.Drawing.Graphics.FromImage(bmp))
+                g.Clear(System.Drawing.Color.Black);
+            bmp.Save(path, System.Drawing.Imaging.ImageFormat.Png);
+        }
+        return _dpBlackIconPath = path;
+    }
 
     // ================================================================
     // Refresh / Persistence
@@ -1850,7 +1983,7 @@ public partial class MainWindow
             : "0 DisplayPad tabs created (SDK reported no plugged device)");
     }
 
-    private int DpCurrentProfile() => CbDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : 1;
+    private int DpCurrentProfile() => LstDpProfile.SelectedItem is DpProfileItem pi ? pi.Slot : 1;
 
     /// <summary>
     /// Reloads the current page's keys from the store and uploads images.
@@ -1918,10 +2051,13 @@ public partial class MainWindow
         }
 
         // Any key without an image on THIS page must go blank on the panel — otherwise it
-        // keeps showing whatever the previously-displayed page (or profile) had there. Only
-        // matters when neither blankFirst (ResetPictures already blanks the whole panel) nor
-        // fullscreenActive (a fullscreen image already owns all 12 slots) is in play.
-        var toBlank = (blankFirst || fullscreenActive)
+        // keeps showing whatever the previously-displayed page (or profile) had there.
+        // Computed even when blankFirst is set: ResetPictures can FAIL (the SDK wrapper
+        // call returns false on some machines — observed 2026-07-16), and when it does
+        // these per-key blanks are the only thing standing between the user and stale
+        // old-profile icons. Skipped only under fullscreenActive (a fullscreen image
+        // already owns all 12 slots).
+        var toBlank = fullscreenActive
             ? Array.Empty<int>()
             : Enumerable.Range(0, _dpKeys.Length).Where(i => !keysWithImage.Contains(i)).ToArray();
 
@@ -1939,7 +2075,13 @@ public partial class MainWindow
             var next = previous.ContinueWith(_ =>
             {
                 if (ct.IsCancellationRequested) return;
-                if (blankFirst) _dpClient.ResetPictures(id);
+                bool panelBlanked = false;
+                if (blankFirst)
+                {
+                    panelBlanked = _dpClient.ResetPictures(id);
+                    if (!panelBlanked)
+                        DpLogAsync("ResetPictures failed — blanking empty keys individually instead");
+                }
 
                 if (fullscreenActive)
                 {
@@ -1948,7 +2090,8 @@ public partial class MainWindow
                     return;
                 }
 
-                foreach (int btnIndex in toBlank)
+                // Redundant (and skipped) when the full-panel reset above really worked.
+                foreach (int btnIndex in panelBlanked ? Array.Empty<int>() : toBlank)
                 {
                     if (ct.IsCancellationRequested) return;
                     DpClearKeyOnDevice(id, btnIndex);
@@ -2062,7 +2205,7 @@ public partial class MainWindow
     /// responding to its own physical key presses and shows the right icons right away —
     /// see <see cref="DpHandleBackgroundKey"/>. Mirrors the essential part of
     /// <see cref="DpActivateDevice"/>/<see cref="DpReloadAndPreloadProfile"/> WITHOUT
-    /// touching any UI-bound field (_dpKeys, CbDpProfile, _dpRotation, ...) — those only
+    /// touching any UI-bound field (_dpKeys, LstDpProfile, _dpRotation, ...) — those only
     /// ever represent whichever single device tab is actually visible.
     /// </summary>
     private void DpActivateBackgroundDevice(int id)
@@ -2100,14 +2243,22 @@ public partial class MainWindow
         var keysWithImage = new HashSet<int>(
             rows.Where(r => !string.IsNullOrEmpty(r.ImagePath) && File.Exists(r.ImagePath))
                 .Select(r => r.ButtonIndex));
-        var toBlank = (blankFirst || fullscreenActive)
+        // Same ResetPictures-can-fail fallback as DpReloadCurrentProfile — see the
+        // comment on toBlank there.
+        var toBlank = fullscreenActive
             ? Array.Empty<int>()
             : Enumerable.Range(0, 12).Where(i => !keysWithImage.Contains(i)).ToArray();
 
         var previous = _dpUploadChain.TryGetValue(id, out var p) ? p : Task.CompletedTask;
         var next = previous.ContinueWith(_ =>
         {
-            if (blankFirst) _dpClient.ResetPictures(id);
+            bool panelBlanked = false;
+            if (blankFirst)
+            {
+                panelBlanked = _dpClient.ResetPictures(id);
+                if (!panelBlanked)
+                    DpLogAsync($"ResetPictures failed (bg device {id}) — blanking empty keys individually instead");
+            }
 
             if (fullscreenActive)
             {
@@ -2115,7 +2266,7 @@ public partial class MainWindow
                     fullscreen!.Value.Path, fullscreen.Value.Rotation, rotation);
                 return;
             }
-            foreach (int btnIndex in toBlank)
+            foreach (int btnIndex in panelBlanked ? Array.Empty<int>() : toBlank)
                 DpClearKeyOnDevice(id, btnIndex);
 
             foreach (var r in rows)

--- a/K2.App/MainWindow.Everest.cs
+++ b/K2.App/MainWindow.Everest.cs
@@ -198,6 +198,8 @@ public partial class MainWindow
     private void InitEverestModule()
     {
         LvEvKeys.ItemsSource    = _evKeys;
+        LstEvProfile.ContextMenu = EvBuildProfileContextMenu();
+        BtnEvProfileMenu.ContextMenu = EvBuildProfileMenuNoEdit();
         EvRefreshProfiles();
         EvSelectProfileSlot(_evStore.GetCurrentProfile());
 
@@ -539,13 +541,6 @@ public partial class MainWindow
                     };
                 }
 
-                var tip = string.IsNullOrEmpty(kd.Label) ? "Space" : kd.Label;
-                if (altLbl   is not null) tip += $"  ⇧ {altLbl}";
-                if (altGrLbl is not null) tip += $"  AltGr {altGrLbl}";
-                if (sAltGrLbl is not null) tip += $"  ⇧AltGr {sAltGrLbl}";
-                tip += $"   (0x{kd.MatrixId:X2})";
-                if (kd.MatrixId == 261) tip += "  — riservato, non configurabile";
-
                 var btn = new Button
                 {
                     Width   = kd.W,
@@ -553,7 +548,6 @@ public partial class MainWindow
                     Style   = keyStyle,
                     Content = content,
                     Tag     = kd.MatrixId,
-                    ToolTip = tip,
                 };
 
                 btn.Click += EvKeyboardButton_Click;
@@ -770,7 +764,7 @@ public partial class MainWindow
             var match = _evKeyVisuals.FirstOrDefault(kv => ReferenceEquals(kv.Value.Button, btn0));
             if (match.Value.Button != null)
             {
-                string label = (btn0.Content as TextBlock)?.Text ?? $"0x{matrixId:X2}";
+                string label = (btn0.Content as TextBlock)?.Text ?? EvKeyLabelForMatrix(matrixId) ?? "";
                 OpenEvKeycapCustomizeDialog(match.Key, label);
             }
             return;
@@ -1065,7 +1059,11 @@ public partial class MainWindow
         ApplyCurrentEffect();
         ApplyEverestSettingsToDevice();
         StartLedPreview();
-        EvUploadNdkImages(); // resync current profile's NDK pictures in case this is a different/reset device
+        // NDK image resync intentionally NOT done here (2026-07-16, user report):
+        // sending the numpad display key pictures during the automatic startup
+        // open hung the whole app on some setups. Still runs on a manual
+        // "Open driver" click (BtnEvOpen_Click) and on profile switch/NDK
+        // hot-plug, just not unconditionally at launch.
 
         // Restore custom device name if previously set
         var savedName = _evStore.GetSetting("device.name");
@@ -1189,19 +1187,34 @@ public partial class MainWindow
                 return;
             }
 
+            // Register the profile's name unconditionally, BEFORE translating any binding —
+            // same fix as BaseCampDbImporter.ImportEverestProfile: without this, a profile
+            // whose regular keys all translate to no action (or one that's entirely NDK/
+            // touch-key content) writes no Keys row and never shows up in
+            // EverestStore.GetExistingProfiles, so it silently disappears after import.
+            _evStore.SetProfileName(slot, profileName);
+
             int regular = 0, touch = 0;
+
+            // Existing K2 macro names, used by TranslateAction to auto-match a Base Camp
+            // named-macro reference ("Default" FunctionType) against the user's own macro
+            // library — see BaseCampDbImporter.TranslateDefaultAction's doc comment.
+            var macroNames = _macroStore?.GetAll()
+                .Select(m => m.Name)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToList();
 
             // FunctionType=="K2Action" is K2's own round-trip encoding (ActionType/Value
             // stashed verbatim in SubFunctionType/FunctionValue); anything else is real
             // Base Camp vocabulary translated through the shared table.
-            static (string? ActionType, string? ActionValue) TranslateBinding(System.Xml.Linq.XElement b)
+            (string? ActionType, string? ActionValue) TranslateBinding(System.Xml.Linq.XElement b)
             {
                 string? funcType  = b.Element("FunctionType")?.Value;
                 string? subType   = b.Element("SubFunctionType")?.Value;
                 string? funcValue = b.Element("FunctionValue")?.Value;
                 if (funcType == "K2Action")
                     return (subType, string.IsNullOrEmpty(funcValue) ? null : funcValue);
-                return BaseCampDbImporter.TranslateAction(funcType, subType, funcValue);
+                return BaseCampDbImporter.TranslateAction(funcType, subType, funcValue, macroNames);
             }
 
             var touchBindings = new List<(int MatrixId, System.Xml.Linq.XElement El)>();
@@ -1287,7 +1300,7 @@ public partial class MainWindow
         var profiles = Enumerable.Range(1, EverestService.ProfileCount)
             .Select(slot => (Slot: slot, Name: _evStore.GetProfileName(slot) ?? Loc.Get("profile_n", slot)))
             .ToList();
-        int? currentSlot = CbEvProfile.SelectedItem is EvProfileItem pi ? pi.Slot : null;
+        int? currentSlot = LstEvProfile.SelectedItem is EvProfileItem pi ? pi.Slot : null;
 
         ExportProfileHelper.Run(
             owner: this,
@@ -1331,38 +1344,66 @@ public partial class MainWindow
             return;
         }
 
-        // All Everest profiles share the same single device — collect them all
-        var allProfiles = bcDevices.Values.SelectMany(x => x).OrderBy(p => p.Slot).ToList();
+        string deviceLabel = TabEverest.Header as string ?? Loc.Get("tab_everest");
+
+        List<BaseCampDbImporter.BcProfile> allProfiles;
+        if (bcDevices.Count == 1)
+        {
+            allProfiles = bcDevices.Values.First().OrderBy(p => p.Slot).ToList();
+        }
+        else
+        {
+            // Base Camp has profiles for more than one physical Everest keyboard — let the
+            // user pick which one, instead of silently flattening every BC device's
+            // profiles together (the old behavior).
+            var options = bcDevices.Select(kv => (
+                BcDeviceId: kv.Key,
+                Label: Loc.Get("bc_pick_device_label", kv.Key, kv.Value.Count,
+                    string.Join(", ", kv.Value.Select(p => p.Name)))
+            )).ToList();
+            var picker = new BcDevicePickerDialog(deviceLabel, options) { Owner = this };
+            if (picker.ShowDialog() != true) return;
+            allProfiles = bcDevices[picker.SelectedBcDeviceId!.Value].OrderBy(p => p.Slot).ToList();
+        }
 
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Base Camp → K2 Everest import:\n");
+        sb.AppendLine($"Import {allProfiles.Count} profile(s) into \"{deviceLabel}\"?\n");
         foreach (var p in allProfiles)
-            sb.AppendLine($"  Slot {p.Slot}: {p.Name}{(p.IsSelected ? " [ACTIVE]" : "")}");
-        sb.AppendLine($"\nImport {allProfiles.Count} profile(s)?");
+            sb.AppendLine($"  {(p.IsSelected ? "[ACTIVE] " : "")}{p.Name}");
+        sb.AppendLine();
+        sb.AppendLine(Loc.Get("bc_import_will_wipe", deviceLabel));
 
         if (MessageBox.Show(this, sb.ToString(), "Import from Base Camp",
-                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
             return;
 
-        int totalRegular = 0, totalTouch = 0;
-        int activeSlot = -1;
-        int skippedNoSlot = 0;
+        // Wipe: replace, don't append (unlike the old free-slot-seeking import).
+        foreach (var slot in _evStore.GetExistingProfiles())
+            _evStore.ClearProfile(slot);
 
-        // Each imported profile lands in a FRESH slot, never profile.Slot verbatim (see
-        // BaseCampDbImporter.FindFreeSlot's doc comment) — track slots claimed so far in
-        // THIS batch too, so importing 3 profiles in one go doesn't pick the same free
-        // slot for all of them.
-        var usedSlots = new HashSet<int>(_evStore.GetExistingProfiles());
+        int totalRegular = 0, totalTouch = 0;
+
+        var usedSlots = new HashSet<int>();
+
+        // Existing K2 macro names, used by TranslateAction to auto-match a Base Camp
+        // named-macro reference ("Default" FunctionType) against the user's own macro
+        // library — same lookup the XML import path already uses (BaseCampDbImporter.
+        // TranslateDefaultAction's doc comment), previously missing here so BC.db imports
+        // never resolved named macros even when the library had a matching name.
+        var macroNames = _macroStore?.GetAll()
+            .Select(m => m.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
 
         foreach (var profile in allProfiles)
         {
             try
             {
                 int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
-                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                if (targetSlot == 0) continue; // sanity ceiling only (5 real firmware slots)
                 usedSlots.Add(targetSlot);
 
-                var (reg, touch) = BaseCampDbImporter.ImportEverestProfile(dbPath, profile, _evStore, targetSlot);
+                var (reg, touch) = BaseCampDbImporter.ImportEverestProfile(dbPath, profile, _evStore, targetSlot, macroNames);
                 totalRegular += reg;
                 totalTouch   += touch;
                 LogEverest($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: {reg} keys, {touch} display keys");
@@ -1372,8 +1413,6 @@ public partial class MainWindow
                 // overlay is up. Same behavior real Base Camp shows during a DB/profile
                 // import (see K2/_reference/usb_dumps analysis, 2026-07-16).
                 if (touch > 0 && _everest.IsOpen) EvUploadNdkImages(targetSlot);
-
-                if (profile.IsSelected) activeSlot = targetSlot;
             }
             catch (Exception ex)
             {
@@ -1381,23 +1420,18 @@ public partial class MainWindow
             }
         }
 
-        if (skippedNoSlot > 0)
-            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
-                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
-
-        // Switch to the active BC profile and reload UI
-        if (activeSlot > 0)
+        // Always land on the FIRST imported profile and force a reload — simpler and
+        // safer than trying to restore whatever was active in Base Camp (user request:
+        // a plain, predictable refresh after import beats guessing at BC's own state).
+        int activateSlot = usedSlots.DefaultIfEmpty(0).Min();
+        EvRefreshProfiles();
+        if (activateSlot > 0)
         {
-            _evStore.SetCurrentProfile(activeSlot);
-            EvSelectProfileSlot(activeSlot);
-            ReloadEverestProfile();
-            LoadNdkState();
+            _evStore.SetCurrentProfile(activateSlot);
+            EvSelectProfileSlot(activateSlot);
         }
-        else
-        {
-            ReloadEverestProfile();
-            LoadNdkState();
-        }
+        ReloadEverestProfile();
+        LoadNdkState();
 
         LogEverest($"[IMP-BC] Done: {totalRegular} regular + {totalTouch} display keys across {allProfiles.Count} profiles");
         LblStatus.Text = Loc.Get("ev_imported_bc", allProfiles.Count, totalRegular);
@@ -1441,10 +1475,10 @@ public partial class MainWindow
         if (any) NdkRefreshDevicePicSlots();
     }
 
-    private void CbEvProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void LstEvProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_evSuppressProfile) return;
-        if (CbEvProfile.SelectedItem is not EvProfileItem pi) return;
+        if (LstEvProfile.SelectedItem is not EvProfileItem pi) return;
         int slot = pi.Slot;
 
         if (pi.IsNew)
@@ -1582,8 +1616,10 @@ public partial class MainWindow
         // Translate SDK wMatrix to visual layout matrixId
         int matrix = EvTranslateMatrix(rawMatrix);
 
-        // Highlight in the visual keyboard overlay
-        EvHighlightKeyboardButton(matrix, e.Pressed);
+        // Physical-press highlight disabled (2026-07-17, user request): the
+        // wMatrix→matrixId translation has gaps, so the tint fired inconsistently
+        // across keys and read as broken rather than useful.
+        // EvHighlightKeyboardButton(matrix, e.Pressed);
 
         if (_evByMatrix.TryGetValue(matrix, out var key))
         {
@@ -1671,7 +1707,7 @@ public partial class MainWindow
     // ============================================================
 
     private int EvCurrentProfile()
-        => CbEvProfile.SelectedItem is EvProfileItem pi ? pi.Slot : 1;
+        => LstEvProfile.SelectedItem is EvProfileItem pi ? pi.Slot : 1;
 
     /// <summary>Populates the Everest profile combo with configured profiles + "New
     /// profile…" (device firmware always has 5 fixed slots — see EverestStore.
@@ -1695,8 +1731,8 @@ public partial class MainWindow
             if (nextFree > 0)
                 items.Add(new EvProfileItem(nextFree, Loc.Get("new_profile")));
 
-            CbEvProfile.DisplayMemberPath = nameof(EvProfileItem.Label);
-            CbEvProfile.ItemsSource = items;
+            LstEvProfile.DisplayMemberPath = nameof(EvProfileItem.Label);
+            LstEvProfile.ItemsSource = items;
         }
         finally { _evSuppressProfile = false; }
     }
@@ -1707,10 +1743,64 @@ public partial class MainWindow
         _evSuppressProfile = true;
         try
         {
-            if (CbEvProfile.ItemsSource is List<EvProfileItem> items)
-                CbEvProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
+            if (LstEvProfile.ItemsSource is List<EvProfileItem> items)
+                LstEvProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
         }
         finally { _evSuppressProfile = false; }
+    }
+
+    /// <summary>Right-click menu for LstEvProfile rows — see DpBuildProfileContextMenu
+    /// (MainWindow.DisplayPad.cs) for the shared pattern/rationale.</summary>
+    private ContextMenu EvBuildProfileContextMenu()
+    {
+        var menu = new ContextMenu();
+        var miRename = new MenuItem { Header = Loc.Get("rename_profile") };
+        miRename.Click += BtnEvRenameProfile_Click;
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnEvImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnEvImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnEvExportProfiles_Click;
+        var miDelete = new MenuItem { Header = Loc.Get("delete_profile") };
+        miDelete.Click += BtnEvDeleteProfile_Click;
+        menu.Items.Add(miRename);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miDelete);
+        return menu;
+    }
+
+    /// <summary>Same items as <see cref="EvBuildProfileContextMenu"/> minus Rename/Delete —
+    /// opened from the small "…" button in the Profile header (BtnEvProfileMenu_Click),
+    /// which is not tied to a specific row so renaming/deleting a specific profile
+    /// wouldn't make sense there.</summary>
+    private ContextMenu EvBuildProfileMenuNoEdit()
+    {
+        var menu = new ContextMenu();
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnEvImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnEvImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnEvExportProfiles_Click;
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        return menu;
+    }
+
+    private void BtnEvProfileMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu is ContextMenu cm)
+        {
+            cm.PlacementTarget = btn;
+            cm.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            cm.IsOpen = true;
+        }
     }
 
     private void BtnEvRenameProfile_Click(object sender, RoutedEventArgs e)
@@ -1822,7 +1912,7 @@ public partial class MainWindow
 
         _everest.SwitchProfile(next);
         _evStore.SetCurrentProfile(next);
-        // EvSelectProfileSlot suppresses CbEvProfile_SelectionChanged (avoids re-entrant
+        // EvSelectProfileSlot suppresses LstEvProfile_SelectionChanged (avoids re-entrant
         // handling while this method is already mid-switch) — which means it does NOT
         // call ReloadEverestProfile on its own. Call it explicitly so the key list AND
         // the NDK hardware re-upload (see ReloadEverestProfile's doc comment) actually

--- a/K2.App/MainWindow.Everest60.cs
+++ b/K2.App/MainWindow.Everest60.cs
@@ -145,6 +145,8 @@ public partial class MainWindow
         _ev60Engine = new ButtonActionEngine(_ev60ActionHost);
         _ev60Engine.Start();
 
+        LstEv60Profile.ContextMenu = Ev60BuildProfileContextMenu();
+        BtnEv60ProfileMenu.ContextMenu = Ev60BuildProfileMenuNoEdit();
         Ev60RefreshProfiles();
         Ev60ReloadProfile(Ev60CurrentProfile());
 
@@ -186,7 +188,7 @@ public partial class MainWindow
     }
 
     private int Ev60CurrentProfile()
-        => CbEv60Profile.SelectedItem is Ev60ProfileItem pi ? pi.Slot : 1;
+        => LstEv60Profile.SelectedItem is Ev60ProfileItem pi ? pi.Slot : 1;
 
     private void Ev60RefreshProfiles()
     {
@@ -196,11 +198,11 @@ public partial class MainWindow
             var items = Enumerable.Range(1, Ev60ProfileCount)
                 .Select(s => new Ev60ProfileItem(s, _ev60Store.GetProfileName(s) ?? Loc.Get("profile_n", s)))
                 .ToList();
-            CbEv60Profile.DisplayMemberPath = nameof(Ev60ProfileItem.Label);
-            CbEv60Profile.ItemsSource = items;
+            LstEv60Profile.DisplayMemberPath = nameof(Ev60ProfileItem.Label);
+            LstEv60Profile.ItemsSource = items;
 
             int current = _ev60Store.GetCurrentProfile();
-            CbEv60Profile.SelectedItem = items.Find(x => x.Slot == current) ?? items[0];
+            LstEv60Profile.SelectedItem = items.Find(x => x.Slot == current) ?? items[0];
         }
         finally { _ev60SuppressProfile = false; }
     }
@@ -210,8 +212,8 @@ public partial class MainWindow
         _ev60SuppressProfile = true;
         try
         {
-            if (CbEv60Profile.ItemsSource is List<Ev60ProfileItem> items)
-                CbEv60Profile.SelectedItem = items.Find(x => x.Slot == slot) ?? items[0];
+            if (LstEv60Profile.ItemsSource is List<Ev60ProfileItem> items)
+                LstEv60Profile.SelectedItem = items.Find(x => x.Slot == slot) ?? items[0];
         }
         finally { _ev60SuppressProfile = false; }
     }
@@ -229,7 +231,7 @@ public partial class MainWindow
     /// profile slot — mirrors MainWindow.Everest.cs's EvSwitchProfile, but
     /// there is no firmware call to make (see the "Profile management" doc
     /// comment above): switching just reloads the slot's stored keys/lighting,
-    /// same as picking it from CbEv60Profile.
+    /// same as picking it from LstEv60Profile.
     /// </summary>
     private void Ev60SwitchProfile(string target)
     {
@@ -258,13 +260,67 @@ public partial class MainWindow
         LogEverest60($"[EXEC] profile -> {next}");
     }
 
-    private void CbEv60Profile_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void LstEv60Profile_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_ev60SuppressProfile) return;
-        if (CbEv60Profile.SelectedItem is not Ev60ProfileItem pi) return;
+        if (LstEv60Profile.SelectedItem is not Ev60ProfileItem pi) return;
         _ev60Store.SetCurrentProfile(pi.Slot);
         LogEverest60($"[UI ] Everest 60 profile selected: {pi.Slot}");
         Ev60ReloadProfile(pi.Slot);
+    }
+
+    /// <summary>Right-click menu for LstEv60Profile rows — see DpBuildProfileContextMenu
+    /// (MainWindow.DisplayPad.cs) for the shared pattern/rationale.</summary>
+    private ContextMenu Ev60BuildProfileContextMenu()
+    {
+        var menu = new ContextMenu();
+        var miRename = new MenuItem { Header = Loc.Get("rename_profile") };
+        miRename.Click += BtnEv60RenameProfile_Click;
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnEv60ImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnEv60ImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnEv60ExportProfiles_Click;
+        var miDelete = new MenuItem { Header = Loc.Get("delete_profile") };
+        miDelete.Click += BtnEv60DeleteProfile_Click;
+        menu.Items.Add(miRename);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miDelete);
+        return menu;
+    }
+
+    /// <summary>Same items as <see cref="Ev60BuildProfileContextMenu"/> minus Rename/Delete —
+    /// opened from the small "…" button in the Profile header (BtnEv60ProfileMenu_Click),
+    /// which is not tied to a specific row so renaming/deleting a specific profile
+    /// wouldn't make sense there.</summary>
+    private ContextMenu Ev60BuildProfileMenuNoEdit()
+    {
+        var menu = new ContextMenu();
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnEv60ImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnEv60ImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnEv60ExportProfiles_Click;
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        return menu;
+    }
+
+    private void BtnEv60ProfileMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu is ContextMenu cm)
+        {
+            cm.PlacementTarget = btn;
+            cm.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            cm.IsOpen = true;
+        }
     }
 
     private void BtnEv60RenameProfile_Click(object sender, RoutedEventArgs e)
@@ -345,45 +401,74 @@ public partial class MainWindow
             return;
         }
 
-        var allProfiles = bcDevices.Values.SelectMany(x => x).OrderBy(p => p.Slot).ToList();
+        string deviceLabel = AppSettings.Everest60DeviceName ?? (TabEverest60.Header as string) ?? Loc.Get("tab_everest60");
+
+        List<BaseCampDbImporter.BcProfile> allProfiles;
+        if (bcDevices.Count == 1)
+        {
+            allProfiles = bcDevices.Values.First().OrderBy(p => p.Slot).ToList();
+        }
+        else
+        {
+            var options = bcDevices.Select(kv => (
+                BcDeviceId: kv.Key,
+                Label: Loc.Get("bc_pick_device_label", kv.Key, kv.Value.Count,
+                    string.Join(", ", kv.Value.Select(p => p.Name)))
+            )).ToList();
+            var picker = new BcDevicePickerDialog(deviceLabel, options) { Owner = this };
+            if (picker.ShowDialog() != true) return;
+            allProfiles = bcDevices[picker.SelectedBcDeviceId!.Value].OrderBy(p => p.Slot).ToList();
+        }
 
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Base Camp -> K2 Everest 60 import:\n");
+        sb.AppendLine($"Import {allProfiles.Count} profile(s) into \"{deviceLabel}\"?\n");
         foreach (var p in allProfiles)
-            sb.AppendLine($"  Slot {p.Slot}: {p.Name}{(p.IsSelected ? " [ACTIVE]" : "")}");
-        sb.AppendLine($"\nImport {allProfiles.Count} profile(s)?");
+            sb.AppendLine($"  {(p.IsSelected ? "[ACTIVE] " : "")}{p.Name}");
+        sb.AppendLine();
+        sb.AppendLine(Loc.Get("bc_import_will_wipe", deviceLabel));
 
         if (MessageBox.Show(this, sb.ToString(), "Import from Base Camp",
-                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
             return;
 
+        // Wipe: replace, don't append. Everest 60 always has 5 fixed K2-side slots (no
+        // firmware profile concept — see the "Profile management" doc comment above).
+        for (int slot = 1; slot <= Ev60ProfileCount; slot++)
+            _ev60Store.ClearProfile(slot);
+
         int totalKeys = 0;
-        int activeSlot = -1;
-        int skippedNoSlot = 0;
-        var usedSlots = new HashSet<int>(_ev60Store.GetExistingProfiles());
+        var usedSlots = new HashSet<int>();
+
+        // Existing K2 macro names, used by TranslateAction to auto-match a Base Camp
+        // named-macro reference ("Default" FunctionType) against the user's own macro
+        // library — same lookup the DisplayPad/Everest import paths use (BaseCampDbImporter.
+        // TranslateDefaultAction's doc comment).
+        var macroNames = _macroStore?.GetAll()
+            .Select(m => m.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
+
         foreach (var profile in allProfiles)
         {
             try
             {
                 int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
-                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                if (targetSlot == 0) continue; // sanity ceiling only (5 fixed slots)
                 usedSlots.Add(targetSlot);
 
-                int keys = BaseCampDbImporter.ImportEverest60Profile(dbPath, profile, _ev60Store, targetSlot);
+                int keys = BaseCampDbImporter.ImportEverest60Profile(dbPath, profile, _ev60Store, targetSlot, macroNames);
                 totalKeys += keys;
-                if (profile.IsSelected) activeSlot = targetSlot;
                 LogEverest60($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: keys={keys}");
             }
             catch (Exception ex) { LogEverest60($"[IMP-BC] slot {profile.Slot} error: {ex.Message}"); }
         }
 
-        if (skippedNoSlot > 0)
-            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
-                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
-
-        if (activeSlot > 0) _ev60Store.SetCurrentProfile(activeSlot);
+        // Always land on the FIRST imported profile and force a reload — simpler and
+        // safer than trying to restore whatever was active in Base Camp (user request:
+        // a plain, predictable refresh after import beats guessing at BC's own state).
+        int finalSlot = usedSlots.DefaultIfEmpty(1).Min();
+        _ev60Store.SetCurrentProfile(finalSlot);
         Ev60RefreshProfiles();
-        int finalSlot = activeSlot > 0 ? activeSlot : Ev60CurrentProfile();
         Ev60SelectProfileSlot(finalSlot);
         Ev60ReloadProfile(finalSlot);
         LogEverest60(Loc.Get("ev60_imported_bc", allProfiles.Count, totalKeys));
@@ -484,7 +569,7 @@ public partial class MainWindow
         var profiles = Enumerable.Range(1, 5)
             .Select(slot => (Slot: slot, Name: _ev60Store.GetProfileName(slot) ?? Loc.Get("profile_n", slot)))
             .ToList();
-        int? currentSlot = CbEv60Profile.SelectedItem is Ev60ProfileItem pi ? pi.Slot : null;
+        int? currentSlot = LstEv60Profile.SelectedItem is Ev60ProfileItem pi ? pi.Slot : null;
 
         ExportProfileHelper.Run(
             owner: this,
@@ -560,7 +645,6 @@ public partial class MainWindow
                     HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center,
                 },
                 Tag = kd.MatrixId, // LED index 0-63
-                ToolTip = $"{kd.Label}  (LED {kd.MatrixId})",
             };
             btn.Click += Ev60KeyboardButton_Click;
             Canvas.SetLeft(btn, kd.X);
@@ -589,7 +673,6 @@ public partial class MainWindow
                     HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center,
                 },
                 IsHitTestVisible = false, // decorative only — no protocol for this accessory
-                ToolTip = Loc.Get("ev60_numpad_decorative_tip"),
             };
             Canvas.SetLeft(btn, kd.X);
             Canvas.SetTop(btn, kd.Y);
@@ -720,7 +803,10 @@ public partial class MainWindow
 
         if (!_ev60DllKeyIdToLedIndex.TryGetValue(wMatrix, out int ledIndex)) return;
 
-        Ev60HighlightKeyboardButton(ledIndex, pressed);
+        // Physical-press highlight disabled (2026-07-17, user request): fired
+        // inconsistently across keys, same reasoning as Everest Max's
+        // EvHighlightKeyboardButton (MainWindow.Everest.cs).
+        // Ev60HighlightKeyboardButton(ledIndex, pressed);
 
         var key = Ev60KeyBindingPanel.ByLed(ledIndex);
         if (key is null) return;

--- a/K2.App/MainWindow.HwBusy.cs
+++ b/K2.App/MainWindow.HwBusy.cs
@@ -17,14 +17,19 @@ public partial class MainWindow
 
     /// <summary>Shows the blocking overlay with <paramref name="message"/> and forces an
     /// immediate render pass — otherwise WPF wouldn't paint it until the UI thread yields,
-    /// which never happens since the caller blocks it right after this call returns.</summary>
+    /// which never happens since the caller blocks it right after this call returns.
+    /// Pumping at <see cref="DispatcherPriority.Render"/> itself is NOT enough: that's the
+    /// same priority the layout/render pass is queued at, so the empty callback can run
+    /// interleaved with it instead of strictly after. <see cref="DispatcherPriority.Background"/>
+    /// is lower, so the dispatcher must drain everything above it — including the actual
+    /// frame render — before reaching this no-op.</summary>
     private void ShowHwBusy(string message)
     {
         TxtHwBusyMessage.Text = message;
         PnlHwBusy.Visibility = Visibility.Visible;
         _hwBusyPrevCursor = Mouse.OverrideCursor;
         Mouse.OverrideCursor = Cursors.Wait;
-        Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
+        Dispatcher.Invoke(() => { }, DispatcherPriority.Background);
     }
 
     private void HideHwBusy()

--- a/K2.App/MainWindow.Keys.cs
+++ b/K2.App/MainWindow.Keys.cs
@@ -125,8 +125,10 @@ public partial class MainWindow
         RebuildKeyGrid();
 
         LvMpKeys.ItemsSource = _mpMappedKeys;
+        LstMpProfile.ContextMenu = MpBuildProfileContextMenu();
+        BtnMpProfileMenu.ContextMenu = MpBuildProfileMenuNoEdit();
 
-        // CbProfile is populated by MpRefreshProfiles on device change
+        // LstMpProfile is populated by MpRefreshProfiles on device change
 
         LoadRotationFromStore();
 
@@ -145,6 +147,60 @@ public partial class MainWindow
         if (name == null) return;
         TabMacroPad.Header = name;
         _store.SetSetting("device.name", name);
+    }
+
+    /// <summary>Right-click menu for LstMpProfile rows — see DpBuildProfileContextMenu
+    /// (MainWindow.DisplayPad.cs) for the shared pattern/rationale.</summary>
+    private ContextMenu MpBuildProfileContextMenu()
+    {
+        var menu = new ContextMenu();
+        var miRename = new MenuItem { Header = Loc.Get("rename_profile") };
+        miRename.Click += BtnMpRenameProfile_Click;
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnMpImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnMpImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnMpExportProfiles_Click;
+        var miDelete = new MenuItem { Header = Loc.Get("delete_profile") };
+        miDelete.Click += BtnMpDeleteProfile_Click;
+        menu.Items.Add(miRename);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miDelete);
+        return menu;
+    }
+
+    /// <summary>Same items as <see cref="MpBuildProfileContextMenu"/> minus Rename/Delete —
+    /// opened from the small "…" button in the Profile header (BtnMpProfileMenu_Click),
+    /// which is not tied to a specific row so renaming/deleting a specific profile
+    /// wouldn't make sense there.</summary>
+    private ContextMenu MpBuildProfileMenuNoEdit()
+    {
+        var menu = new ContextMenu();
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnMpImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnMpImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnMpExportProfiles_Click;
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        return menu;
+    }
+
+    private void BtnMpProfileMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu is ContextMenu cm)
+        {
+            cm.PlacementTarget = btn;
+            cm.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            cm.IsOpen = true;
+        }
     }
 
     private void BtnMpRenameProfile_Click(object sender, RoutedEventArgs e)
@@ -185,7 +241,7 @@ public partial class MainWindow
         _store.SetSetting($"profile.{id}.{slot}.name", "");
         Log($"[UI ] MacroPad profile {slot} deleted.");
         MpRefreshProfiles(id);
-        // CbProfile_SelectionChanged will reload the key grid automatically
+        // LstMpProfile_SelectionChanged will reload the key grid automatically
     }
 
     /// <summary>Resets the currently selected profile's key actions back to K2's defaults
@@ -505,11 +561,11 @@ public partial class MainWindow
         ReloadCurrentProfile();
     }
 
-    private void CbProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void LstMpProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppressProfileUpdate) return;
         if (CurrentDeviceId() is not int id) return;
-        if (CbProfile.SelectedItem is not MpProfileItem pi) return;
+        if (LstMpProfile.SelectedItem is not MpProfileItem pi) return;
         int profile = pi.Slot;
 
         if (pi.IsNew)
@@ -546,12 +602,12 @@ public partial class MainWindow
             if (nextFree > 0)
                 items.Add(new MpProfileItem(nextFree, Loc.Get("new_profile")));
 
-            CbProfile.DisplayMemberPath = nameof(MpProfileItem.Label);
-            CbProfile.ItemsSource = items;
+            LstMpProfile.DisplayMemberPath = nameof(MpProfileItem.Label);
+            LstMpProfile.ItemsSource = items;
 
             int current = _store.GetCurrentProfile(deviceId);
             var match = items.Find(x => x.Slot == current && !x.IsNew);
-            CbProfile.SelectedItem = match ?? items[0];
+            LstMpProfile.SelectedItem = match ?? items[0];
         }
         finally { _suppressProfileUpdate = false; }
     }
@@ -562,8 +618,8 @@ public partial class MainWindow
         _suppressProfileUpdate = true;
         try
         {
-            if (CbProfile.ItemsSource is List<MpProfileItem> items)
-                CbProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
+            if (LstMpProfile.ItemsSource is List<MpProfileItem> items)
+                LstMpProfile.SelectedItem = items.Find(x => x.Slot == slot && !x.IsNew) ?? items[0];
         }
         finally { _suppressProfileUpdate = false; }
     }
@@ -696,6 +752,13 @@ public partial class MainWindow
             _store.ClearProfile(id, slot);
             int imported = 0;
 
+            // Existing K2 macro names, so "Run Macro" bindings resolve against the
+            // user's macro library — same pattern as the BC-db import below.
+            var macroNames = _macroStore?.GetAll()
+                .Select(m => m.Name)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToList();
+
             foreach (var b in bindings)
             {
                 if (!int.TryParse(b.Element("KeyId")?.Value, out int keyId) || keyId < 1 || keyId > 12) continue;
@@ -717,7 +780,7 @@ public partial class MainWindow
                 }
                 else
                 {
-                    (actionType, actionValue) = BaseCampDbImporter.TranslateMakaluAction(funcType, funcValue);
+                    (actionType, actionValue) = BaseCampDbImporter.TranslateMakaluAction(funcType, funcValue, macroNames);
                 }
 
                 if (actionType is null) continue;
@@ -750,7 +813,7 @@ public partial class MainWindow
         var profiles = _store.GetExistingProfiles(id)
             .Select(slot => (Slot: slot, Name: _store.GetProfileName(id, slot) ?? Loc.Get("profile_n", slot)))
             .ToList();
-        int? currentSlot = CbProfile.SelectedItem is MpProfileItem pi && !pi.IsNew ? pi.Slot : null;
+        int? currentSlot = LstMpProfile.SelectedItem is MpProfileItem pi && !pi.IsNew ? pi.Slot : null;
         string deviceLabel = _mpDeviceLabels.GetValueOrDefault((uint)id, $"MacroPad {id}");
 
         ExportProfileHelper.Run(
@@ -801,41 +864,66 @@ public partial class MainWindow
             return;
         }
 
-        // Auto-mapping: BC DeviceId == K2 SDK DeviceId
-        if (!bcDevices.TryGetValue(k2DeviceId, out var profiles) || profiles.Count == 0)
+        string deviceLabel = TabMacroPad.Header as string ?? Loc.Get("tab_macropad");
+
+        List<BaseCampDbImporter.BcProfile> profiles;
+        if (bcDevices.Count == 1)
         {
-            Log($"[IMP-BC] No BC profiles for device #{k2DeviceId}.");
-            LblStatus.Text = Loc.Get("dp_no_profiles_in_bc");
-            return;
+            profiles = bcDevices.Values.First();
+        }
+        else
+        {
+            // Ask which BC device to import from, instead of requiring an exact BC/K2
+            // DeviceId match (the old behavior silently skipped everything on a mismatch).
+            var options = bcDevices.Select(kv => (
+                BcDeviceId: kv.Key,
+                Label: Loc.Get("bc_pick_device_label", kv.Key, kv.Value.Count,
+                    string.Join(", ", kv.Value.Select(p => p.Name)))
+            )).ToList();
+            var picker = new BcDevicePickerDialog(deviceLabel, options) { Owner = this };
+            if (picker.ShowDialog() != true) return;
+            profiles = bcDevices[picker.SelectedBcDeviceId!.Value];
         }
 
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine($"Base Camp → K2 MacroPad import (device #{k2DeviceId}):\n");
+        sb.AppendLine($"Import {profiles.Count} profile(s) into \"{deviceLabel}\"?\n");
         foreach (var p in profiles)
-            sb.AppendLine($"  Slot {p.Slot}: {p.Name}{(p.IsSelected ? " [ACTIVE]" : "")}");
-        sb.AppendLine($"\nImport {profiles.Count} profile(s)?");
+            sb.AppendLine($"  {(p.IsSelected ? "[ACTIVE] " : "")}{p.Name}");
+        sb.AppendLine();
+        sb.AppendLine(Loc.Get("bc_import_will_wipe", deviceLabel));
 
         if (MessageBox.Show(this, sb.ToString(), "Import from Base Camp",
-                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
             return;
 
+        // Wipe: replace, don't append.
+        foreach (var slot in _store.GetExistingProfiles(k2DeviceId))
+        {
+            _store.ClearProfile(k2DeviceId, slot);
+            _store.SetSetting($"profile.{k2DeviceId}.{slot}.name", "");
+        }
+
         int totalKeys = 0;
-        int activeSlot = -1;
-        int skippedNoSlot = 0;
-        var usedSlots = new HashSet<int>(_store.GetExistingProfiles(k2DeviceId));
+        var usedSlots = new HashSet<int>();
+
+        // Existing K2 macro names, so "Run Macro" bindings resolve against the user's
+        // macro library — same pattern as the DisplayPad/Everest/Everest60 BC imports.
+        var macroNames = _macroStore?.GetAll()
+            .Select(m => m.Name)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
 
         foreach (var profile in profiles)
         {
             try
             {
                 int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
-                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                if (targetSlot == 0) continue; // sanity ceiling only (5 real firmware slots)
                 usedSlots.Add(targetSlot);
 
-                int n = BaseCampDbImporter.ImportMacroPadProfile(dbPath, profile, k2DeviceId, _store, targetSlot);
+                int n = BaseCampDbImporter.ImportMacroPadProfile(dbPath, profile, k2DeviceId, _store, targetSlot, macroNames);
                 totalKeys += n;
                 Log($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: {n} keys");
-                if (profile.IsSelected) activeSlot = targetSlot;
             }
             catch (Exception ex)
             {
@@ -843,14 +931,12 @@ public partial class MainWindow
             }
         }
 
-        if (skippedNoSlot > 0)
-            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
-                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
-
-        // Switch to active BC profile and reload UI
-        int slotToShow = activeSlot > 0 ? activeSlot : CurrentProfile();
+        // Always land on the FIRST imported profile and force a reload — simpler and
+        // safer than trying to restore whatever was active in Base Camp (user request:
+        // a plain, predictable refresh after import beats guessing at BC's own state).
+        int slotToShow = usedSlots.DefaultIfEmpty(0).Min();
         MpRefreshProfiles(k2DeviceId);
-        MpSelectProfileSlot(slotToShow);
+        if (slotToShow > 0) MpSelectProfileSlot(slotToShow);
         ReloadCurrentProfile();
 
         Log($"[IMP-BC] Done: {totalKeys} keys across {profiles.Count} profiles");
@@ -883,7 +969,7 @@ public partial class MainWindow
 
     /// <summary>Currently selected profile for editing (1..5).</summary>
     private int CurrentProfile()
-        => CbProfile.SelectedItem is MpProfileItem pi ? pi.Slot : 1;
+        => LstMpProfile.SelectedItem is MpProfileItem pi ? pi.Slot : 1;
 
     // ================================================================
     // Profile switching (called by IActionHost.SwitchProfile when

--- a/K2.App/MainWindow.Makalu.cs
+++ b/K2.App/MainWindow.Makalu.cs
@@ -56,6 +56,8 @@ public partial class MainWindow
         BuildMkHotspots();
         InitMkSectionNav();
 
+        LstMkProfile.ContextMenu = MkBuildProfileContextMenu();
+        BtnMkProfileMenu.ContextMenu = MkBuildProfileMenuNoEdit();
         MkRefreshProfiles();
         MkReloadProfile(MkCurrentProfile());
 
@@ -72,7 +74,7 @@ public partial class MainWindow
     // device), persisted in MakaluStore. Switching means re-sending the
     // stored lighting/DPI/remap/settings to the device — see
     // MakaluRgbSettingsPanel.MkReloadProfile / MakaluDpiRemapPanel.MkReloadRemap.
-    // Mirrors CbEvProfile_SelectionChanged/EvRefreshProfiles/EvSelectProfileSlot
+    // Mirrors LstEvProfile_SelectionChanged/EvRefreshProfiles/EvSelectProfileSlot
     // in MainWindow.Everest.cs.
     // ------------------------------------------------------------
 
@@ -82,7 +84,7 @@ public partial class MainWindow
     }
 
     private int MkCurrentProfile()
-        => CbMkProfile.SelectedItem is MkProfileItem pi ? pi.Slot : 1;
+        => LstMkProfile.SelectedItem is MkProfileItem pi ? pi.Slot : 1;
 
     private void MkRefreshProfiles()
     {
@@ -92,11 +94,11 @@ public partial class MainWindow
             var items = Enumerable.Range(1, 5)
                 .Select(s => new MkProfileItem(s, _mkStore.GetProfileName(s) ?? Loc.Get("profile_n", s)))
                 .ToList();
-            CbMkProfile.DisplayMemberPath = nameof(MkProfileItem.Label);
-            CbMkProfile.ItemsSource = items;
+            LstMkProfile.DisplayMemberPath = nameof(MkProfileItem.Label);
+            LstMkProfile.ItemsSource = items;
 
             int current = _mkStore.GetCurrentProfile();
-            CbMkProfile.SelectedItem = items.Find(x => x.Slot == current) ?? items[0];
+            LstMkProfile.SelectedItem = items.Find(x => x.Slot == current) ?? items[0];
         }
         finally { _mkSuppressProfile = false; }
     }
@@ -106,8 +108,8 @@ public partial class MainWindow
         _mkSuppressProfile = true;
         try
         {
-            if (CbMkProfile.ItemsSource is List<MkProfileItem> items)
-                CbMkProfile.SelectedItem = items.Find(x => x.Slot == slot) ?? items[0];
+            if (LstMkProfile.ItemsSource is List<MkProfileItem> items)
+                LstMkProfile.SelectedItem = items.Find(x => x.Slot == slot) ?? items[0];
         }
         finally { _mkSuppressProfile = false; }
     }
@@ -120,13 +122,67 @@ public partial class MainWindow
         MkDpiRemap.MkReloadRemap(slot);
     }
 
-    private void CbMkProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    private void LstMkProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_mkSuppressProfile) return;
-        if (CbMkProfile.SelectedItem is not MkProfileItem pi) return;
+        if (LstMkProfile.SelectedItem is not MkProfileItem pi) return;
         _mkStore.SetCurrentProfile(pi.Slot);
         LogMakalu($"[UI ] Makalu profile selected: {pi.Slot}");
         MkReloadProfile(pi.Slot);
+    }
+
+    /// <summary>Right-click menu for LstMkProfile rows — see DpBuildProfileContextMenu
+    /// (MainWindow.DisplayPad.cs) for the shared pattern/rationale.</summary>
+    private ContextMenu MkBuildProfileContextMenu()
+    {
+        var menu = new ContextMenu();
+        var miRename = new MenuItem { Header = Loc.Get("rename_profile") };
+        miRename.Click += BtnMkRenameProfile_Click;
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnMkImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnMkImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnMkExportProfiles_Click;
+        var miDelete = new MenuItem { Header = Loc.Get("delete_profile") };
+        miDelete.Click += BtnMkDeleteProfile_Click;
+        menu.Items.Add(miRename);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        menu.Items.Add(new Separator());
+        menu.Items.Add(miDelete);
+        return menu;
+    }
+
+    /// <summary>Same items as <see cref="MkBuildProfileContextMenu"/> minus Rename/Delete —
+    /// opened from the small "…" button in the Profile header (BtnMkProfileMenu_Click),
+    /// which is not tied to a specific row so renaming/deleting a specific profile
+    /// wouldn't make sense there.</summary>
+    private ContextMenu MkBuildProfileMenuNoEdit()
+    {
+        var menu = new ContextMenu();
+        var miImportXml = new MenuItem { Header = Loc.Get("dp_import_xml") };
+        miImportXml.Click += BtnMkImportXml_Click;
+        var miImportBc = new MenuItem { Header = Loc.Get("import_bc") };
+        miImportBc.Click += BtnMkImportBc_Click;
+        var miExport = new MenuItem { Header = Loc.Get("export_profiles_btn") };
+        miExport.Click += BtnMkExportProfiles_Click;
+        menu.Items.Add(miImportXml);
+        menu.Items.Add(miImportBc);
+        menu.Items.Add(miExport);
+        return menu;
+    }
+
+    private void BtnMkProfileMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button btn && btn.ContextMenu is ContextMenu cm)
+        {
+            cm.PlacementTarget = btn;
+            cm.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            cm.IsOpen = true;
+        }
     }
 
     private void BtnMkRenameProfile_Click(object sender, RoutedEventArgs e)
@@ -209,45 +265,64 @@ public partial class MainWindow
             return;
         }
 
-        var allProfiles = bcDevices.Values.SelectMany(x => x).OrderBy(p => p.Slot).ToList();
+        string deviceLabel = AppSettings.MakaluDeviceName ?? (TabMakalu.Header as string) ?? Loc.Get("tab_makalu");
+
+        List<BaseCampDbImporter.BcProfile> allProfiles;
+        if (bcDevices.Count == 1)
+        {
+            allProfiles = bcDevices.Values.First().OrderBy(p => p.Slot).ToList();
+        }
+        else
+        {
+            var options = bcDevices.Select(kv => (
+                BcDeviceId: kv.Key,
+                Label: Loc.Get("bc_pick_device_label", kv.Key, kv.Value.Count,
+                    string.Join(", ", kv.Value.Select(p => p.Name)))
+            )).ToList();
+            var picker = new BcDevicePickerDialog(deviceLabel, options) { Owner = this };
+            if (picker.ShowDialog() != true) return;
+            allProfiles = bcDevices[picker.SelectedBcDeviceId!.Value].OrderBy(p => p.Slot).ToList();
+        }
 
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("Base Camp -> K2 Makalu import:\n");
+        sb.AppendLine($"Import {allProfiles.Count} profile(s) into \"{deviceLabel}\"?\n");
         foreach (var p in allProfiles)
-            sb.AppendLine($"  Slot {p.Slot}: {p.Name}{(p.IsSelected ? " [ACTIVE]" : "")}");
-        sb.AppendLine($"\nImport {allProfiles.Count} profile(s)?");
+            sb.AppendLine($"  {(p.IsSelected ? "[ACTIVE] " : "")}{p.Name}");
+        sb.AppendLine();
+        sb.AppendLine(Loc.Get("bc_import_will_wipe", deviceLabel));
 
         if (MessageBox.Show(this, sb.ToString(), "Import from Base Camp",
-                MessageBoxButton.YesNo, MessageBoxImage.Question) != MessageBoxResult.Yes)
+                MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
             return;
 
+        // Wipe: replace, don't append. Makalu always has 5 fixed K2-side slots (no
+        // firmware profile concept — see the "Profile management" doc comment above).
+        for (int slot = 1; slot <= 5; slot++)
+            _mkStore.ClearProfile(slot);
+
         int totalRemap = 0;
-        int activeSlot = -1;
-        int skippedNoSlot = 0;
-        var usedSlots = new HashSet<int>(_mkStore.GetExistingProfiles());
+        var usedSlots = new HashSet<int>();
         foreach (var profile in allProfiles)
         {
             try
             {
                 int targetSlot = BaseCampDbImporter.FindFreeSlot(usedSlots);
-                if (targetSlot == 0) { skippedNoSlot++; continue; }
+                if (targetSlot == 0) continue; // sanity ceiling only (5 fixed slots)
                 usedSlots.Add(targetSlot);
 
                 var (remap, lighting, settings) = BaseCampDbImporter.ImportMakaluProfile(dbPath, profile, _mkStore, targetSlot);
                 totalRemap += remap;
-                if (profile.IsSelected) activeSlot = targetSlot;
                 LogMakalu($"[IMP-BC] slot {profile.Slot} '{profile.Name}' -> K2 slot {targetSlot}: remap={remap} lighting={lighting} settings={settings}");
             }
             catch (Exception ex) { LogMakalu($"[IMP-BC] slot {profile.Slot} error: {ex.Message}"); }
         }
 
-        if (skippedNoSlot > 0)
-            MessageBox.Show(this, Loc.Get("import_some_skipped_no_slot", skippedNoSlot),
-                "Import from Base Camp", MessageBoxButton.OK, MessageBoxImage.Warning);
-
-        if (activeSlot > 0) _mkStore.SetCurrentProfile(activeSlot);
+        // Always land on the FIRST imported profile and force a reload — simpler and
+        // safer than trying to restore whatever was active in Base Camp (user request:
+        // a plain, predictable refresh after import beats guessing at BC's own state).
+        int finalSlot = usedSlots.DefaultIfEmpty(1).Min();
+        _mkStore.SetCurrentProfile(finalSlot);
         MkRefreshProfiles();
-        int finalSlot = activeSlot > 0 ? activeSlot : MkCurrentProfile();
         MkSelectProfileSlot(finalSlot);
         MkReloadProfile(finalSlot);
         LogMakalu(Loc.Get("mk_imported_bc", allProfiles.Count, totalRemap));
@@ -362,7 +437,7 @@ public partial class MainWindow
         var profiles = Enumerable.Range(1, 5)
             .Select(slot => (Slot: slot, Name: _mkStore.GetProfileName(slot) ?? Loc.Get("profile_n", slot)))
             .ToList();
-        int? currentSlot = CbMkProfile.SelectedItem is MkProfileItem pi ? pi.Slot : null;
+        int? currentSlot = LstMkProfile.SelectedItem is MkProfileItem pi ? pi.Slot : null;
 
         ExportProfileHelper.Run(
             owner: this,

--- a/K2.App/MainWindow.Settings.cs
+++ b/K2.App/MainWindow.Settings.cs
@@ -56,11 +56,92 @@ public partial class MainWindow
             MessageBoxButton.YesNo, MessageBoxImage.Question);
         if (res != MessageBoxResult.Yes) return;
 
+        // Macros FIRST, before any device's key bindings: a "Default" FunctionType binding
+        // (BaseCampDbImporter.TranslateDefaultAction) is matched by name against the K2 macro
+        // library at import time — if the library is still empty because this cascade never
+        // imported macros, every named-macro reference lands unresolved (red "action not
+        // found" triangle) even though the same-named macro exists right there in BaseCamp.db.
+        // Reuses the same button handler (and its own confirm/count dialogs) as the standalone
+        // "Import from BaseCamp" button on the Macro tab — same pattern every device below
+        // already follows (each shows its own confirmation in this cascade).
+        BtnMacroImportBC_Click(this, new RoutedEventArgs());
+
         BtnEvImportBc_Click(this, new RoutedEventArgs());
         BtnEv60ImportBc_Click(this, new RoutedEventArgs());
         BtnMkImportBc_Click(this, new RoutedEventArgs());
         BtnMpImportBc_Click(this, new RoutedEventArgs());
-        BtnDpImportBc_Click(this, new RoutedEventArgs());
+        // DisplayPad supports multiple simultaneous physical devices — repeat the
+        // per-device import (incl. the Base Camp device picker, when needed) once per
+        // connected pad instead of the single-tab BtnDpImportBc_Click.
+        DpImportBcForAllDevices();
+    }
+
+    /// <summary>Loads the persisted "Base Camp DLL folder" (see
+    /// <see cref="AppSettings.BaseCampDllFolder"/>) into the picker, mirrors the
+    /// installer's "detected install vs. manual folder" radio choice (see
+    /// K2Setup.iss's BcPage), and refreshes the found/missing status of the three
+    /// non-redistributable Base Camp native DLLs (MacroPadSDK.dll, SDKDLL.dll,
+    /// Everest360_USB.dll — see <see cref="NativeDependencyResolver"/>). Called once
+    /// from InitAppSettingsPanel and again after the user changes the radio or
+    /// browses the folder.</summary>
+    private void InitBcDllFolderPanel()
+    {
+        if (_bcDllPanelUpdating) return; // re-entrancy guard: setting IsChecked below fires RbBcDllMode_Checked
+        _bcDllPanelUpdating = true;
+        try
+        {
+            string? detected = NativeDependencyResolver.BaseCampDirectories().FirstOrDefault();
+            RbBcDllAuto.IsEnabled = detected is not null;
+            TxtBcDetected.Text = detected ?? Loc.Get("settings_bc_dll_radio_auto_notfound");
+
+            // Manual mode whenever the user has an explicit override saved, or nothing
+            // was auto-detected to fall back on (same default as the installer's page).
+            bool manual = !string.IsNullOrWhiteSpace(AppSettings.BaseCampDllFolder) || detected is null;
+            RbBcDllManual.IsChecked = manual;
+            RbBcDllAuto.IsChecked = !manual;
+            TxtBcDllFolder.IsEnabled = manual;
+            BtnBcDllFolderBrowse.IsEnabled = manual;
+
+            TxtBcDllFolder.Text = AppSettings.BaseCampDllFolder ?? Loc.Get("settings_bc_dll_none");
+            RefreshBcDllStatus();
+        }
+        finally
+        {
+            _bcDllPanelUpdating = false;
+        }
+    }
+
+    private bool _bcDllPanelUpdating;
+
+    private void RefreshBcDllStatus()
+    {
+        var parts = NativeDependencyResolver.BaseCampNativeDlls.Select(dll =>
+            $"{dll}: {(NativeDependencyResolver.IsResolvable(dll) ? Loc.Get("settings_bc_dll_found") : Loc.Get("settings_bc_dll_missing"))}");
+        TxtBcDllStatus.Text = string.Join("   ", parts);
+    }
+
+    /// <summary>Fires when either "Base Camp DLL folder" radio is checked. Switching to
+    /// auto-detect clears any saved manual override so <see cref="NativeDependencyResolver"/>
+    /// falls back to its own detection; switching to manual just unlocks the folder
+    /// picker below (the folder itself is only saved once the user browses to one).</summary>
+    private void RbBcDllMode_Checked(object sender, RoutedEventArgs e)
+    {
+        if (RbBcDllAuto.IsChecked == true)
+            AppSettings.SetBaseCampDllFolder(null);
+        InitBcDllFolderPanel();
+    }
+
+    /// <summary>"Browse…" in the "Base Camp DLL folder" group — lets the user point K2
+    /// at a folder containing the Base Camp native DLLs (e.g. copied from another PC or
+    /// extracted from the Base Camp installer) without installing Base Camp itself or
+    /// setting the K2_BASECAMP_DIR environment variable by hand.</summary>
+    private void BtnBcDllFolderBrowse_Click(object sender, RoutedEventArgs e)
+    {
+        var folder = new Microsoft.Win32.OpenFolderDialog { Title = Loc.Get("settings_bc_dll_browse") };
+        if (folder.ShowDialog(this) != true) return;
+
+        AppSettings.SetBaseCampDllFolder(folder.FolderName);
+        InitBcDllFolderPanel();
     }
 
     /// <summary>Loads persisted AppSettings into the Settings tab UI and applies
@@ -70,7 +151,6 @@ public partial class MainWindow
     {
         bool debug = AppSettings.DebugMode;
         CkAppDebugMode.IsChecked = debug;
-        PnlDebugNativeEngines.Visibility = debug ? Visibility.Visible : Visibility.Collapsed;
 
         switch (AppSettings.LogLevel)
         {
@@ -79,12 +159,12 @@ public partial class MainWindow
             default:                 RbLogNormal.IsChecked  = true; break;
         }
 
-        CkDpNativeEngine.IsChecked = AppSettings.DisplayPadNativeEngine;
-        CkEvNativeEngine.IsChecked = AppSettings.EverestNativeEngine;
         CkAutoStopBaseCamp.IsChecked = AppSettings.AutoStopBaseCamp;
         CkKillBcWorker.IsChecked = AppSettings.KillBaseCampWorker;
         CkRestartBcOnClose.IsChecked = AppSettings.RestartBaseCampOnClose;
         InitBcAutostartCheckbox();
+
+        InitBcDllFolderPanel();
 
         CkCloseToTray.IsChecked = AppSettings.CloseToTray;
         CkStartMinToTray.IsChecked = AppSettings.StartMinimizedToTray;
@@ -216,27 +296,11 @@ public partial class MainWindow
         InitBcAutostartCheckbox();
     }
 
-    /// <summary>Persists the DisplayPad native-engine flag. The backend is chosen when
-    /// MainWindow is constructed (see _dpClient initializer), so this takes effect at
-    /// the next app start — the hint text under the checkbox says so.</summary>
-    private void CkDpNativeEngine_Click(object sender, RoutedEventArgs e)
-    {
-        AppSettings.SetDisplayPadNativeEngine(CkDpNativeEngine.IsChecked == true);
-    }
-
-    /// <summary>Persists the Everest native-engine flag (Phase 1: connectivity + numpad
-    /// D1-D4 buttons only — see EverestService._nativePad). Takes effect at next start.</summary>
-    private void CkEvNativeEngine_Click(object sender, RoutedEventArgs e)
-    {
-        AppSettings.SetEverestNativeEngine(CkEvNativeEngine.IsChecked == true);
-    }
-
     private void CkAppDebugMode_Click(object sender, RoutedEventArgs e)
     {
         bool debug = CkAppDebugMode.IsChecked == true;
         AppSettings.SetDebugMode(debug);
         ApplyDebugModeToAllDevices(debug);
-        PnlDebugNativeEngines.Visibility = debug ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void RbLogLevel_Checked(object sender, RoutedEventArgs e)

--- a/K2.App/MainWindow.xaml
+++ b/K2.App/MainWindow.xaml
@@ -310,6 +310,12 @@
                             <DataTrigger Binding="{Binding HasImageNoAction}" Value="True">
                                 <Setter TargetName="WarnTriangle" Property="Visibility" Value="Visible"/>
                             </DataTrigger>
+                            <!-- Imported "Play macro" action with no macro matched by name
+                                 (BaseCampDbImporter.TranslateDefaultAction) — same "action not
+                                 found" warning triangle as an image without an action. -->
+                            <DataTrigger Binding="{Binding HasUnresolvedAction}" Value="True">
+                                <Setter TargetName="WarnTriangle" Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>
@@ -415,6 +421,64 @@
             <Setter Property="Margin" Value="0,0,0,6"/>
             <Setter Property="HorizontalAlignment" Value="Left"/>
         </Style>
+
+        <!-- Profile picker: replaces K2SideActionCombo for the per-device profile
+             selector (see MainWindow.{Device}.cs's Refresh...Profiles methods) — an
+             always-visible list (no hidden dropdown) instead of a ComboBox, so more
+             than a handful of profiles (DisplayPad has no hard cap) stay browsable.
+             Same Width as every other sidebar control so the column doesn't resize. -->
+        <Style x:Key="K2SideProfileItemStyle" TargetType="ListBoxItem">
+            <Setter Property="Foreground" Value="#9A9AA2"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Padding" Value="8,7"/>
+            <Setter Property="Margin" Value="0,1"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <EventSetter Event="PreviewMouseRightButtonDown" Handler="ProfileItem_PreviewRightClick"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBoxItem">
+                        <Border x:Name="Bd" Background="{TemplateBinding Background}"
+                                BorderThickness="3,0,0,0" BorderBrush="Transparent"
+                                CornerRadius="4" Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#1E1E26"/>
+                                <Setter Property="Foreground" Value="#DCDCE0"/>
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource K2AccentBrush}"/>
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource K2AccentBrush}"/>
+                                <Setter Property="Foreground" Value="{StaticResource K2AccentTextBrush}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="K2SideProfileList" TargetType="ListBox">
+            <Setter Property="Width" Value="190"/>
+            <Setter Property="Height" Value="150"/>
+            <Setter Property="Margin" Value="0,0,0,6"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="Background" Value="#111115"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="ItemContainerStyle" Value="{StaticResource K2SideProfileItemStyle}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBox">
+                        <Border Background="{TemplateBinding Background}" CornerRadius="6" Padding="4">
+                            <ScrollViewer Background="Transparent" CanContentScroll="False">
+                                <ItemsPresenter/>
+                            </ScrollViewer>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <Style x:Key="K2SideGroupHeader" TargetType="TextBlock">
             <Setter Property="FontSize" Value="9"/>
             <Setter Property="FontWeight" Value="Bold"/>
@@ -1197,7 +1261,7 @@
                                                         </StackPanel>
                                                     </WrapPanel>
 
-                                                    <TextBlock Text="{loc:Get dial_screensaver_section}" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                                    <TextBlock Text="{loc:Get dial_screensaver_section}" FontWeight="SemiBold" Margin="0,-10,0,8"/>
                                                     <Grid Margin="0,0,0,12">
                                                         <Grid.ColumnDefinitions>
                                                             <!-- Fixed-width label column so both rows' entries share the same left edge -->
@@ -1216,7 +1280,9 @@
                                                                   Content="{loc:Get dial_screensaver}" VerticalAlignment="Center"
                                                                   ToolTip="{loc:Get dial_screensaver_enable_tip}"
                                                                   Click="CkDialScreenSaverEnable_Click"/>
-                                                        <TextBox  Grid.Row="0" Grid.Column="1" x:Name="TxtDialScreenSaver" Margin="0,0,6,0"
+                                                        <TextBox  Grid.Row="0" Grid.Column="1" x:Name="TxtDialScreenSaver" Width="48" Height="30"
+                                                                  Margin="0,0,6,0" Padding="4,0" VerticalContentAlignment="Center"
+                                                                  VerticalAlignment="Center" HorizontalAlignment="Left"
                                                                   TextChanged="TxtDialScreenSaver_TextChanged"/>
                                                         <TextBlock Grid.Row="0" Grid.Column="2" Text="{loc:Get unit_seconds}" VerticalAlignment="Center"/>
                                                         <TextBlock Grid.Row="0" Grid.Column="3" Text="{loc:Get dial_screensaver_function_label}"
@@ -1240,13 +1306,15 @@
                                                         </StackPanel>
 
                                                         <CheckBox Grid.Row="1" Grid.Column="0" x:Name="CkDialTurnOffEnable"
-                                                                  Content="{loc:Get dial_autooff}" VerticalAlignment="Center" Margin="0,8,0,0"
+                                                                  Content="{loc:Get dial_autooff}" VerticalAlignment="Center" Margin="0,-7,0,0"
                                                                   ToolTip="{loc:Get dial_turnoff_enable_tip}"
                                                                   Click="CkDialTurnOffEnable_Click"/>
-                                                        <TextBox  Grid.Row="1" Grid.Column="1" x:Name="TxtDialTurnOff" Margin="0,8,6,0"
+                                                        <TextBox  Grid.Row="1" Grid.Column="1" x:Name="TxtDialTurnOff" Width="48" Height="30"
+                                                                  Margin="0,-7,6,0" Padding="4,0" VerticalContentAlignment="Center"
+                                                                  VerticalAlignment="Center" HorizontalAlignment="Left"
                                                                   TextChanged="TxtDialTurnOff_TextChanged"/>
                                                         <TextBlock Grid.Row="1" Grid.Column="2" Text="{loc:Get unit_seconds}"
-                                                                   VerticalAlignment="Center" Margin="0,8,0,0"/>
+                                                                   VerticalAlignment="Center" Margin="0,-7,0,0"/>
                                                     </Grid>
                                                 </StackPanel>
                                             </Grid>
@@ -1424,30 +1492,19 @@
                         <Border Grid.Column="2" Background="#111115" CornerRadius="6"
                                 Margin="8,0,0,0" Padding="10" VerticalAlignment="Top">
                             <StackPanel>
-                                <TextBlock Text="{loc:Get profile}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <ComboBox x:Name="CbEvProfile" Style="{StaticResource K2SideActionCombo}"
-                                          SelectionChanged="CbEvProfile_SelectionChanged"/>
-                                <Button x:Name="BtnEvRenameProfile" Content="{loc:Get rename_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8D3;"
-                                        Click="BtnEvRenameProfile_Click"/>
-                                <Button x:Name="BtnEvDeleteProfile" Content="{loc:Get delete_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE74D;"
-                                        Click="BtnEvDeleteProfile_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get import}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnEvImportXml" Content="{loc:Get dp_import_xml}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8E5;"
-                                        Click="BtnEvImportXml_Click"/>
-                                <Button x:Name="BtnEvImportBc" Content="{loc:Get import_bc}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8B5;"
-                                        Click="BtnEvImportBc_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get export}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnEvExportProfiles" Content="{loc:Get export_profiles_btn}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE896;"
-                                        Click="BtnEvExportProfiles_Click"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Get profile}"
+                                               Style="{StaticResource K2SideGroupHeader}" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="1" x:Name="BtnEvProfileMenu"
+                                            Style="{StaticResource MacroRowIconButton}" Tag="&#xE712;"
+                                            ToolTip="{loc:Get profile}" Click="BtnEvProfileMenu_Click"/>
+                                </Grid>
+                                <ListBox x:Name="LstEvProfile" Style="{StaticResource K2SideProfileList}"
+                                         SelectionChanged="LstEvProfile_SelectionChanged"/>
 
                                 <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
                                 <TextBlock Text="{loc:Get device}" Style="{StaticResource K2SideGroupHeader}"/>
@@ -1694,34 +1751,23 @@
 
                         <!-- RIGHT: generic settings — Profile/Import/Export now backed by
                              Everest60Store (see MainWindow.Everest60.cs), same pattern as
-                             Everest Max's CbEvProfile block. Device rename via AppSettings unchanged. -->
+                             Everest Max's LstEvProfile block. Device rename via AppSettings unchanged. -->
                         <Border Grid.Column="2" Background="#111115" CornerRadius="6"
                                 Margin="8,0,0,0" Padding="10" VerticalAlignment="Top">
                             <StackPanel>
-                                <TextBlock Text="{loc:Get profile}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <ComboBox x:Name="CbEv60Profile" Style="{StaticResource K2SideActionCombo}"
-                                          SelectionChanged="CbEv60Profile_SelectionChanged"/>
-                                <Button x:Name="BtnEv60RenameProfile" Content="{loc:Get rename_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8D3;"
-                                        Click="BtnEv60RenameProfile_Click"/>
-                                <Button x:Name="BtnEv60DeleteProfile" Content="{loc:Get delete_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE74D;"
-                                        Click="BtnEv60DeleteProfile_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get import}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnEv60ImportXml" Content="{loc:Get dp_import_xml}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8E5;"
-                                        Click="BtnEv60ImportXml_Click"/>
-                                <Button x:Name="BtnEv60ImportBc" Content="{loc:Get import_bc}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8B5;"
-                                        Click="BtnEv60ImportBc_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get export}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnEv60ExportProfiles" Content="{loc:Get export_profiles_btn}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE896;"
-                                        Click="BtnEv60ExportProfiles_Click"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Get profile}"
+                                               Style="{StaticResource K2SideGroupHeader}" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="1" x:Name="BtnEv60ProfileMenu"
+                                            Style="{StaticResource MacroRowIconButton}" Tag="&#xE712;"
+                                            ToolTip="{loc:Get profile}" Click="BtnEv60ProfileMenu_Click"/>
+                                </Grid>
+                                <ListBox x:Name="LstEv60Profile" Style="{StaticResource K2SideProfileList}"
+                                         SelectionChanged="LstEv60Profile_SelectionChanged"/>
 
                                 <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
                                 <TextBlock Text="{loc:Get device}" Style="{StaticResource K2SideGroupHeader}"/>
@@ -1895,34 +1941,23 @@
 
                         <!-- RIGHT: generic settings — Profile/Import/Export now backed by
                              MakaluStore (see MainWindow.Makalu.cs), same pattern as Everest Max's
-                             CbEvProfile block. Device rename via AppSettings unchanged. -->
+                             LstEvProfile block. Device rename via AppSettings unchanged. -->
                         <Border Grid.Column="2" Background="#111115" CornerRadius="6"
                                 Margin="8,0,0,0" Padding="10" VerticalAlignment="Top">
                             <StackPanel>
-                                <TextBlock Text="{loc:Get profile}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <ComboBox x:Name="CbMkProfile" Style="{StaticResource K2SideActionCombo}"
-                                          SelectionChanged="CbMkProfile_SelectionChanged"/>
-                                <Button x:Name="BtnMkRenameProfile" Content="{loc:Get rename_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8D3;"
-                                        Click="BtnMkRenameProfile_Click"/>
-                                <Button x:Name="BtnMkDeleteProfile" Content="{loc:Get delete_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE74D;"
-                                        Click="BtnMkDeleteProfile_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get import}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnMkImportXml" Content="{loc:Get dp_import_xml}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8E5;"
-                                        Click="BtnMkImportXml_Click"/>
-                                <Button x:Name="BtnMkImportBc" Content="{loc:Get import_bc}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8B5;"
-                                        Click="BtnMkImportBc_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get export}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnMkExportProfiles" Content="{loc:Get export_profiles_btn}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE896;"
-                                        Click="BtnMkExportProfiles_Click"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Get profile}"
+                                               Style="{StaticResource K2SideGroupHeader}" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="1" x:Name="BtnMkProfileMenu"
+                                            Style="{StaticResource MacroRowIconButton}" Tag="&#xE712;"
+                                            ToolTip="{loc:Get profile}" Click="BtnMkProfileMenu_Click"/>
+                                </Grid>
+                                <ListBox x:Name="LstMkProfile" Style="{StaticResource K2SideProfileList}"
+                                         SelectionChanged="LstMkProfile_SelectionChanged"/>
 
                                 <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
                                 <TextBlock Text="{loc:Get device}" Style="{StaticResource K2SideGroupHeader}"/>
@@ -2239,30 +2274,19 @@
                         <Border Grid.Column="2" Background="#111115" CornerRadius="6"
                                 Margin="8,0,0,0" Padding="10" VerticalAlignment="Top">
                             <StackPanel>
-                                <TextBlock Text="{loc:Get profile}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <ComboBox x:Name="CbProfile" Style="{StaticResource K2SideActionCombo}"
-                                          SelectionChanged="CbProfile_SelectionChanged"/>
-                                <Button x:Name="BtnMpRenameProfile" Content="{loc:Get rename_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8D3;"
-                                        Click="BtnMpRenameProfile_Click"/>
-                                <Button x:Name="BtnMpDeleteProfile" Content="{loc:Get delete_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE74D;"
-                                        Click="BtnMpDeleteProfile_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get import}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnMpImportXml" Content="{loc:Get dp_import_xml}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8E5;"
-                                        Click="BtnMpImportXml_Click"/>
-                                <Button x:Name="BtnMpImportBc" Content="{loc:Get import_bc}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8B5;"
-                                        Click="BtnMpImportBc_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get export}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnMpExportProfiles" Content="{loc:Get export_profiles_btn}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE896;"
-                                        Click="BtnMpExportProfiles_Click"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Get profile}"
+                                               Style="{StaticResource K2SideGroupHeader}" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="1" x:Name="BtnMpProfileMenu"
+                                            Style="{StaticResource MacroRowIconButton}" Tag="&#xE712;"
+                                            ToolTip="{loc:Get profile}" Click="BtnMpProfileMenu_Click"/>
+                                </Grid>
+                                <ListBox x:Name="LstMpProfile" Style="{StaticResource K2SideProfileList}"
+                                         SelectionChanged="LstMpProfile_SelectionChanged"/>
 
                                 <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
                                 <TextBlock Text="{loc:Get device}" Style="{StaticResource K2SideGroupHeader}"/>
@@ -2543,15 +2567,19 @@
                         <Border Grid.Column="2" Background="#111115" CornerRadius="6"
                                 Margin="8,0,0,0" Padding="10" VerticalAlignment="Top">
                             <StackPanel>
-                                <TextBlock Text="{loc:Get profile}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <ComboBox x:Name="CbDpProfile" Style="{StaticResource K2SideActionCombo}"
-                                          SelectionChanged="CbDpProfile_SelectionChanged"/>
-                                <Button x:Name="BtnDpRenameProfile" Content="{loc:Get rename_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8D3;"
-                                        Click="BtnDpRenameProfile_Click"/>
-                                <Button x:Name="BtnDpDeleteProfile" Content="{loc:Get delete_profile}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE74D;"
-                                        Click="BtnDpDeleteProfile_Click"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Get profile}"
+                                               Style="{StaticResource K2SideGroupHeader}" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="1" x:Name="BtnDpProfileMenu"
+                                            Style="{StaticResource MacroRowIconButton}" Tag="&#xE712;"
+                                            ToolTip="{loc:Get profile}" Click="BtnDpProfileMenu_Click"/>
+                                </Grid>
+                                <ListBox x:Name="LstDpProfile" Style="{StaticResource K2SideProfileList}"
+                                         SelectionChanged="LstDpProfile_SelectionChanged"/>
 
                                 <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
                                 <TextBlock Text="{loc:Get dp_fullscreen_group}" Style="{StaticResource K2SideGroupHeader}"/>
@@ -2561,21 +2589,6 @@
                                 <Button x:Name="BtnDpFullscreenClear" Content="{loc:Get dp_fullscreen_clear}"
                                         Style="{StaticResource K2SideActionButton}" Tag="&#xE74D;"
                                         Click="BtnDpFullscreenClear_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get import}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnDpImportXml" Content="{loc:Get dp_import_xml}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE8E5;"
-                                        Click="BtnDpImportXml_Click"/>
-                                <Button x:Name="BtnDpImportBc" Content="{loc:Get dp_import_bc}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE896;"
-                                        Click="BtnDpImportBc_Click"/>
-
-                                <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
-                                <TextBlock Text="{loc:Get export}" Style="{StaticResource K2SideGroupHeader}"/>
-                                <Button x:Name="BtnDpExportProfiles" Content="{loc:Get export_profiles_btn}"
-                                        Style="{StaticResource K2SideActionButton}" Tag="&#xE896;"
-                                        Click="BtnDpExportProfiles_Click"/>
 
                                 <Separator Style="{StaticResource K2SideSeparator}" Margin="0,4,0,10"/>
                                 <TextBlock Text="{loc:Get device}" Style="{StaticResource K2SideGroupHeader}"/>
@@ -2902,6 +2915,29 @@
                         </StackPanel>
                     </GroupBox>
 
+                    <GroupBox x:Name="GbAppBcDllFolder" Header="{loc:Get settings_bc_dll_group}" Margin="0,0,0,20">
+                        <StackPanel Margin="8">
+                            <TextBlock Text="{loc:Get settings_bc_dll_hint}" Foreground="#9A9AA2"
+                                       TextWrapping="Wrap" Margin="0,0,0,8" FontSize="12"/>
+
+                            <RadioButton x:Name="RbBcDllAuto" Content="{loc:Get settings_bc_dll_radio_auto}"
+                                         GroupName="BcDllMode" Margin="0,4" Checked="RbBcDllMode_Checked"/>
+                            <TextBlock x:Name="TxtBcDetected" Foreground="#9A9AA2"
+                                       TextWrapping="Wrap" Margin="20,0,0,10" FontSize="12"/>
+
+                            <RadioButton x:Name="RbBcDllManual" Content="{loc:Get settings_bc_dll_radio_manual}"
+                                         GroupName="BcDllMode" Margin="0,4" Checked="RbBcDllMode_Checked"/>
+                            <TextBox x:Name="TxtBcDllFolder" IsReadOnly="True" Margin="20,4,0,8"/>
+                            <Button x:Name="BtnBcDllFolderBrowse" Content="{loc:Get settings_bc_dll_browse}"
+                                    Padding="8,4" HorizontalAlignment="Left" Margin="20,0,0,0"
+                                    Click="BtnBcDllFolderBrowse_Click"
+                                    Style="{StaticResource K2IconButton}" Tag="&#xE8DA;"/>
+
+                            <TextBlock x:Name="TxtBcDllStatus" Foreground="#9A9AA2"
+                                       TextWrapping="Wrap" Margin="0,8,0,0" FontSize="12"/>
+                        </StackPanel>
+                    </GroupBox>
+
                     <GroupBox x:Name="GbAppGeneral" Header="{loc:Get settings_general}" Margin="0,0,0,20">
                         <StackPanel Margin="8">
                             <CheckBox x:Name="CkCloseToTray" Content="{loc:Get settings_close_to_tray}"
@@ -2937,19 +2973,9 @@
                     <TextBlock Text="{loc:Get settings_debug_mode_hint}" Foreground="#9A9AA2"
                                TextWrapping="Wrap" Margin="20,4,0,20" FontSize="12"/>
 
-                    <!-- Native USB engines are always on by default now — surfaced only under
-                         Debug Mode, as a diagnostic opt-out rather than a base setting. -->
-                    <StackPanel x:Name="PnlDebugNativeEngines" Margin="20,0,0,20" Visibility="Collapsed">
-                        <CheckBox x:Name="CkDpNativeEngine" Content="{loc:Get settings_dp_native}"
-                                  Click="CkDpNativeEngine_Click" FontSize="14"/>
-                        <TextBlock Text="{loc:Get settings_dp_native_hint}" Foreground="#9A9AA2"
-                                   TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
-
-                        <CheckBox x:Name="CkEvNativeEngine" Content="{loc:Get settings_ev_native}"
-                                  Click="CkEvNativeEngine_Click" FontSize="14" Margin="0,16,0,0"/>
-                        <TextBlock Text="{loc:Get settings_ev_native_hint}" Foreground="#9A9AA2"
-                                   TextWrapping="Wrap" Margin="20,4,0,0" FontSize="12"/>
-                    </StackPanel>
+                    <!-- Native USB engines (DisplayPad/Everest raw-HID) are hardcoded ON —
+                         see AppSettings.DisplayPadNativeEngine. The Debug Mode opt-out
+                         checkboxes that used to live here were removed 2026-07-16. -->
 
                     <GroupBox x:Name="GbAppLogLevel" Header="{loc:Get settings_log_level}" Margin="0,4,0,0">
                         <StackPanel Margin="8">

--- a/K2.App/MainWindow.xaml.cs
+++ b/K2.App/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using K2.App.Services;
@@ -83,8 +84,9 @@ public partial class MainWindow : Window
         Log("distributed with K2. To use the MacroPad, choose one option:");
         Log($"  1) copy '{dll}' from the Base Camp installation folder");
         Log("     next to K2.App.exe;");
-        Log("  2) keep Base Camp installed: K2 detects it automatically;");
-        Log($"  3) set the environment variable {NativeDependencyResolver.BaseCampDirEnvVar}");
+        Log("  2) pick the Base Camp DLL folder in Settings > Base Camp DLL folder;");
+        Log("  3) keep Base Camp installed: K2 detects it automatically;");
+        Log($"  4) set the environment variable {NativeDependencyResolver.BaseCampDirEnvVar}");
         Log("     to the path of the Base Camp folder.");
         Log(NativeDependencyResolver.DescribeSearch(dll));
         Log("──────────────────────────────────────────────");
@@ -327,6 +329,18 @@ public partial class MainWindow : Window
                      .Where(t => (t.Tag as string)?.StartsWith(prefix) == true)
                      .ToList())
             TcDevices.Items.Remove(t);
+    }
+
+    /// <summary>Shared by every device's profile list (K2SideProfileItemStyle's
+    /// PreviewMouseRightButtonDown EventSetter): a plain ListBox doesn't move selection
+    /// on a right-click the way it does on left-click, but every per-device profile
+    /// ContextMenu (DpBuildProfileContextMenu etc.) is built once and acts on whatever
+    /// row is currently SelectedItem — so the row under the cursor must become selected
+    /// BEFORE the context menu opens, or "Rename"/"Delete"/... would silently act on the
+    /// previously-selected profile instead of the one the user right-clicked.</summary>
+    private void ProfileItem_PreviewRightClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is ListBoxItem item) item.IsSelected = true;
     }
 
     /// <summary>Shows or hides a static top-level device tab (Everest Max/60, Makalu,

--- a/K2.App/Models/DisplayPadKey.cs
+++ b/K2.App/Models/DisplayPadKey.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using K2.App.Services;
+using K2.Core;
 
 namespace K2.App.Models;
 
@@ -24,7 +25,7 @@ public sealed class DisplayPadKey : INotifyPropertyChanged
     public DisplayPadKey(int index) => Index = index;
 
     public int Index { get; }
-    public string Label => $"#{Index}";
+    public string Label => Loc.Get("dp_key_button_label", Index + 1);
 
     private string? _imagePath;
     public string? ImagePath
@@ -132,6 +133,7 @@ public sealed class DisplayPadKey : INotifyPropertyChanged
             OnChanged();
             OnChanged(nameof(HasAction));
             OnChanged(nameof(HasImageNoAction));
+            OnChanged(nameof(HasUnresolvedAction));
             OnChanged(nameof(Display));
             OnChanged(nameof(ListDisplay));
         }
@@ -146,12 +148,19 @@ public sealed class DisplayPadKey : INotifyPropertyChanged
             if (_actionValue == value) return;
             _actionValue = value;
             OnChanged();
+            OnChanged(nameof(HasUnresolvedAction));
             OnChanged(nameof(Display));
             OnChanged(nameof(ListDisplay));
         }
     }
 
     public bool HasAction => !string.IsNullOrEmpty(_actionType);
+
+    /// <summary>True for a "Play macro" action imported from Base Camp with no matching
+    /// macro found by name (see BaseCampDbImporter.TranslateDefaultAction) — shown with the
+    /// same warning triangle as <see cref="HasImageNoAction"/> so the user notices it needs
+    /// a macro picked manually.</summary>
+    public bool HasUnresolvedAction => ActionTypeHelper.IsMacroMissingTarget(_actionType, _actionValue);
 
     /// <summary>Label shown on the overlay button.</summary>
     public string Display
@@ -167,7 +176,8 @@ public sealed class DisplayPadKey : INotifyPropertyChanged
                     "exec"      => Path.GetFileName(_actionValue ?? ""),
                     "dp_folder" => "▸",   // folder — label comes from image
                     "dp_back"   => "◂",   // back — label comes from image
-                    _           => _actionType ?? "",
+                    "macro"     => ActionTypeHelper.MacroSummary(_actionValue),
+                    _           => ActionTypeHelper.IsUnrecognized(_actionType) ? Loc.Get("act_unrecognized") : _actionType ?? "",
                 };
             // Empty key: show index only in debug mode
             return _debugMode ? $"#{Index}" : "";
@@ -196,7 +206,8 @@ public sealed class DisplayPadKey : INotifyPropertyChanged
         "exec"      => Path.GetFileName(_actionValue ?? ""),
         "dp_folder" => "Folder",
         "dp_back"   => "Back",
-        _           => _actionType ?? "",
+        "macro"     => ActionTypeHelper.MacroSummary(_actionValue),
+        _           => ActionTypeHelper.IsUnrecognized(_actionType) ? Loc.Get("act_unrecognized") : _actionType ?? "",
     };
 
     /// <summary>Refreshes display-related bindings after a DebugMode change.</summary>

--- a/K2.App/Models/Ev60Key.cs
+++ b/K2.App/Models/Ev60Key.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using K2.Core;
 
 namespace K2.App.Models;
 
@@ -53,7 +54,7 @@ public sealed class Ev60Key : INotifyPropertyChanged
     public string? ActionValue
     {
         get => _actionValue;
-        set { if (_actionValue == value) return; _actionValue = value; OnChanged(); }
+        set { if (_actionValue == value) return; _actionValue = value; OnChanged(); OnChanged(nameof(Display)); }
     }
 
     private bool _isHighlighted;
@@ -73,7 +74,9 @@ public sealed class Ev60Key : INotifyPropertyChanged
     {
         get
         {
-            string body = string.IsNullOrEmpty(_actionType) ? "(empty)" : _actionType;
+            string body = ActionTypeHelper.IsUnrecognized(_actionType) ? Loc.Get("act_unrecognized")
+                        : string.Equals(_actionType, "macro", System.StringComparison.Ordinal) ? ActionTypeHelper.MacroSummary(_actionValue)
+                        : string.IsNullOrEmpty(_actionType) ? "(empty)" : _actionType;
             return $"{Name}  —  {body}";
         }
     }

--- a/K2.App/Models/EverestKey.cs
+++ b/K2.App/Models/EverestKey.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using K2.Core;
 
 namespace K2.App.Models;
 
@@ -75,7 +76,7 @@ public sealed class EverestKey : INotifyPropertyChanged
     public string? ActionValue
     {
         get => _actionValue;
-        set { if (_actionValue == value) return; _actionValue = value; OnChanged(); }
+        set { if (_actionValue == value) return; _actionValue = value; OnChanged(); OnChanged(nameof(Display)); }
     }
 
     private bool _isHighlighted;
@@ -98,8 +99,10 @@ public sealed class EverestKey : INotifyPropertyChanged
     {
         get
         {
-            string body = !string.IsNullOrEmpty(_actionType) ? _actionType
-                         : _hasImage ? K2.Core.Loc.Get("ev_display_key_icon_only")
+            string body = ActionTypeHelper.IsUnrecognized(_actionType) ? Loc.Get("act_unrecognized")
+                         : string.Equals(_actionType, "macro", System.StringComparison.Ordinal) ? ActionTypeHelper.MacroSummary(_actionValue)
+                         : !string.IsNullOrEmpty(_actionType) ? _actionType
+                         : _hasImage ? Loc.Get("ev_display_key_icon_only")
                          : "(empty)";
             return $"{Name}  —  {body}";
         }

--- a/K2.App/Models/MacroPadKey.cs
+++ b/K2.App/Models/MacroPadKey.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using K2.Core;
 
 namespace K2.App.Models;
 
@@ -92,7 +93,8 @@ public sealed class MacroPadKey : INotifyPropertyChanged
         "keys"  => _actionValue ?? _actionType!,
         "exec"  => System.IO.Path.GetFileName(_actionValue ?? _actionType!),
         "media" => _actionValue ?? _actionType!,
-        _       => _actionType ?? "",
+        "macro" => ActionTypeHelper.MacroSummary(_actionValue),
+        _       => ActionTypeHelper.IsUnrecognized(_actionType) ? Loc.Get("act_unrecognized") : _actionType ?? "",
     };
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/K2.App/NdkKeyConfigDialog.xaml.cs
+++ b/K2.App/NdkKeyConfigDialog.xaml.cs
@@ -213,7 +213,7 @@ public partial class NdkKeyConfigDialog : Window
             "command"  => $"Command: {val}",
             "macro"    => $"Macro: {val}",
             "pyscript" => "Python script",
-            _          => $"{ActionType}: {val}",
+            _          => ActionTypeHelper.IsUnrecognized(ActionType) ? Loc.Get("act_unrecognized") : $"{ActionType}: {val}",
         };
     }
 

--- a/K2.App/Services/BaseCampDbImporter.cs
+++ b/K2.App/Services/BaseCampDbImporter.cs
@@ -192,7 +192,8 @@ public sealed class BaseCampDbImporter
         BcProfile profile,
         int k2DeviceId,
         DisplayPadStore store,
-        int targetSlot)
+        int targetSlot,
+        IReadOnlyCollection<string>? macroNames = null)
     {
         var buttons = ReadButtons(dbPath, profile.ProfileId);
         int slot = targetSlot;
@@ -267,7 +268,7 @@ public sealed class BaseCampDbImporter
             else
             {
                 (actionType, actionValue) = TranslateAction(
-                    btn.FunctionType, btn.SubFunctionType, btn.FunctionValue);
+                    btn.FunctionType, btn.SubFunctionType, btn.FunctionValue, macroNames);
             }
 
             store.SaveButton(k2DeviceId, slot, pageId, btn.ButtonIndex,
@@ -286,6 +287,40 @@ public sealed class BaseCampDbImporter
     /// </summary>
     internal static bool IsBcDefaultAction(string? actionType) =>
         string.Equals(actionType, "bc:Default", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Maps Base Camp's "Run browser" action to K2's native "browser" action instead of the
+    /// generic "url" type or a valueless placeholder — pre-selects the first browser
+    /// <see cref="BrowserDetector"/> finds installed (its fixed chrome/edge/firefox/opera/brave
+    /// order) so the imported button already points at a real, launchable browser instead of
+    /// relying on the legacy "no browser chosen" fallback (OS default via ShellExecute).
+    /// </summary>
+    private static (string? ActionType, string? ActionValue) ImportBrowserAction(string? url)
+    {
+        var installed = BrowserDetector.DetectInstalled();
+        var payload = new BrowserActionPayload
+        {
+            Browser = installed.Count > 0 ? installed[0].Id : "other",
+            Url     = url ?? "",
+        };
+        return ("browser", payload.ToJson());
+    }
+
+    /// <summary>
+    /// Maps Base Camp's "Run Program" action to K2's "exec" action — unless the target
+    /// executable is one of the well-known browsers (<see cref="BrowserDetector.TryIdentifyByExeName"/>),
+    /// in which case it becomes K2's native "browser" action with that browser pre-selected instead
+    /// (a "Run Program" pointed at chrome.exe/msedge.exe/etc. is really a browser-open action that
+    /// just wasn't expressed as one in Base Camp).
+    /// </summary>
+    private static (string? ActionType, string? ActionValue) ImportExecOrBrowserAction(string? execPath)
+    {
+        string? browserId = BrowserDetector.TryIdentifyByExeName(execPath);
+        if (browserId is null) return ("exec", execPath);
+
+        var payload = new BrowserActionPayload { Browser = browserId, Url = "" };
+        return ("browser", payload.ToJson());
+    }
 
     /// <summary>Parses {"Id":2407,...} from OptionalText to extract the folder page ID.</summary>
     internal static int ParseFolderPageId(string? optionalText)
@@ -306,14 +341,15 @@ public sealed class BaseCampDbImporter
     /// into K2.Core action types (ActionType/ActionValue).
     /// </summary>
     public static (string? ActionType, string? ActionValue) TranslateAction(
-        string? funcType, string? subType, string? funcValue)
+        string? funcType, string? subType, string? funcValue,
+        IReadOnlyCollection<string>? macroNames = null)
     {
         if (string.IsNullOrEmpty(funcType)) return (null, null);
 
         return funcType switch
         {
             "Run Program" =>
-                ("exec", subType ?? funcValue),   // subType = path to exe
+                ImportExecOrBrowserAction(subType ?? funcValue),   // subType = path to exe
 
             "Open Folder" =>
                 ("folder", subType),              // opens OS folder in Explorer
@@ -325,11 +361,7 @@ public sealed class BaseCampDbImporter
                 ("dp_back", null),
 
             "Run browser" =>
-                funcValue switch
-                {
-                    null or "" or "Run browser" => ("browser", null),
-                    _ => ("url", funcValue)
-                },
+                ImportBrowserAction(funcValue is null or "" or "Run browser" ? null : funcValue),
 
             "Profile" => subType switch
             {
@@ -345,8 +377,15 @@ public sealed class BaseCampDbImporter
             "Multi Key" =>
                 ("keys", funcValue),
 
-            "Macro" =>
-                ("macro", funcValue),
+            // "Run Macro" is the FunctionType real Base Camp data uses for a Macro Library
+            // reference (verified in the user's live BaseCamp.db): DisplayPad rows carry the
+            // macro's name in BOTH SubFunctionType and FunctionValue, Everest rows in
+            // FunctionValue only — TranslateDefaultAction's subType-then-funcValue fallback
+            // covers both shapes. Previously only "Macro" (never seen in real data) and
+            // "Default" were handled, so every real macro key fell through to the generic
+            // "bc:Run Macro" arm below and showed up as an unrecognized action.
+            "Macro" or "Run Macro" =>
+                TranslateDefaultAction(subType, funcValue, macroNames),
 
             "Open Website" or "Open URL" =>
                 ("url", funcValue),
@@ -369,13 +408,47 @@ public sealed class BaseCampDbImporter
             "Mouse Button" =>
                 ("mouse", subType?.ToLowerInvariant()),
 
-            "Disable" or "Disabled" or "Default" =>
+            "Disable" or "Disabled" =>
                 (null, null),
+
+            "Default" =>
+                TranslateDefaultAction(subType, funcValue, macroNames),
 
             _ =>
                 // Unknown type: preserve it generically
                 ($"bc:{funcType}", funcValue ?? subType)
         };
+    }
+
+    /// <summary>
+    /// Base Camp's "Default" FunctionType is ALWAYS a reference to a NAMED macro from BC's own
+    /// Macro Library (SubFunctionType holds the macro's name) — including single-character
+    /// entries like "À": confirmed via a real decompiled snapshot of a user's BC macro DB
+    /// (K2.DisplayPad/Assets/BaseCampMacros.json) that lists "À"/"È"/etc. as genuine named
+    /// macros (type "text", value = that same character), not a distinct raw-literal case.
+    /// An earlier version of this method special-cased single-character names as literal
+    /// "text" actions directly, which produced the right on-screen character by coincidence
+    /// but skipped macro-name matching entirely — reported by the user as "le macro non sono
+    /// state riconosciute come macro ma come paste text" after importing a profile whose only
+    /// Default bindings happened to be single accented characters. K2 doesn't import BC's
+    /// macro CONTENT automatically (it lives in a separate DB table real BC XML exports don't
+    /// even include), so every name becomes K2's own "macro" (Play Macro) action type, matched
+    /// case-insensitively against <paramref name="macroNames"/> (the caller's current K2 macro
+    /// library) when a same-named macro already exists there — otherwise left with no macro
+    /// assigned, which <see cref="ActionTypeHelper.IsMacroMissingTarget"/> flags so the UI's
+    /// "action not found" warning triangle surfaces it for manual assignment instead of
+    /// silently dropping the binding. Also used for the "Run Macro"/"Macro" FunctionTypes
+    /// (same named-macro reference, name in SubFunctionType and/or FunctionValue).
+    /// </summary>
+    private static (string? ActionType, string? ActionValue) TranslateDefaultAction(
+        string? subType, string? funcValue, IReadOnlyCollection<string>? macroNames)
+    {
+        var name = !string.IsNullOrEmpty(subType) ? subType : funcValue;
+        if (string.IsNullOrEmpty(name)) return (null, null);
+
+        string? matched = macroNames?.FirstOrDefault(
+            n => string.Equals(n, name, StringComparison.OrdinalIgnoreCase));
+        return ("macro", matched);
     }
 
     // =========================================================
@@ -476,11 +549,23 @@ public sealed class BaseCampDbImporter
     /// slot picked by the caller via <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.
     /// </summary>
     public static (int Regular, int Touch) ImportEverestProfile(
-        string dbPath, BcProfile profile, EverestStore store, int targetSlot)
+        string dbPath, BcProfile profile, EverestStore store, int targetSlot,
+        IReadOnlyCollection<string>? macroNames = null)
     {
         var bindings = ReadKeyBindings(dbPath, profile.ProfileId);
         int slot = targetSlot;
         int regular = 0, touch = 0;
+
+        // Register the profile's name unconditionally, BEFORE translating any binding —
+        // mirrors ImportMakaluProfile/ImportEverest60Profile. Without this, a profile whose
+        // regular keys all translate to (null, null) (e.g. only "Default"/unmapped bindings,
+        // or a profile that's entirely NDK/touch-key content) writes no Keys row and stays
+        // entirely invisible to EverestStore.GetExistingProfiles (which has no other way to
+        // know the slot exists — the NDK settings written below aren't checked by it either),
+        // so the profile silently disappears after import instead of showing up empty.
+        // Confirmed real bug (user report 2026-07-17: "a volte quando si importa da xml non
+        // viene creato nessun nuovo profilo, resta solo il primo").
+        store.SetProfileName(slot, profile.Name);
 
         // Split: regular keys (actions) vs touch keys (LCD images)
         var touchKeys = bindings.Where(b => b.IsTouchKey).OrderBy(b => b.DLLMatrixIndex).ToList();
@@ -491,7 +576,7 @@ public sealed class BaseCampDbImporter
         // (EverestStore has no ClearProfile: we just overwrite via SaveKey)
         foreach (var b in regularKeys)
         {
-            var (at, av) = TranslateAction(b.FunctionType, b.SubFunctionType, b.FunctionValue);
+            var (at, av) = TranslateAction(b.FunctionType, b.SubFunctionType, b.FunctionValue, macroNames);
             if (at is null) continue;
             store.SaveKey(new EverestKeyRecord(slot, b.DLLMatrixIndex, null, at, av));
             regular++;
@@ -526,7 +611,7 @@ public sealed class BaseCampDbImporter
             if (imagePath is not null)
                 store.SetSetting($"{prefix}.imagePath", imagePath);
 
-            var (at, av) = TranslateAction(b.FunctionType, b.SubFunctionType, b.FunctionValue);
+            var (at, av) = TranslateAction(b.FunctionType, b.SubFunctionType, b.FunctionValue, macroNames);
             if (at is not null)
             {
                 store.SetSetting($"{prefix}.actionType",  at);
@@ -617,7 +702,8 @@ public sealed class BaseCampDbImporter
     /// <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.
     /// </summary>
     public static int ImportMacroPadProfile(
-        string dbPath, BcProfile profile, int k2DeviceId, MacroPadStore store, int targetSlot)
+        string dbPath, BcProfile profile, int k2DeviceId, MacroPadStore store, int targetSlot,
+        IReadOnlyCollection<string>? macroNames = null)
     {
         var bindings = ReadMakaluBindings(dbPath, profile.ProfileId);
         int slot = targetSlot;
@@ -627,7 +713,7 @@ public sealed class BaseCampDbImporter
         {
             if (!b.IsAssigned) continue;
 
-            var (at, av) = TranslateMakaluAction(b.FunctionType, b.FunctionValue);
+            var (at, av) = TranslateMakaluAction(b.FunctionType, b.FunctionValue, macroNames);
             if (at is null) continue;
             store.SaveKey(new MacroKeyRecord(k2DeviceId, slot, b.ButtonIndex, at, av));
             imported++;
@@ -643,7 +729,8 @@ public sealed class BaseCampDbImporter
     /// but no execution: preserved only so the information isn't lost.
     /// </summary>
     public static (string? ActionType, string? ActionValue) TranslateMakaluAction(
-        string? functionType, string? functionValue)
+        string? functionType, string? functionValue,
+        IReadOnlyCollection<string>? macroNames = null)
     {
         var ft = (functionType ?? "").Trim();
         var fv = (functionValue ?? "").Trim();
@@ -652,7 +739,7 @@ public sealed class BaseCampDbImporter
         switch (ft)
         {
             case "Run Program":
-                return string.IsNullOrEmpty(fv) ? (null, null) : ("exec", fv);
+                return string.IsNullOrEmpty(fv) ? (null, null) : ImportExecOrBrowserAction(fv);
 
             case "Keyboard Shortcuts":
                 return string.IsNullOrEmpty(fv) ? (null, null) : ("keys", fv);
@@ -668,7 +755,7 @@ public sealed class BaseCampDbImporter
                     "Volume down"     => ("media", "volume_down"),
                     "Mute"            => ("media", "mute"),
                     "Mic Mute"        => ("media", "mic_mute"),
-                    "Run browser"     => ("browser", null),
+                    "Run browser"     => ImportBrowserAction(null),
                     "Calculator"      => ("oscmd", "calculator"),
                     _ => ("none", $"[media] {fv}")
                 };
@@ -698,7 +785,7 @@ public sealed class BaseCampDbImporter
                 return fv switch
                 {
                     "Run task manager" => ("oscmd", "run task manager"),
-                    "Run browser"      => ("browser", null),
+                    "Run browser"      => ImportBrowserAction(null),
                     "Lock computer"    => ("oscmd", "lock computer"),
                     "Shut down"        => ("oscmd", "shutdown"),
                     "Sleep"            => ("oscmd", "sleep"),
@@ -708,9 +795,15 @@ public sealed class BaseCampDbImporter
                 };
 
             case "Run Macro":
-                // K2 doesn't have a macro engine (yet): preserve the reference as an
-                // inert placeholder instead of executing something wrong.
-                return ("none", $"[macro] {fv}");
+                // Named-macro reference, same as the shared TranslateAction's "Run Macro"
+                // arm: K2's macro engine plays these via ButtonActionEngine's "macro"
+                // action, so resolve the name against the user's K2 macro library instead
+                // of the old inert "[macro]" placeholder (written when K2 had no macro
+                // engine yet). Unmatched names stay as a valueless "macro" action, flagged
+                // by ActionTypeHelper.IsMacroMissingTarget.
+                return string.IsNullOrEmpty(fv)
+                    ? (null, null)
+                    : TranslateDefaultAction(null, fv, macroNames);
 
             case "Battery level check":
             case "Brightness cycle":
@@ -1131,7 +1224,8 @@ public sealed class BaseCampDbImporter
     /// see class-level doc comment) into Everest60Store. Returns the number
     /// of key bindings imported. <paramref name="targetSlot"/> is a fresh slot
     /// picked by the caller via <see cref="FindFreeSlot"/>, not <c>profile.Slot</c>.</summary>
-    public static int ImportEverest60Profile(string dbPath, BcProfile profile, Everest60Store store, int targetSlot)
+    public static int ImportEverest60Profile(string dbPath, BcProfile profile, Everest60Store store, int targetSlot,
+        IReadOnlyCollection<string>? macroNames = null)
     {
         int slot = targetSlot;
         store.ClearProfile(slot);
@@ -1150,7 +1244,7 @@ public sealed class BaseCampDbImporter
             int ledIndex = Array.IndexOf(Everest60RemapData.LedIndexToDllKeyIdArray, b.DllKeyId);
             if (ledIndex < 0) continue;
 
-            var (at, av) = TranslateAction(b.FunctionType, b.SubFunctionType, b.FunctionValue);
+            var (at, av) = TranslateAction(b.FunctionType, b.SubFunctionType, b.FunctionValue, macroNames);
             if (at is null) continue;
 
             store.SaveKey(new Ev60KeyRecord(slot, ledIndex, null, at, av));

--- a/K2.App/Services/DisplayPadStore.cs
+++ b/K2.App/Services/DisplayPadStore.cs
@@ -270,8 +270,11 @@ ON CONFLICT(Key) DO UPDATE SET Value=excluded.Value";
 
     public int GetCurrentProfile(int deviceId, int fallback = 1)
     {
+        // No upper bound: DisplayPad profiles are pure K2-side bookkeeping (no firmware
+        // slot cap, unlike Everest/MacroPad's real 5-slot FW_NUM_PROFILE) — see
+        // MainWindow.DisplayPad.cs's DpSwitchProfile doc comment.
         var s = GetSetting($"device.{deviceId}.currentProfile");
-        return int.TryParse(s, out var v) && v >= 1 && v <= 5 ? v : fallback;
+        return int.TryParse(s, out var v) && v >= 1 ? v : fallback;
     }
 
     public void SetCurrentProfile(int deviceId, int profile) =>

--- a/K2.App/Services/MacroPlayer.cs
+++ b/K2.App/Services/MacroPlayer.cs
@@ -58,9 +58,10 @@ public sealed class MacroPlayer
             for (int i = 0; i < iterations && !ct.IsCancellationRequested; i++)
             {
                 heldKeys.Clear();
-                foreach (var input in macro.Inputs)
+                for (int idx = 0; idx < macro.Inputs.Count; idx++)
                 {
                     if (ct.IsCancellationRequested) break;
+                    var input = macro.Inputs[idx];
 
                     // Delay
                     int delay = macro.DelayOption switch
@@ -71,6 +72,25 @@ public sealed class MacroPlayer
                     };
                     if (delay > 0)
                         HoldRepeat(delay, heldKeys, ct);
+
+                    // Alt+Numpad code (Alt held, numpad digits, Alt released — e.g.
+                    // Alt+0192 = "À"): compose the character ourselves and inject it as
+                    // a single Unicode keystroke instead of replaying the raw keys.
+                    // Windows' own Alt+Numpad composer has proven unreliable with
+                    // injected input on this machine — a clean SendInput stream (with
+                    // scan codes, with/without the HoldRepeat modifier re-assert)
+                    // produced empty text in a dedicated standalone harness, root cause
+                    // never isolated (see CHANGELOG 2026-07-14). Composing the group
+                    // deterministically removes every timing/composer dependency.
+                    // Only when no other key is currently held by the macro: a group
+                    // played under e.g. a held Ctrl isn't a plain Alt code.
+                    if (heldKeys.Count == 0
+                        && TryComposeAltCode(macro.Inputs, idx, out char altChar, out int groupEnd))
+                    {
+                        SendCharInput(altChar);
+                        idx = groupEnd; // skip the whole group, intra-group delays included
+                        continue;
+                    }
 
                     ExecuteInput(input, heldKeys);
                 }
@@ -108,6 +128,65 @@ public sealed class MacroPlayer
                 if (IsModifierKey(vk))
                     SendKeyInput(vk, false);
         }
+    }
+
+    /// <summary>
+    /// Detects an Alt+Numpad compose group starting at <paramref name="start"/>:
+    /// a keydown of plain Alt (VK_MENU/VK_LMENU — not AltGr, which is Ctrl+Alt and
+    /// never a plain Alt code) followed exclusively by numpad-digit keydown/keyups
+    /// (VK_NUMPAD0-9) up to the matching Alt keyup. On success returns the composed
+    /// character and the index of the closing Alt keyup. Decoding follows Windows'
+    /// own legacy rule: a leading 0 selects the active ANSI code page (e.g. Alt+0192
+    /// → cp1252 "À"), no leading 0 the OEM code page — resolved via
+    /// MultiByteToWideChar so the result matches this system's exact code pages
+    /// without any encoding-provider dependency. Any other event inside the group
+    /// (another key, a mouse event) means "not an Alt code" — caller falls back to
+    /// normal key playback.
+    /// </summary>
+    private static bool TryComposeAltCode(
+        IReadOnlyList<MacroInput> inputs, int start, out char ch, out int end)
+    {
+        ch = '\0';
+        end = start;
+        if (inputs[start].Type != "keydown") return false;
+        ushort altVk = (ushort)inputs[start].Key;
+        if (altVk is not (0x12 or 0xA4)) return false; // VK_MENU, VK_LMENU
+
+        var digits = new System.Text.StringBuilder();
+        for (int j = start + 1; j < inputs.Count; j++)
+        {
+            var ev = inputs[j];
+            ushort vk = (ushort)ev.Key;
+
+            if (ev.Type == "keyup" && (vk == altVk || vk == 0x12))
+            {
+                if (digits.Length == 0 || !TryDecodeAltCode(digits.ToString(), out ch))
+                    return false;
+                end = j;
+                return true;
+            }
+
+            if (ev.Type is not ("keydown" or "keyup")) return false;
+            if (vk is < 0x60 or > 0x69) return false; // numpad digits only
+            if (ev.Type == "keydown")
+                digits.Append((char)('0' + (vk - 0x60)));
+            if (digits.Length > 10) return false; // runaway/garbage recording
+        }
+        return false; // Alt never released within the macro
+    }
+
+    private static bool TryDecodeAltCode(string digits, out char ch)
+    {
+        ch = '\0';
+        if (!int.TryParse(digits, out int value) || value <= 0) return false;
+        // Windows' legacy composer uses the low byte of the accumulated number.
+        var bytes = new[] { (byte)(value & 0xFF) };
+        uint codePage = digits[0] == '0' ? CP_ACP : CP_OEMCP;
+        var buf = new char[2];
+        int n = MultiByteToWideChar(codePage, 0, bytes, bytes.Length, buf, buf.Length);
+        if (n <= 0) return false;
+        ch = buf[0];
+        return true;
     }
 
     private static bool IsModifierKey(ushort vk) => vk switch
@@ -284,4 +363,12 @@ public sealed class MacroPlayer
 
     [DllImport("user32.dll")]
     private static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+    private const uint CP_ACP   = 0; // active ANSI code page
+    private const uint CP_OEMCP = 1; // active OEM code page
+
+    [DllImport("kernel32.dll")]
+    private static extern int MultiByteToWideChar(
+        uint codePage, uint dwFlags, byte[] lpMultiByteStr, int cbMultiByte,
+        [Out] char[] lpWideCharStr, int cchWideChar);
 }

--- a/K2.App/Services/NativeDependencyResolver.cs
+++ b/K2.App/Services/NativeDependencyResolver.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using K2.Core;
 using Microsoft.Win32;
 
 namespace K2.App.Services;
@@ -19,6 +20,8 @@ namespace K2.App.Services;
 /// </para>
 /// <list type="number">
 ///   <item>next to <c>K2.App.exe</c> (the user copied it there manually);</item>
+///   <item>in the folder chosen via Settings &gt; "Base Camp DLL folder"
+///         (<see cref="AppSettings.BaseCampDllFolder"/>);</item>
 ///   <item>in the folder indicated by the <c>K2_BASECAMP_DIR</c> environment
 ///         variable (explicit override);</item>
 ///   <item>in a Base Camp installation found via the system registry
@@ -125,12 +128,17 @@ internal static class NativeDependencyResolver
         // 1) next to the executable
         yield return Path.Combine(AppContext.BaseDirectory, dll);
 
-        // 2) explicit override via environment variable
+        // 2) folder chosen via Settings > "Base Camp DLL folder"
+        var custom = AppSettings.BaseCampDllFolder;
+        if (!string.IsNullOrWhiteSpace(custom))
+            yield return Path.Combine(custom.Trim(), dll);
+
+        // 3) explicit override via environment variable
         var env = Environment.GetEnvironmentVariable(BaseCampDirEnvVar);
         if (!string.IsNullOrWhiteSpace(env))
             yield return Path.Combine(env.Trim(), dll);
 
-        // 3) detected Base Camp installations
+        // 4) detected Base Camp installations
         foreach (var dir in BaseCampDirectories())
             yield return Path.Combine(dir, dll);
     }

--- a/K2.Core/ActionExecutor.cs
+++ b/K2.Core/ActionExecutor.cs
@@ -166,9 +166,9 @@ public static class ActionExecutor
         // Replicates the mapping from BaseCampProfileImporter.MapActionExt
         switch ((s.FunctionType ?? "").Trim())
         {
-            case "Run Program":      return ("exec", s.FunctionValue, null);
+            case "Run Program":      return ImportExecOrBrowserAction(s.FunctionValue);
             case "Open Folder":      return ("folder", s.FunctionValue, null);
-            case "Run browser":      return ("browser", "", null);
+            case "Run browser":      return ImportBrowserAction();
             case "Adobe":
             case "DaVinci":
             case "Zoom":
@@ -180,6 +180,27 @@ public static class ActionExecutor
             case "Profile":          return ("profile", s.FunctionValue, null);
             default:                 return (null, null, $"FunctionType \"{s.FunctionType}\" not handled");
         }
+    }
+
+    /// <summary>Same "Run browser" -> native browser action mapping as
+    /// BaseCampDbImporter/BaseCampProfileImporter — pre-selects the first detected browser
+    /// instead of running with no browser chosen (OS default via ShellExecute).</summary>
+    private static (string? Type, string? Value, string? Reason) ImportBrowserAction()
+    {
+        var installed = BrowserDetector.DetectInstalled();
+        var payload = new BrowserActionPayload { Browser = installed.Count > 0 ? installed[0].Id : "other" };
+        return ("browser", payload.ToJson(), null);
+    }
+
+    /// <summary>Same "Run Program" -> "exec" (or native "browser" if it targets a known browser
+    /// executable) mapping as BaseCampDbImporter/BaseCampProfileImporter.</summary>
+    private static (string? Type, string? Value, string? Reason) ImportExecOrBrowserAction(string? execPath)
+    {
+        string? browserId = BrowserDetector.TryIdentifyByExeName(execPath);
+        if (browserId is null) return ("exec", execPath, null);
+
+        var payload = new BrowserActionPayload { Browser = browserId };
+        return ("browser", payload.ToJson(), null);
     }
 
     public sealed class MultiStep

--- a/K2.Core/ActionTypeHelper.cs
+++ b/K2.Core/ActionTypeHelper.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace K2.Core;
+
+/// <summary>
+/// Shared helper for classifying an action's <c>ActionType</c> string — there's no central
+/// enum, every device (DisplayPad, MacroPad, Everest, Everest60) just stores/reads raw
+/// strings set by <see cref="ButtonActionDialog"/> or produced by import.
+/// </summary>
+public static class ActionTypeHelper
+{
+    /// <summary>
+    /// True for a "bc:XYZ" action type — Base Camp's own function type preserved verbatim by
+    /// import because K2 has no native equivalent for it (see BaseCampDbImporter.TranslateAction's
+    /// default arm). Excludes "bc:Default", Base Camp's own "no binding" placeholder, which store
+    /// loaders already filter out before it reaches any display code.
+    /// </summary>
+    public static bool IsUnrecognized(string? actionType) =>
+        actionType is not null
+        && actionType.StartsWith("bc:", StringComparison.Ordinal)
+        && !string.Equals(actionType, "bc:Default", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True for a "macro" (Play Macro) action with no macro assigned — the state left by
+    /// importing a Base Camp named-macro reference that didn't match any macro in the user's
+    /// K2 library by name (see BaseCampDbImporter.TranslateDefaultAction). Used to show the
+    /// same "action not found" warning as an unrecognized "bc:" action type.
+    /// </summary>
+    public static bool IsMacroMissingTarget(string? actionType, string? actionValue) =>
+        string.Equals(actionType, "macro", StringComparison.Ordinal)
+        && string.IsNullOrEmpty(actionValue);
+
+    /// <summary>Display text for a "macro" action: the assigned macro's name, or a visible
+    /// "unassigned" warning when <see cref="IsMacroMissingTarget"/> — used by every device's
+    /// key-list Display/ActionSummary so an unresolved imported macro reference doesn't just
+    /// show up as the raw "macro" action-type string with no indication anything is wrong.</summary>
+    public static string MacroSummary(string? actionValue) =>
+        string.IsNullOrEmpty(actionValue) ? Loc.Get("act_macro_unresolved") : $"{Loc.Get("act_macro")}: {actionValue}";
+}

--- a/K2.Core/AppSettings.cs
+++ b/K2.Core/AppSettings.cs
@@ -30,8 +30,6 @@ public static class AppSettings
     {
         public bool DebugMode { get; set; }
         public K2LogLevel LogLevel { get; set; } = K2LogLevel.Normal;
-        public bool DisplayPadNativeEngine { get; set; } = true;
-        public bool EverestNativeEngine { get; set; } = true;
         public bool KillBaseCampWorker { get; set; } = true;
         public bool AutoStopBaseCamp { get; set; } = true;
         public bool CloseToTray { get; set; }
@@ -43,6 +41,7 @@ public static class AppSettings
         public string? Everest60DeviceName { get; set; }
         public string AppFontFamily { get; set; } = Services.FontCatalog.DefaultKey;
         public bool BcImportPromptShown { get; set; }
+        public string? BaseCampDllFolder { get; set; }
     }
 
     private static Data _data = new();
@@ -82,54 +81,26 @@ public static class AppSettings
 
     /// <summary>
     /// Drive the DisplayPad through the raw USB-HID engine (DisplayPadNativeClient)
-    /// instead of DisplayPadSDK.dll + satellite process. Default ON — the native engine
-    /// is now the standard path; the checkbox only surfaces under Settings &gt; Debug Mode
-    /// as a diagnostic opt-out (fall back to the SDK) if it ever needs ruling out.
-    /// Read once at startup (backend is chosen when MainWindow is constructed), so
-    /// changing it requires an app restart.
+    /// instead of DisplayPadSDK.dll + satellite process. Hardcoded ON since 2026-07-16:
+    /// it went opt-in → default-ON → fixed as the native engines proved reliable, while
+    /// the SDK backend accumulated machine-specific failures (DisplayPadResetPicture
+    /// returning false on some installs, no raw-buffer blanking). The constant is kept
+    /// (rather than deleting every call site) so the SDK/satellite code path stays
+    /// compilable as reference and can be re-enabled here in one line if a machine ever
+    /// needs ruling out. Old persisted values in app_settings.json are simply ignored.
     /// </summary>
-    public static bool DisplayPadNativeEngine
-    {
-        get { EnsureLoaded(); return _data.DisplayPadNativeEngine; }
-    }
-
-    public static void SetDisplayPadNativeEngine(bool value)
-    {
-        EnsureLoaded();
-        lock (_lock)
-        {
-            if (_data.DisplayPadNativeEngine == value) return;
-            _data.DisplayPadNativeEngine = value;
-            Save();
-        }
-        Changed?.Invoke();
-    }
+    public static bool DisplayPadNativeEngine => true;
 
     /// <summary>
     /// Drive the Everest Max's connectivity (open/close/init) and RGB effects through the
     /// raw USB-HID engine (<c>EverestHidNative</c>) instead of SDKDLL.dll. The full
     /// 171-key remap event stream, numpad display icons, and Media Dock still go through
     /// SDKDLL.dll regardless of this flag — those are not natively implemented yet
-    /// (unconfirmed wire protocol, see task/memory "Everest nativo — Fase 3/4"). Default
-    /// ON for what it covers; the checkbox only surfaces under Settings &gt; Debug Mode as
-    /// a diagnostic opt-out. Read once at startup, so changing it requires a restart.
+    /// (unconfirmed wire protocol, see task/memory "Everest nativo — Fase 3/4").
+    /// Hardcoded ON since 2026-07-16 — same rationale and re-enable path as
+    /// <see cref="DisplayPadNativeEngine"/>.
     /// </summary>
-    public static bool EverestNativeEngine
-    {
-        get { EnsureLoaded(); return _data.EverestNativeEngine; }
-    }
-
-    public static void SetEverestNativeEngine(bool value)
-    {
-        EnsureLoaded();
-        lock (_lock)
-        {
-            if (_data.EverestNativeEngine == value) return;
-            _data.EverestNativeEngine = value;
-            Save();
-        }
-        Changed?.Invoke();
-    }
+    public static bool EverestNativeEngine => true;
 
     /// <summary>
     /// When the native DisplayPad engine is active, automatically terminate Base Camp's
@@ -323,6 +294,29 @@ public static class AppSettings
         Changed?.Invoke();
     }
 
+    /// <summary>User-chosen folder to search for non-redistributable Base Camp native
+    /// DLLs (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll) when Base Camp isn't
+    /// installed on this PC and the user doesn't want to copy them next to K2.App.exe
+    /// or set the K2_BASECAMP_DIR environment variable by hand. Checked by
+    /// K2.App's NativeDependencyResolver — see Settings tab's "Base Camp DLL folder"
+    /// picker.</summary>
+    public static string? BaseCampDllFolder
+    {
+        get { EnsureLoaded(); return _data.BaseCampDllFolder; }
+    }
+
+    public static void SetBaseCampDllFolder(string? value)
+    {
+        EnsureLoaded();
+        lock (_lock)
+        {
+            if (_data.BaseCampDllFolder == value) return;
+            _data.BaseCampDllFolder = value;
+            Save();
+        }
+        Changed?.Invoke();
+    }
+
     /// <summary>Resets every app-wide preference (tray/autostart/font/log level/native
     /// engine toggles/auto-stop/kill-worker/recent paths/device nicknames) back to its
     /// built-in default and persists it. Used by the app-wide "Restore all defaults"
@@ -424,6 +418,7 @@ public static class AppSettings
             // Corrupt/missing settings file: fall back to defaults.
             _data = new Data();
         }
+
     }
 
     private static void Save()

--- a/K2.Core/BrowserDetector.cs
+++ b/K2.Core/BrowserDetector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Win32;
 
 namespace K2.Core;
@@ -43,6 +44,20 @@ public static class BrowserDetector
         foreach (var (kid, _, exe) in Known)
             if (string.Equals(kid, id, StringComparison.OrdinalIgnoreCase))
                 return ResolveAppPath(exe);
+        return null;
+    }
+
+    /// <summary>Returns the known browser id whose executable filename matches <paramref name="execPath"/>
+    /// (e.g. "C:\...\chrome.exe" → "chrome"), or null if it's not one of the well-known browsers this
+    /// class tracks. Used when importing a generic "run program" action that happens to point at a
+    /// browser executable, so it becomes K2's native "browser" action instead of a plain exec.</summary>
+    public static string? TryIdentifyByExeName(string? execPath)
+    {
+        if (string.IsNullOrWhiteSpace(execPath)) return null;
+        string fileName = Path.GetFileName(execPath);
+        foreach (var (id, _, exe) in Known)
+            if (string.Equals(exe, fileName, StringComparison.OrdinalIgnoreCase))
+                return id;
         return null;
     }
 

--- a/K2.Core/ButtonActionDialog.Simple.cs
+++ b/K2.Core/ButtonActionDialog.Simple.cs
@@ -105,7 +105,13 @@ public partial class ButtonActionDialog
 
         var match = CbComboValue.Items.OfType<ComboBoxItem>()
             .FirstOrDefault(i => string.Equals((string?)i.Tag, selectValue, System.StringComparison.OrdinalIgnoreCase));
-        CbComboValue.SelectedItem = match ?? (CbComboValue.Items.Count > 0 ? CbComboValue.Items[0] : null);
+        // For "macro" (dynamic library list), no match is a real, expected state — an
+        // imported Base Camp named-macro reference that didn't resolve to any macro in the
+        // user's K2 library (see BaseCampDbImporter.TranslateDefaultAction). Defaulting to
+        // the first macro in the list here would silently bind the key to an unrelated macro
+        // the moment the user opens and saves the dialog without noticing. Fixed enums
+        // (oscmd/media/mouse) keep the old fallback since a mismatch there shouldn't happen.
+        CbComboValue.SelectedItem = match ?? (tag == "macro" ? null : (CbComboValue.Items.Count > 0 ? CbComboValue.Items[0] : null));
     }
 
     private string SaveComboSpec()

--- a/K2.Core/Strings.it.xml
+++ b/K2.Core/Strings.it.xml
@@ -74,7 +74,9 @@
   <string name="act_command">Comando shell</string>
   <string name="act_text">Incolla testo</string>
   <string name="act_macro">Riproduci macro</string>
+  <string name="act_macro_unresolved">Riproduci macro (non assegnata)</string>
   <string name="act_pyscript">Script Python</string>
+  <string name="act_unrecognized">Non riconosciuto</string>
   <string name="py_file">File .py</string>
   <string name="py_inline">Codice inline</string>
   <string name="py_browse">Sfoglia…</string>
@@ -154,6 +156,16 @@
   <string name="settings_bc_import_hint">Cerca un'installazione di Base Camp esistente e propone di importarne profili e impostazioni per ogni dispositivo K2 (Everest Max, Everest 60, Makalu, MacroPad, DisplayPad). Viene mostrato automaticamente al primo avvio di K2 — usa questo pulsante per rilanciarlo in qualsiasi momento.</string>
   <string name="bc_import_prompt_title">Importa da Base Camp</string>
   <string name="bc_import_prompt_text">È stata rilevata un'installazione di Base Camp su questo PC. Vuoi importare i suoi profili e impostazioni esistenti in K2? Per ogni dispositivo collegato potrai controllare cosa è stato trovato prima che venga importato qualcosa.</string>
+  <!-- Base Camp DLL folder picker -->
+  <string name="settings_bc_dll_group">Cartella DLL Base Camp</string>
+  <string name="settings_bc_dll_hint">MacroPad, Everest Max ed Everest 60 usano alcune DLL native che sono componenti interni di Base Camp e NON vengono distribuite con K2 (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll). Usa un'installazione di Base Camp rilevata automaticamente, oppure indica a K2 una cartella che contiene le DLL.</string>
+  <string name="settings_bc_dll_radio_auto">Usa l'installazione di Base Camp trovata su questo PC:</string>
+  <string name="settings_bc_dll_radio_auto_notfound">Nessuna installazione di Base Camp rilevata automaticamente.</string>
+  <string name="settings_bc_dll_radio_manual">Specifica una cartella manualmente:</string>
+  <string name="settings_bc_dll_browse">Sfoglia…</string>
+  <string name="settings_bc_dll_none">Nessuna cartella impostata.</string>
+  <string name="settings_bc_dll_found">trovata</string>
+  <string name="settings_bc_dll_missing">mancante</string>
   <!-- Ripristina impostazioni predefinite -->
   <string name="settings_danger_zone">Zona pericolosa</string>
   <string name="restore_defaults">Ripristina predefiniti</string>
@@ -486,6 +498,7 @@
   <string name="dp_mapping_done">Rimappatura DisplayPad completata.</string>
   <string name="dp_imported_xml">Profilo '{0}' importato nello slot {1}.</string>
   <string name="dp_choose_image">Scegli immagine per il tasto #{0}</string>
+  <string name="dp_key_button_label">Tasto {0}</string>
   <string name="dp_load_image">Carica immagine…</string>
   <string name="dp_rotate_image">Ruota immagine:</string>
   <string name="dp_action_section">Azione</string>
@@ -563,6 +576,11 @@
   <string name="delete_profile_last">Impossibile eliminare l'ultimo profilo.</string>
   <string name="import_no_free_slot">Tutti e 5 gli slot profilo sono già occupati — elimina o libera uno slot prima di importare "{0}".</string>
   <string name="import_some_skipped_no_slot">{0} profilo/i saltato/i: nessuno slot libero rimasto (tutti e 5 sono occupati).</string>
+  <string name="bc_pick_device_title">Scegli dispositivo Base Camp</string>
+  <string name="bc_pick_device_text">Base Camp ha profili per più di un dispositivo. Scegli quale importare su "{0}":</string>
+  <string name="bc_pick_device_none">Scegli un dispositivo da cui importare.</string>
+  <string name="bc_pick_device_label">Dispositivo #{0} — {1} profilo/i: {2}</string>
+  <string name="bc_import_will_wipe">Questa operazione ELIMINERÀ tutti i profili K2 esistenti su "{0}" prima di importare.</string>
   <string name="ev_no_profiles_in_bc">Nessun profilo Everest trovato nel database Base Camp.</string>
   <string name="ev_imported_bc">Importati {0} profili Everest ({1} tasti) da Base Camp.</string>
   <string name="mp_no_profiles_in_bc">Nessun profilo MacroPad trovato nel database Base Camp.</string>

--- a/K2.Core/Strings.xml
+++ b/K2.Core/Strings.xml
@@ -75,7 +75,9 @@
   <string name="act_command">Shell command</string>
   <string name="act_text">Paste text</string>
   <string name="act_macro">Play macro</string>
+  <string name="act_macro_unresolved">Play macro (unassigned)</string>
   <string name="act_pyscript">Python Script</string>
+  <string name="act_unrecognized">Not recognized</string>
   <string name="py_file">File .py</string>
   <string name="py_inline">Inline code</string>
   <string name="py_browse">Browse…</string>
@@ -155,6 +157,16 @@
   <string name="settings_bc_import_hint">Looks for an existing Base Camp installation and offers to import its profiles and settings for every K2 device (Everest Max, Everest 60, Makalu, MacroPad, DisplayPad). Shown automatically the first time K2 runs — use this button to run it again any time.</string>
   <string name="bc_import_prompt_title">Import from Base Camp</string>
   <string name="bc_import_prompt_text">A Base Camp installation was detected on this PC. Would you like to import its existing profiles and settings into K2? You'll get a chance to review what's found for each connected device before anything is imported.</string>
+  <!-- Base Camp DLL folder picker -->
+  <string name="settings_bc_dll_group">Base Camp DLL folder</string>
+  <string name="settings_bc_dll_hint">MacroPad, Everest Max and Everest 60 rely on a few native DLLs that are internal Base Camp components and are NOT distributed with K2 (MacroPadSDK.dll, SDKDLL.dll, Everest360_USB.dll). Either use a detected Base Camp installation, or point K2 at a folder containing the DLLs.</string>
+  <string name="settings_bc_dll_radio_auto">Use the Base Camp installation found on this PC:</string>
+  <string name="settings_bc_dll_radio_auto_notfound">No Base Camp installation was detected automatically.</string>
+  <string name="settings_bc_dll_radio_manual">Specify a folder manually:</string>
+  <string name="settings_bc_dll_browse">Browse…</string>
+  <string name="settings_bc_dll_none">No folder set.</string>
+  <string name="settings_bc_dll_found">found</string>
+  <string name="settings_bc_dll_missing">missing</string>
   <!-- Restore defaults -->
   <string name="settings_danger_zone">Danger zone</string>
   <string name="restore_defaults">Restore defaults</string>
@@ -487,6 +499,7 @@
   <string name="dp_mapping_done">DisplayPad mapping complete.</string>
   <string name="dp_imported_xml">Profile '{0}' imported to slot {1}.</string>
   <string name="dp_choose_image">Choose image for key #{0}</string>
+  <string name="dp_key_button_label">Button {0}</string>
   <string name="dp_load_image">Load image…</string>
   <string name="dp_rotate_image">Rotate image:</string>
   <string name="dp_action_section">Action</string>
@@ -564,6 +577,12 @@
   <string name="delete_profile_last">Cannot delete the last profile.</string>
   <string name="import_no_free_slot">All 5 profile slots are already used — delete or free one before importing "{0}".</string>
   <string name="import_some_skipped_no_slot">{0} profile(s) skipped: no free slot left (all 5 are used).</string>
+  <!-- Base Camp device picker (shown when the DB has profiles for more than one physical device of the same type) -->
+  <string name="bc_pick_device_title">Choose Base Camp device</string>
+  <string name="bc_pick_device_text">Base Camp has profiles for more than one device. Choose which one to import into "{0}":</string>
+  <string name="bc_pick_device_none">Choose a device to import from.</string>
+  <string name="bc_pick_device_label">Device #{0} — {1} profile(s): {2}</string>
+  <string name="bc_import_will_wipe">This will DELETE all existing K2 profiles on "{0}" before importing.</string>
   <!-- Everest import -->
   <string name="ev_no_profiles_in_bc">No Everest profiles found in the Base Camp database.</string>
   <string name="ev_imported_bc">Imported {0} Everest profiles ({1} keys) from Base Camp.</string>

--- a/K2.DisplayPad/Dialogs/CellConfigDialog.xaml.cs
+++ b/K2.DisplayPad/Dialogs/CellConfigDialog.xaml.cs
@@ -220,7 +220,7 @@ public partial class CellConfigDialog : Window
             "command"  => $"Command: {val}",
             "macro"    => $"Macro: {val}",
             "pyscript" => "Python script",
-            _          => $"{ActionType}: {val}",
+            _          => ActionTypeHelper.IsUnrecognized(ActionType) ? Loc.Get("act_unrecognized") : $"{ActionType}: {val}",
         };
     }
 

--- a/K2.DisplayPad/Services/BaseCampProfileImporter.cs
+++ b/K2.DisplayPad/Services/BaseCampProfileImporter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Xml.Linq;
+using K2.Core;
 
 namespace K2.DisplayPad.Services;
 
@@ -178,9 +179,9 @@ public sealed class BaseCampProfileImporter
 
         switch (ft)
         {
-            case "Run Program":   return string.IsNullOrEmpty(fv) ? (null,null,"Run Program without FunctionValue") : ("exec",  fv, null);
+            case "Run Program":   return string.IsNullOrEmpty(fv) ? (null,null,"Run Program without FunctionValue") : ImportExecOrBrowserAction(fv);
             case "Open Folder":   return string.IsNullOrEmpty(fv) ? (null,null,"Open Folder without FunctionValue") : ("folder",fv, null);
-            case "Run browser":   return ("browser", "", null);
+            case "Run browser":   return ImportBrowserAction(fv is "" or "Run browser" ? null : fv);
             case "Profile":       return ("profile", string.IsNullOrEmpty(fv) ? sft : fv, null);
             case "Adobe":
             case "DaVinci":
@@ -205,19 +206,30 @@ public sealed class BaseCampProfileImporter
                 // 1) literal character as SubFunctionType
                 if (sft.Length == 1) return ("text", sft, null);
                 if (!string.IsNullOrEmpty(fv) && fv.Length == 1) return ("text", fv, null);
-                // 2) named macro resolved via MacroLibrary
-                if (!string.IsNullOrEmpty(sft) && _macros.TryGet(sft, out var def))
+                goto case "Run Macro";
+
+            // "Run Macro" is what real Base Camp data uses for a Macro Library reference
+            // (name in SubFunctionType and/or FunctionValue) — same named-macro lookup as
+            // "Default"'s case 2. The standalone app has no macro engine, so the macro is
+            // reduced to text/keys via MacroLibrary when possible (K2.App instead resolves
+            // it to its own "macro" Play Macro action — BaseCampDbImporter.TranslateAction).
+            case "Run Macro":
+            {
+                var name = !string.IsNullOrEmpty(sft) ? sft : fv;
+                // named macro resolved via MacroLibrary
+                if (!string.IsNullOrEmpty(name) && _macros.TryGet(name, out var def))
                 {
                     if (def.Type == "text" && !string.IsNullOrEmpty(def.Value))
                         return ("text", def.Value, null);
                     if (def.Type == "keys" && !string.IsNullOrEmpty(def.Value))
                         return ("keys", def.Value, null);
                     // raw or unknown: leave as a placeholder
-                    return ("none", $"[macro raw] {sft}", $"macro \"{sft}\" not reducible (raw)");
+                    return ("none", $"[macro raw] {name}", $"macro \"{name}\" not reducible (raw)");
                 }
-                if (!string.IsNullOrEmpty(sft))
-                    return ("none", $"[macro] {sft}", $"macro \"{sft}\" not in library");
-                return (null, null, "Default with no information");
+                if (!string.IsNullOrEmpty(name))
+                    return ("none", $"[macro] {name}", $"macro \"{name}\" not in library");
+                return (null, null, $"{ft} with no information");
+            }
 
             case "":
                 return (null, null, null);
@@ -242,7 +254,7 @@ public sealed class BaseCampProfileImporter
             case "Run Program":
                 return string.IsNullOrEmpty(fv)
                     ? (null, null, "Run Program without FunctionValue")
-                    : ("exec", fv, null);
+                    : ImportExecOrBrowserAction(fv);
 
             case "Open Folder":
                 return string.IsNullOrEmpty(fv)
@@ -250,7 +262,7 @@ public sealed class BaseCampProfileImporter
                     : ("folder", fv, null);
 
             case "Run browser":
-                return ("browser", "", null);
+                return ImportBrowserAction(fv is "" or "Run browser" ? null : fv);
 
             case "Profile":
                 // E.g. "Next Profile", "Previous Profile", or a profile name
@@ -283,6 +295,36 @@ public sealed class BaseCampProfileImporter
             default:
                 return (null, null, $"FunctionType \"{ft}\" not handled");
         }
+    }
+
+    /// <summary>Maps Base Camp's "Run browser" action to K2's native "browser" action,
+    /// pre-selecting the first browser <see cref="BrowserDetector"/> finds installed, so the
+    /// imported button already points at a real, launchable browser instead of relying on the
+    /// legacy "no browser chosen" fallback (OS default via ShellExecute). <paramref name="url"/>
+    /// carries over Base Camp's FunctionValue when it holds an actual URL (not the literal
+    /// "Run browser" placeholder some exports use) — previously dropped, leaving every imported
+    /// "Run browser" button with an empty URL regardless of what BC had configured.</summary>
+    private static (string? Type, string? Value, string? UnmappedReason) ImportBrowserAction(string? url)
+    {
+        var installed = BrowserDetector.DetectInstalled();
+        var payload = new BrowserActionPayload
+        {
+            Browser = installed.Count > 0 ? installed[0].Id : "other",
+            Url     = url ?? "",
+        };
+        return ("browser", payload.ToJson(), null);
+    }
+
+    /// <summary>Maps a "Run Program" action to "exec" — unless the target executable is one of
+    /// the well-known browsers (<see cref="BrowserDetector.TryIdentifyByExeName"/>), in which case
+    /// it becomes the native "browser" action with that browser pre-selected instead.</summary>
+    private static (string? Type, string? Value, string? UnmappedReason) ImportExecOrBrowserAction(string? execPath)
+    {
+        string? browserId = BrowserDetector.TryIdentifyByExeName(execPath);
+        if (browserId is null) return ("exec", execPath, null);
+
+        var payload = new BrowserActionPayload { Browser = browserId };
+        return ("browser", payload.ToJson(), null);
     }
 }
 


### PR DESCRIPTION
## Summary
- Everest per-profile NDK images, HW-busy detection, and startup diagnostics
- BC device picker for multi-device Base Camp imports, plus detection/surfacing of unrecognized bc: actions and unresolved macro references

## Test plan
- [x] build-check.bat clean on both solutions
- [ ] Verify on physical hardware (Everest NDK upload, HW-busy detection, BC multi-device import)