### PR TITLE
1.0.3: Add Everest 60 numpad key binding and remap protocol support

### DIFF
--- a/K2.App/Everest60KeyBindingPanel.xaml.cs
+++ b/K2.App/Everest60KeyBindingPanel.xaml.cs
@@ -30,6 +30,22 @@ public partial class Everest60KeyBindingPanel : UserControl
     private Action<string> _log = _ => { };
     private IActionHost? _actionHost;
 
+    /// <summary>Device-side push for a numpad key's binding, set once from
+    /// MainWindow.Everest60.cs via <see cref="SetNumpadDevicePush"/> — kept as
+    /// injected delegates (same style as <see cref="Ev60ActionHost"/>'s
+    /// constructor) rather than a direct <c>Everest60Service</c> reference, so
+    /// this panel stays a plain list/dialog owner. See
+    /// <see cref="Everest60Protocol.NumpadKeyBinding"/> for the protocol and
+    /// why the write doesn't need to carry real meaning to Base Camp.</summary>
+    private Action<int, string>? _writeNumpadBinding;
+    private Action<int>? _unassignNumpadBinding;
+
+    internal void SetNumpadDevicePush(Action<int, string> writeBinding, Action<int> unassignBinding)
+    {
+        _writeNumpadBinding = writeBinding;
+        _unassignNumpadBinding = unassignBinding;
+    }
+
     /// <summary>Profile persistence — set once from Init, same pattern as
     /// Everest60RgbPanel._ev60Store/_ev60Slot.</summary>
     private Everest60Store? _ev60Store;
@@ -53,6 +69,15 @@ public partial class Everest60KeyBindingPanel : UserControl
     /// (see MainWindow.Everest60.cs's _ev60LayoutType), no hex/raw-index fallback.</summary>
     private string BoardLabelForLed(int ledIndex)
     {
+        if (ledIndex >= Everest60Protocol.NumpadLedIndexBase)
+        {
+            int numpadIndex = ledIndex - Everest60Protocol.NumpadLedIndexBase;
+            var numpad = Everest60KeyboardLayout.Numpad;
+            if (numpadIndex >= 0 && numpadIndex < numpad.Length)
+                return string.IsNullOrEmpty(numpad[numpadIndex].Label) ? $"Numpad {numpadIndex}" : numpad[numpadIndex].Label;
+            return $"Numpad {numpadIndex}";
+        }
+
         var layout = _ev60Layout?.Invoke() ?? KeyboardLayoutType.AnsiUs;
         foreach (var kd in Everest60KeyboardLayout.GetMainBoard(layout))
             if (kd.MatrixId == ledIndex) return string.IsNullOrEmpty(kd.Label) ? $"Key {ledIndex}" : kd.Label;
@@ -116,6 +141,50 @@ public partial class Everest60KeyBindingPanel : UserControl
         PersistOrDiscardKey(key);
     }
 
+    /// <summary>Called by MainWindow when a key on the 17-key numpad accessory
+    /// overlay is clicked while the Key Binding section is active — same
+    /// flow as <see cref="SelectKey"/>, but stored at
+    /// <c>Everest60Protocol.NumpadLedIndexBase + numpadIndex</c> so it can't
+    /// collide with a main-board LedIndex in the same store table.
+    /// <para><b>Fase 1 only</b> (2026-07-22): the chosen action is persisted
+    /// to the profile like any other key, but nothing is written to the
+    /// device yet and no physical press will execute it — that needs the
+    /// device-side remap write + a press-detection poller, still pending
+    /// verification of the real event protocol (see the plan/CHANGELOG).</para>
+    /// </summary>
+    internal void SelectNumpadKey(int numpadIndex, string label)
+    {
+        int ledIndex = Everest60Protocol.NumpadLedIndexBase + numpadIndex;
+        bool isNewKey = !_byLed.ContainsKey(ledIndex);
+        if (!_byLed.TryGetValue(ledIndex, out var key))
+        {
+            key = new Ev60Key(ledIndex, numpadIndex) { Label = label };
+            _keys.Add(key);
+            _byLed[ledIndex] = key;
+            _log($"[KeyBind] new numpad key idx={numpadIndex} added via overlay click");
+        }
+
+        LvEv60Keys.SelectedItem = key;
+
+        var dlg = new ButtonActionDialog(ledIndex, key.ActionType, key.ActionValue, _actionHost)
+                  { Owner = Window.GetWindow(this) };
+        if (dlg.ShowDialog() != true)
+        {
+            if (isNewKey && key.ActionType is null)
+            {
+                _keys.Remove(key);
+                _byLed.Remove(ledIndex);
+            }
+            return;
+        }
+
+        key.ActionType  = string.IsNullOrEmpty(dlg.ActionType) || dlg.ActionType == "none"
+                          ? null : dlg.ActionType;
+        key.ActionValue = key.ActionType is null ? null : dlg.ActionValue;
+
+        PersistOrDiscardKey(key);
+    }
+
     private void UpdateListButtons()
     {
         bool hasSelection = LvEv60Keys.SelectedItem is not null;
@@ -147,11 +216,18 @@ public partial class Everest60KeyBindingPanel : UserControl
         _byLed.Remove(key.LedIndex);
         _ev60Store?.RemoveKey(CurrentSlot, key.LedIndex);
         _log($"[KeyBind] key led={key.LedIndex} removed");
+        if (key.NumpadIndex is int npi)
+            _unassignNumpadBinding?.Invoke(Everest60RemapData.NumpadDllKeyId[npi]);
     }
 
     /// <summary>Persists a key's current action, or — if it has no action assigned —
     /// discards it entirely (list + DB) instead of keeping an empty entry. Mirrors
-    /// MainWindow.Everest.cs's EvPersistOrDiscardKey.</summary>
+    /// MainWindow.Everest.cs's EvPersistOrDiscardKey. For a numpad key
+    /// (<see cref="Ev60Key.NumpadIndex"/> set) this ALSO pushes the binding to
+    /// the physical device (write on save, unassign on empty) — see
+    /// <see cref="SetNumpadDevicePush"/>/<c>Everest60Protocol.NumpadKeyBinding</c>.
+    /// The main board never needs this: its bindings execute purely in K2
+    /// software off the SDK's existing key callback.</summary>
     private void PersistOrDiscardKey(Ev60Key key)
     {
         if (key.ActionType is null)
@@ -160,11 +236,15 @@ public partial class Everest60KeyBindingPanel : UserControl
             _byLed.Remove(key.LedIndex);
             _ev60Store?.RemoveKey(CurrentSlot, key.LedIndex);
             _log($"[KeyBind] key led={key.LedIndex} emptied, removed");
+            if (key.NumpadIndex is int npi1)
+                _unassignNumpadBinding?.Invoke(Everest60RemapData.NumpadDllKeyId[npi1]);
         }
         else
         {
             _ev60Store?.SaveKey(new Ev60KeyRecord(CurrentSlot, key.LedIndex, key.Label, key.ActionType, key.ActionValue));
             _log($"[KeyBind] key led={key.LedIndex} <- type={key.ActionType}");
+            if (key.NumpadIndex is int npi2)
+                _writeNumpadBinding?.Invoke(Everest60RemapData.NumpadDllKeyId[npi2], key.Label);
         }
     }
 
@@ -191,7 +271,10 @@ public partial class Everest60KeyBindingPanel : UserControl
 
         foreach (var r in _ev60Store.LoadProfile(slot))
         {
-            var k = new Ev60Key(r.LedIndex)
+            int? numpadIndex = r.LedIndex >= Everest60Protocol.NumpadLedIndexBase
+                              ? r.LedIndex - Everest60Protocol.NumpadLedIndexBase
+                              : null;
+            var k = new Ev60Key(r.LedIndex, numpadIndex)
             {
                 Label       = string.IsNullOrEmpty(r.Label) ? BoardLabelForLed(r.LedIndex) : r.Label,
                 ActionType  = r.ActionType,

--- a/K2.App/MainWindow.Everest.cs
+++ b/K2.App/MainWindow.Everest.cs
@@ -1755,6 +1755,34 @@ public partial class MainWindow
         LoadNdkState();
         EvAddNdkEntriesToKeyList();
         LogEverest($"[DB  ] profile {profile}: loaded {_evKeys.Count} keys");
+
+        ReloadEverestRgbForProfileSwitch();
+    }
+
+    /// <summary>
+    /// Re-loads the RGB lighting panel for the profile that just became active
+    /// (device firmware is already switched to it at this point — see callers of
+    /// <see cref="ReloadEverestProfile"/>) and resends the effect, so each profile
+    /// keeps its own remembered lighting when "sync across profiles" is off
+    /// (no-op in practice when synced: same shared keys, same values). Mirrors
+    /// Everest 60/Makalu's ReloadProfile. User request 2026-07-22.
+    /// </summary>
+    private void ReloadEverestRgbForProfileSwitch()
+    {
+        if (!_evRgbInitialized) return;
+        bool prev = _evRgbSuppress;
+        _evRgbSuppress = true;
+        try
+        {
+            LoadEverestRgbFromStore();
+            UpdateEvCapabilities();
+            LblEvBrightness.Text = $"{(int)SldEvBrightness.Value}%";
+            ApplyColorButton(BtnEvColor1, _evColor1);
+            ApplyColorButton(BtnEvColor2, _evColor2);
+            ApplyColorButton(BtnEvColor3, _evColor3);
+        }
+        finally { _evRgbSuppress = prev; }
+        ApplyCurrentEffect();
     }
 
     /// <summary>
@@ -2106,8 +2134,10 @@ public partial class MainWindow
     // firmware (firmware presets are "fire & forget"). Colors are chosen with
     // System.Windows.Forms.ColorDialog (WPF has no built-in color dialog).
     //
-    // State (effect + params + colors) lives only in memory — per-profile
-    // persistence is a future step.
+    // State (effect + params + colors) is persisted in Settings — shared
+    // across profiles ("rgb.*") when "sync across profiles" is on, or
+    // per-profile ("rgb.p{N}.*") when off, mirroring Everest 60/Makalu (see
+    // EvRgbPrefix, user request 2026-07-22).
     // ------------------------------------------------------------
 
     /// <summary>
@@ -2279,24 +2309,35 @@ public partial class MainWindow
     }
 
     /// <summary>
-    /// Loads RGB parameters saved from the previous session (keys
-    /// <c>rgb.*</c> in the Settings table). Global state, not per-profile:
-    /// per-profile extension is a future step.
+    /// Key namespace for the RGB effect settings: shared (<c>"rgb."</c>) when
+    /// "sync across profiles" is on, or profile-scoped (<c>"rgb.p{N}."</c>)
+    /// when off — synced means one shared effect for every profile by
+    /// definition, so only the un-synced case needs per-profile storage
+    /// (mirrors Everest 60/Makalu, user request 2026-07-22).
+    /// </summary>
+    private string EvRgbPrefix() =>
+        CkEvSync.IsChecked == true ? "rgb." : $"rgb.p{EvCurrentProfile()}.";
+
+    /// <summary>
+    /// Loads RGB parameters saved from the previous session/profile (see
+    /// <see cref="EvRgbPrefix"/>). The "sync" flag itself and the auto-off
+    /// timer are always global device settings, not per-profile.
     /// </summary>
     private void LoadEverestRgbFromStore()
     {
         int? IntSetting(string key) =>
             int.TryParse(_evStore.GetSetting(key), out var v) ? v : null;
 
-        if (IntSetting("rgb.effect") is int eIdx)
+        if (IntSetting("rgb.sync") is int sy) CkEvSync.IsChecked = sy != 0;
+
+        string prefix = EvRgbPrefix();
+        if ((IntSetting(prefix + "effect") ?? IntSetting("rgb.effect")) is int eIdx)
         {
             for (int i = 0; i < EvEffectList.Length; i++)
                 if ((byte)EvEffectList[i].Eff == eIdx) { CbEvEffect.SelectedIndex = i; break; }
         }
         if (CbEvEffect.SelectedItem is EvEffectChoice pick)
             LoadEffectParamsIntoControls(pick.Eff);
-
-        if (IntSetting("rgb.sync") is int sy) CkEvSync.IsChecked = sy != 0;
 
         CkEvAutoOffEnable.IsChecked = IntSetting("rgb.autoOffEnable") == 1;
         TxtEvAutoOffSeconds.Text    = (IntSetting("rgb.autoOffSeconds") ?? 60).ToString();
@@ -2318,28 +2359,33 @@ public partial class MainWindow
     {
         int? I(string key) =>
             int.TryParse(_evStore.GetSetting(key), out var v) ? v : null;
-        string p = $"rgb.{(byte)eff}.";
+        // Profile-scoped (or shared, if synced — see EvRgbPrefix) namespace first,
+        // falling back to the legacy always-global "rgb.{effectByte}." keys —
+        // one-time seeding for existing installs/profiles that never had their
+        // own per-profile value saved yet.
+        string p  = $"{EvRgbPrefix()}{(byte)eff}.";
+        string gp = $"rgb.{(byte)eff}.";
 
-        int speed = I(p + "speed") ?? I("rgb.speed") ?? 50;
+        int speed = I(p + "speed") ?? I(gp + "speed") ?? 50;
         if (speed is >= 0 and <= 100) SldEvSpeed.Value = speed;
 
         // Direction is applied by UpdateEvCapabilities (options depend on effect);
         // here we only restore the saved index, used there if valid.
-        _evSavedDirIndex = I(p + "direction") ?? I("rgb.direction") ?? 0;
+        _evSavedDirIndex = I(p + "direction") ?? I(gp + "direction") ?? 0;
         _evDirIndex      = _evSavedDirIndex;
 
-        int bright = I(p + "brightness") ?? I("rgb.brightness") ?? 100;
+        int bright = I(p + "brightness") ?? I(gp + "brightness") ?? 100;
         if (bright is >= 0 and <= 100) SldEvBrightness.Value = bright;
 
         // Rainbow/Double/Single are one mutually-exclusive radio group — Rainbow
         // wins if both were somehow persisted true (shouldn't happen going forward).
-        if ((I(p + "rainbow") ?? I("rgb.rainbow") ?? 0) != 0) RbEvRainbow.IsChecked = true;
-        else if ((I(p + "colorDouble") ?? I("rgb.colorDouble") ?? 0) != 0) RbEvColorDouble.IsChecked = true;
+        if ((I(p + "rainbow") ?? I(gp + "rainbow") ?? 0) != 0) RbEvRainbow.IsChecked = true;
+        else if ((I(p + "colorDouble") ?? I(gp + "colorDouble") ?? 0) != 0) RbEvColorDouble.IsChecked = true;
         else RbEvColorSingle.IsChecked = true;
 
-        _evColor1 = (I(p + "color1") ?? I("rgb.color1") ?? _evColor1) & 0xFFFFFF;
-        _evColor2 = (I(p + "color2") ?? I("rgb.color2") ?? _evColor2) & 0xFFFFFF;
-        _evColor3 = (I(p + "color3") ?? I("rgb.color3") ?? _evColor3) & 0xFFFFFF;
+        _evColor1 = (I(p + "color1") ?? I(gp + "color1") ?? _evColor1) & 0xFFFFFF;
+        _evColor2 = (I(p + "color2") ?? I(gp + "color2") ?? _evColor2) & 0xFFFFFF;
+        _evColor3 = (I(p + "color3") ?? I(gp + "color3") ?? _evColor3) & 0xFFFFFF;
         ApplyColorButton(BtnEvColor1, _evColor1);
         ApplyColorButton(BtnEvColor2, _evColor2);
         ApplyColorButton(BtnEvColor3, _evColor3);
@@ -2394,16 +2440,18 @@ public partial class MainWindow
         EvApplyAutoOffConfig();
     }
 
-    /// <summary>Saves the current panel payload to Settings — the effect-independent
-    /// bits under global keys (<c>rgb.effect</c>/<c>rgb.sync</c>), everything else
-    /// under the selected effect's own <c>rgb.{effectByte}.*</c> namespace (see
-    /// <see cref="LoadEffectParamsIntoControls"/>).</summary>
+    /// <summary>Saves the current panel payload to Settings — under the shared or
+    /// profile-scoped namespace given by <see cref="EvRgbPrefix"/> (effect id under
+    /// <c>{prefix}effect</c>, everything else under <c>{prefix}{effectByte}.*</c>,
+    /// see <see cref="LoadEffectParamsIntoControls"/>). <c>rgb.sync</c> itself is
+    /// always the global device flag.</summary>
     private void SaveEverestRgbToStore()
     {
         if (!_evRgbInitialized || _evRgbSuppress) return;
         if (CbEvEffect.SelectedItem is not EvEffectChoice pick) return;
-        string p = $"rgb.{(byte)pick.Eff}.";
-        _evStore.SetSetting("rgb.effect",      ((byte)pick.Eff).ToString());
+        string prefix = EvRgbPrefix();
+        string p = $"{prefix}{(byte)pick.Eff}.";
+        _evStore.SetSetting(prefix + "effect", ((byte)pick.Eff).ToString());
         _evStore.SetSetting(p + "speed",       ((int)SldEvSpeed.Value).ToString());
         _evStore.SetSetting(p + "direction",   _evDirIndex.ToString());
         _evStore.SetSetting(p + "brightness",  ((int)SldEvBrightness.Value).ToString());

--- a/K2.App/MainWindow.Everest60.cs
+++ b/K2.App/MainWindow.Everest60.cs
@@ -108,6 +108,20 @@ public partial class MainWindow
     /// fallback pattern to port.</summary>
     private readonly Dictionary<int, int> _ev60DllKeyIdToLedIndex = new();
 
+    /// <summary>Reverse of <see cref="Everest60RemapData.NumpadDllKeyId"/>
+    /// (DllKeyId -> NumpadIndex 0-16), built once in
+    /// <see cref="InitEverest60Module"/> — used by <see cref="OnEv60NumpadKeyPressed"/>
+    /// to translate <see cref="_ev60NumpadKeyPoller"/>'s event back to a
+    /// numpad key identity.</summary>
+    private readonly Dictionary<int, int> _ev60NumpadDllKeyIdToIndex = new();
+
+    /// <summary>Numpad accessory Key Binding: polls for physical presses over
+    /// the same raw-HID channel as lighting — see
+    /// <see cref="Everest60NumpadKeyPoller"/>'s doc comment for why this is
+    /// "always on" (unlike <see cref="_ev60LedPoller"/>, not gated to the
+    /// Lighting section).</summary>
+    private Everest60NumpadKeyPoller? _ev60NumpadKeyPoller;
+
     /// <summary>Called once from the MainWindow constructor.</summary>
     private void InitEverest60Module()
     {
@@ -139,6 +153,11 @@ public partial class MainWindow
         for (int led = 0; led < table.Length; led++)
             _ev60DllKeyIdToLedIndex[table[led]] = led;
 
+        // DllKeyId -> NumpadIndex reverse map (see _ev60NumpadDllKeyIdToIndex's doc comment).
+        var numpadTable = Everest60RemapData.NumpadDllKeyId;
+        for (int npi = 0; npi < numpadTable.Length; npi++)
+            _ev60NumpadDllKeyIdToIndex[numpadTable[npi]] = npi;
+
         _ev60Sdk.KeyEvent += OnEv60Key;
 
         _ev60ActionHost = new Ev60ActionHost(
@@ -156,6 +175,9 @@ public partial class MainWindow
             listMacroNames:        ListAllMacroNames,
             playMacro:             PlayMacroByName);
         Ev60KeyBindingPanel.SetActionHost(_ev60ActionHost);
+        Ev60KeyBindingPanel.SetNumpadDevicePush(
+            writeBinding:     (dllKeyId, label) => { _ev60.WriteNumpadKeyBinding(dllKeyId, label); StartEv60NumpadPresenceGrace(); },
+            unassignBinding:  dllKeyId => { _ev60.UnassignNumpadKey(dllKeyId); StartEv60NumpadPresenceGrace(); });
 
         _ev60Engine = new ButtonActionEngine(_ev60ActionHost);
         _ev60Engine.Start();
@@ -168,9 +190,16 @@ public partial class MainWindow
         _ev60LedPoller = new Everest60LedColorPoller(_ev60);
         _ev60LedPoller.ColorsUpdated += OnEv60ColorsUpdated;
 
+        // Always-on (not gated to a section, unlike _ev60LedPoller) — see
+        // Everest60NumpadKeyPoller's doc comment.
+        _ev60NumpadKeyPoller = new Everest60NumpadKeyPoller(_ev60);
+        _ev60NumpadKeyPoller.KeyPressed += OnEv60NumpadKeyPressed;
+        _ev60NumpadKeyPoller.Start();
+
         Closed += (_, _) =>
         {
             try { _ev60LedPoller?.Dispose(); } catch { /* ignore */ }
+            try { _ev60NumpadKeyPoller?.Dispose(); } catch { /* ignore */ }
             try { _ev60Engine?.Dispose(); } catch { /* ignore */ }
             try { _ev60Sdk.Dispose(); } catch { /* ignore */ }
         };
@@ -265,6 +294,25 @@ public partial class MainWindow
     {
         Ev60RgbPanel.Ev60ReloadProfile(slot);
         Ev60KeyBindingPanel.Ev60ReloadKeyBindings(slot);
+        PushNumpadKeyBindingsToDevice();
+    }
+
+    /// <summary>Re-writes every numpad key currently bound in this profile to
+    /// the physical device — the firmware doesn't persist a binding across a
+    /// replug/profile switch (same reason lighting needs re-applying via
+    /// Ev60RgbPanel.Ev60ReloadProfile above), unlike the main board's
+    /// bindings which live purely in K2 software and need no device push at
+    /// all.</summary>
+    private void PushNumpadKeyBindingsToDevice()
+    {
+        bool wroteAny = false;
+        foreach (var key in Ev60KeyBindingPanel.Keys)
+            if (key.NumpadIndex is int npi)
+            {
+                _ev60.WriteNumpadKeyBinding(Everest60RemapData.NumpadDllKeyId[npi], key.Label);
+                wroteAny = true;
+            }
+        if (wroteAny) StartEv60NumpadPresenceGrace();
     }
 
     /// <summary>
@@ -762,8 +810,12 @@ public partial class MainWindow
                     TextAlignment = TextAlignment.Center,
                     HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center,
                 },
-                IsHitTestVisible = false, // decorative only — no protocol for this accessory
+                Tag = kd.NumpadIndex, // 0-16, see KeyDef.NumpadIndex
             };
+            // Key Binding identity/persistence only (Fase 1) — no device write,
+            // no physical-press detection yet, see Ev60NumpadButton_Click and
+            // Everest60KeyBindingPanel.SelectNumpadKey's doc comments.
+            btn.Click += Ev60NumpadButton_Click;
             Canvas.SetLeft(btn, kd.X);
             Canvas.SetTop(btn, kd.Y);
             CvsEv60Numpad.Children.Add(btn);
@@ -949,6 +1001,21 @@ public partial class MainWindow
             ApplyEv60KeyOverlay(v, color);
     }
 
+    /// <summary>Key click on the 17-key numpad accessory overlay. Only does
+    /// anything while the Key Binding section is active — unlike the main
+    /// board, the numpad has no per-key paint mode and no keycap-customize
+    /// dialog (it only gets the shared base Keycap Appearance colors, see
+    /// BuildEverest60KeyboardOverlay's numpad loop), so any other section is
+    /// a no-op here, same as before this click handler existed.</summary>
+    private void Ev60NumpadButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { Tag: int numpadIndex } btn) return;
+        if (!ReferenceEquals(_activeEv60Section, Ev60KeyBindingPanel)) return;
+
+        string label = (btn.Content as TextBlock)?.Text ?? $"#{numpadIndex}";
+        Ev60KeyBindingPanel.SelectNumpadKey(numpadIndex, label);
+    }
+
     // ============================================================
     // IActionHost adapter (delegates passed to Ev60ActionHost) +
     // physical key-press execution
@@ -1006,6 +1073,23 @@ public partial class MainWindow
         if (pressed) ExecuteEv60Key(key);
     }
 
+    /// <summary>Physical press of a numpad accessory key, reported by
+    /// <see cref="_ev60NumpadKeyPoller"/> (raw-HID poll, cmd 0x08 — see
+    /// Everest60Protocol.NumpadKeyBinding, NOT the SDK callback <see cref="HandleEv60Key"/>
+    /// uses for the main board). Only fires for a numpad key the user has
+    /// actually bound in K2 — an unbound key never reaches this poller at
+    /// all (it's still typing its normal literal digit, no device write was
+    /// ever made for it).</summary>
+    private void OnEv60NumpadKeyPressed(int dllKeyId)
+    {
+        if (!_ev60NumpadDllKeyIdToIndex.TryGetValue(dllKeyId, out int numpadIndex)) return;
+
+        var key = Ev60KeyBindingPanel.Keys.FirstOrDefault(k => k.NumpadIndex == numpadIndex);
+        if (key is null) return;
+
+        ExecuteEv60Key(key);
+    }
+
     /// <summary>Same "Tint" overlay approach as Everest Max's
     /// EvHighlightKeyboardButton (MainWindow.Everest.cs) — SetKeyTint/
     /// SetLegendForeground live in MainWindow.KeycapAppearance.cs and own
@@ -1027,6 +1111,45 @@ public partial class MainWindow
     /// comment); side (left/right) is NOT re-derived each poll, only
     /// presence is — see Ev60RefreshStatus for why.</summary>
     private Ev60NumpadPosition _ev60NumpadPosition = Ev60NumpadPosition.None;
+
+    /// <summary>Consecutive "not present" readings from <see cref="Everest60Service.TryGetNumpadPresent"/>.
+    /// Debounced (hide only after 2 in a row) so a single blip doesn't
+    /// flicker the UI — but see <see cref="_ev60NumpadPresenceGraceUntil"/>
+    /// for the real fix: diagnostic logging on real hardware (2026-07-22,
+    /// see CHANGELOG) confirmed this ISN'T a brief host-side race at all —
+    /// after a Key Binding write, <c>cmd 0x20</c> genuinely, repeatedly reads
+    /// an all-zero "not present" buffer for **~20+ consecutive seconds**
+    /// (5+ clean, fast, correctly-echoed reads in a row, all "empty") before
+    /// self-recovering, with the write's own <c>CommitKeyBinding</c> (cmd
+    /// 0x2C) never getting a clean ack either (3 retries, stale echo every
+    /// time). This is the firmware itself — likely the same long-standing,
+    /// previously-reported "Ev60 numpad sometimes disappears, replug fixes
+    /// it" hardware quirk, now confirmed to correlate with a Key Binding
+    /// write specifically — nothing on the host side to fix. A 2-tick
+    /// debounce alone doesn't cover 20+ seconds; presence coming back is
+    /// never debounced — reconnecting (real or after the firmware settles)
+    /// should still feel instant.</summary>
+    private int _ev60NumpadAbsentStreak;
+
+    /// <summary>Suppresses hiding the numpad (but never suppresses showing
+    /// it) until this time — set by <see cref="StartEv60NumpadPresenceGrace"/>
+    /// right after any numpad Key Binding write, to ride out the firmware's
+    /// own "not present" window documented on <see cref="_ev60NumpadAbsentStreak"/>
+    /// instead of hiding the accessory for real. Each new write RENEWS this
+    /// (confirmed working via a 2026-07-22 log: three writes ~4-14s apart
+    /// each pushed the deadline out, keeping <c>grace=True</c> the whole
+    /// time) — but a single 30s window turned out too short for that same
+    /// back-to-back-writes case: the numpad was still reading absent 33s
+    /// after the LAST write when the grace expired and it got hidden, with
+    /// no sign of recovery yet in that log. Widened to 60s (evidence-based
+    /// margin, not a guess pulled from nowhere: covers the single-write
+    /// ~23s case with room to spare, and the observed 45s-and-still-absent
+    /// multi-write case) — widen further if a future log still shows it
+    /// hidden before recovering.</summary>
+    private DateTime _ev60NumpadPresenceGraceUntil = DateTime.MinValue;
+
+    private void StartEv60NumpadPresenceGrace() =>
+        _ev60NumpadPresenceGraceUntil = DateTime.UtcNow.AddSeconds(60);
 
     /// <summary>Moves/mirrors/shows-or-hides CvsEv60Numpad for the given
     /// position. No separate right-side art exists (Base Camp itself only
@@ -1282,13 +1405,30 @@ public partial class MainWindow
         // as the only physical unit seen in every capture/log so far.
         Ev60NumpadPosition numpadPos;
         if (!connected)
+        {
             numpadPos = Ev60NumpadPosition.None;
+            _ev60NumpadAbsentStreak = 0;
+        }
         else
         {
             bool? present = _ev60.TryGetNumpadPresent();
-            numpadPos = present == true
-                ? (_ev60NumpadPosition == Ev60NumpadPosition.None ? Ev60NumpadPosition.Right : _ev60NumpadPosition)
-                : Ev60NumpadPosition.None;
+            if (present == true)
+            {
+                _ev60NumpadAbsentStreak = 0;
+                numpadPos = _ev60NumpadPosition == Ev60NumpadPosition.None ? Ev60NumpadPosition.Right : _ev60NumpadPosition;
+            }
+            else
+            {
+                _ev60NumpadAbsentStreak++;
+                bool inGrace = DateTime.UtcNow < _ev60NumpadPresenceGraceUntil;
+                // Debounced (2-tick) normally; during the post-write grace
+                // window (see _ev60NumpadPresenceGraceUntil) never hide at
+                // all — the firmware's own ~20+s "not present" spell after a
+                // binding write is expected, not a real disconnect.
+                numpadPos = (!inGrace && _ev60NumpadAbsentStreak >= 2) ? Ev60NumpadPosition.None : _ev60NumpadPosition;
+            }
+            LogEverest60($"[Ev60-NumpadTick] present={present?.ToString() ?? "null"} " +
+                         $"streak={_ev60NumpadAbsentStreak} grace={DateTime.UtcNow < _ev60NumpadPresenceGraceUntil} -> pos={numpadPos}");
         }
         ApplyEv60NumpadPosition(numpadPos);
     }

--- a/K2.App/MainWindow.Keys.cs
+++ b/K2.App/MainWindow.Keys.cs
@@ -697,7 +697,7 @@ public partial class MainWindow
     private void ReloadCurrentProfile()
     {
         foreach (var k in _keys) { k.ActionType = null; k.ActionValue = null; }
-        if (CurrentDeviceId() is not int id) { RefreshMpMappedKeys(); return; }
+        if (CurrentDeviceId() is not int id) { RefreshMpMappedKeys(); ReloadMacroLedForProfileSwitch(); return; }
         int profile = CurrentProfile();
         var rows = _store.LoadProfile(id, profile);
         foreach (var r in rows)
@@ -708,6 +708,8 @@ public partial class MainWindow
         }
         RefreshMpMappedKeys();
         Log($"[DB  ] loaded {rows.Count} actions for device={id} profile={profile}");
+
+        ReloadMacroLedForProfileSwitch();
     }
 
     // ============================================================

--- a/K2.App/MainWindow.MacroLed.cs
+++ b/K2.App/MainWindow.MacroLed.cs
@@ -18,8 +18,11 @@ namespace K2.App;
 /// (<see cref="CurrentDeviceId"/>): every native MacroPad command takes the
 /// slot id as last parameter.
 ///
-/// Panel state is persisted globally in Settings (keys <c>macroled.*</c>)
-/// and reapplied when the driver opens.
+/// Panel state is persisted in Settings — shared across profiles (keys
+/// <c>macroled.*</c>) when "sync across profiles" is on, or per-profile
+/// (<c>macroled.p{N}.*</c>) when off, mirroring Everest 60/Makalu (see
+/// MacroLedPrefix, user request 2026-07-22) — and reapplied when the driver
+/// opens or the active profile changes.
 /// </summary>
 public partial class MainWindow
 {
@@ -203,25 +206,47 @@ public partial class MainWindow
         _macroLedInitialized = true;
     }
 
-    /// <summary>Restores the panel from <c>macroled.*</c> keys (global state).</summary>
+    /// <summary>
+    /// Key namespace for the LED effect settings: shared (<c>"macroled."</c>)
+    /// when "sync across profiles" is on, or profile-scoped
+    /// (<c>"macroled.p{N}."</c>) when off — synced means one shared effect for
+    /// every profile by definition, so only the un-synced case needs
+    /// per-profile storage (mirrors Everest 60/Makalu, user request 2026-07-22).
+    /// </summary>
+    private string MacroLedPrefix() =>
+        CkMacroSync.IsChecked == true ? "macroled." : $"macroled.p{CurrentProfile()}.";
+
+    /// <summary>Restores the panel from Settings (see <see cref="MacroLedPrefix"/>):
+    /// falls back once to the legacy always-global <c>macroled.*</c> keys for a
+    /// profile that has no per-profile value yet (existing installs). <c>macroled.sync</c>
+    /// itself and the auto-off timer are always global device settings.</summary>
     private void LoadMacroLedFromStore()
     {
-        if (IntSetting("macroled.effect") is int eIdx)
+        if (IntSetting("macroled.sync") is int sy) CkMacroSync.IsChecked = sy != 0;
+
+        string p = MacroLedPrefix();
+        const string gp = "macroled.";
+
+        if ((IntSetting(p + "effect") ?? IntSetting(gp + "effect")) is int eIdx)
             for (int i = 0; i < MacroEffectList.Length; i++)
                 if ((byte)MacroEffectList[i].Eff == eIdx) { CbMacroEffect.SelectedIndex = i; break; }
-        if (IntSetting("macroled.speed")      is int sp && sp is >= 0 and <= 100) SldMacroSpeed.Value = sp;
+        if ((IntSetting(p + "speed") ?? IntSetting(gp + "speed")) is int sp && sp is >= 0 and <= 100)
+            SldMacroSpeed.Value = sp;
         // Direction is set by UpdateMpCapabilities (depends on effect);
         // here we only restore the saved index, applied later if valid.
-        if (IntSetting("macroled.direction")  is int dr && dr >= 0) _macroSavedDirIndex = dr;
-        if (IntSetting("macroled.brightness") is int br && br is >= 0 and <= 100) SldMacroBrightness.Value = br;
+        if ((IntSetting(p + "direction") ?? IntSetting(gp + "direction")) is int dr && dr >= 0)
+            _macroSavedDirIndex = dr;
+        if ((IntSetting(p + "brightness") ?? IntSetting(gp + "brightness")) is int br && br is >= 0 and <= 100)
+            SldMacroBrightness.Value = br;
         // Rainbow/Double are mutually exclusive (one radio group) — Rainbow wins
         // if both were somehow persisted true (shouldn't happen going forward).
-        if (IntSetting("macroled.rainbow") is int rb && rb != 0) RbMacroRainbow.IsChecked = true;
-        else if (IntSetting("macroled.colorDouble") is int cd && cd != 0) RbMacroColorDouble.IsChecked = true;
-        if (IntSetting("macroled.color1")     is int c1) _macroColor1 = c1 & 0xFFFFFF;
-        if (IntSetting("macroled.color2")     is int c2) _macroColor2 = c2 & 0xFFFFFF;
-        if (IntSetting("macroled.color3")     is int c3) _macroColor3 = c3 & 0xFFFFFF;
-        if (IntSetting("macroled.sync")       is int sy) CkMacroSync.IsChecked = sy != 0;
+        if ((IntSetting(p + "rainbow") ?? IntSetting(gp + "rainbow")) is int rb && rb != 0)
+            RbMacroRainbow.IsChecked = true;
+        else if ((IntSetting(p + "colorDouble") ?? IntSetting(gp + "colorDouble")) is int cd && cd != 0)
+            RbMacroColorDouble.IsChecked = true;
+        if ((IntSetting(p + "color1") ?? IntSetting(gp + "color1")) is int c1) _macroColor1 = c1 & 0xFFFFFF;
+        if ((IntSetting(p + "color2") ?? IntSetting(gp + "color2")) is int c2) _macroColor2 = c2 & 0xFFFFFF;
+        if ((IntSetting(p + "color3") ?? IntSetting(gp + "color3")) is int c3) _macroColor3 = c3 & 0xFFFFFF;
 
         CkMacroAutoOffEnable.IsChecked = IntSetting("macroled.autoOffEnable") == 1;
         TxtMacroAutoOffSeconds.Text    = (IntSetting("macroled.autoOffSeconds") ?? 60).ToString();
@@ -270,21 +295,49 @@ public partial class MainWindow
     private int? IntSetting(string key) =>
         int.TryParse(_store.GetSetting(key), out int v) ? v : null;
 
-    /// <summary>Saves the current panel payload to Settings.</summary>
+    /// <summary>Saves the current panel payload to Settings, under the shared or
+    /// profile-scoped namespace given by <see cref="MacroLedPrefix"/>.
+    /// <c>macroled.sync</c> itself is always the global device flag.</summary>
     private void SaveMacroLedToStore()
     {
         if (!_macroLedInitialized || _macroLedSuppress) return;
         if (CbMacroEffect.SelectedItem is not MacroEffectChoice pick) return;
-        _store.SetSetting("macroled.effect",     ((int)(byte)pick.Eff).ToString());
-        _store.SetSetting("macroled.speed",      ((int)SldMacroSpeed.Value).ToString());
-        _store.SetSetting("macroled.direction",  _macroDirIndex.ToString());
-        _store.SetSetting("macroled.brightness", ((int)SldMacroBrightness.Value).ToString());
-        _store.SetSetting("macroled.rainbow",    RbMacroRainbow.IsChecked == true ? "1" : "0");
-        _store.SetSetting("macroled.colorDouble", RbMacroColorDouble.IsChecked == true ? "1" : "0");
-        _store.SetSetting("macroled.color1",     _macroColor1.ToString());
-        _store.SetSetting("macroled.color2",     _macroColor2.ToString());
-        _store.SetSetting("macroled.color3",     _macroColor3.ToString());
-        _store.SetSetting("macroled.sync",       CkMacroSync.IsChecked == true ? "1" : "0");
+        string p = MacroLedPrefix();
+        _store.SetSetting(p + "effect",     ((int)(byte)pick.Eff).ToString());
+        _store.SetSetting(p + "speed",      ((int)SldMacroSpeed.Value).ToString());
+        _store.SetSetting(p + "direction",  _macroDirIndex.ToString());
+        _store.SetSetting(p + "brightness", ((int)SldMacroBrightness.Value).ToString());
+        _store.SetSetting(p + "rainbow",    RbMacroRainbow.IsChecked == true ? "1" : "0");
+        _store.SetSetting(p + "colorDouble", RbMacroColorDouble.IsChecked == true ? "1" : "0");
+        _store.SetSetting(p + "color1",     _macroColor1.ToString());
+        _store.SetSetting(p + "color2",     _macroColor2.ToString());
+        _store.SetSetting(p + "color3",     _macroColor3.ToString());
+        _store.SetSetting("macroled.sync", CkMacroSync.IsChecked == true ? "1" : "0");
+    }
+
+    /// <summary>
+    /// Re-loads the LED panel for the profile that just became active and resends
+    /// the effect (targets that profile explicitly via SetEffect's own
+    /// <c>profile</c> parameter — see ApplyCurrentMacroEffect), so each profile
+    /// keeps its own remembered lighting when "sync across profiles" is off
+    /// (no-op in practice when synced: same shared keys, same values). Mirrors
+    /// Everest Max's ReloadEverestRgbForProfileSwitch. User request 2026-07-22.
+    /// </summary>
+    private void ReloadMacroLedForProfileSwitch()
+    {
+        if (!_macroLedInitialized) return;
+        bool prev = _macroLedSuppress;
+        _macroLedSuppress = true;
+        try
+        {
+            LoadMacroLedFromStore();
+            UpdateMpCapabilities();
+            LblMacroBrightness.Text = $"{(int)SldMacroBrightness.Value}%";
+            ApplyColorButton(BtnMacroColor1, _macroColor1);
+            ApplyColorButton(BtnMacroColor2, _macroColor2);
+        }
+        finally { _macroLedSuppress = prev; }
+        ApplyCurrentMacroEffect();
     }
 
     // WPF does NOT raise SelectionChanged when re-clicking the already selected item,

--- a/K2.App/Models/Ev60Key.cs
+++ b/K2.App/Models/Ev60Key.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using K2.App.Services;
 using K2.Core;
 
 namespace K2.App.Models;
@@ -9,14 +10,26 @@ namespace K2.App.Models;
 /// <see cref="EverestKey"/> (Everest Max), but identity is the board's LED
 /// index (0-63, same as <see cref="Everest60KeyboardLayout"/>'s MatrixId)
 /// instead of a raw SDK hardware matrix code: the 64-key overlay is a fixed
-/// grid (no dynamic discovery needed like Everest Max's 100+ keys).
+/// grid (no dynamic discovery needed like Everest Max's 100+ keys). Also
+/// covers the 17-key numpad accessory (<see cref="NumpadIndex"/> non-null),
+/// stored at <c>LedIndex = Everest60Protocol.NumpadLedIndexBase + NumpadIndex</c>
+/// to share the same store table without colliding with the main board.
 /// </summary>
 public sealed class Ev60Key : INotifyPropertyChanged
 {
-    public Ev60Key(int ledIndex) => LedIndex = ledIndex;
+    public Ev60Key(int ledIndex, int? numpadIndex = null) =>
+        (LedIndex, NumpadIndex) = (ledIndex, numpadIndex);
 
-    /// <summary>Board LED index: stable key identity (0-63).</summary>
+    /// <summary>Board LED index: stable key identity (0-63 for the main
+    /// board; <see cref="Everest60Protocol.NumpadLedIndexBase"/> + 0-16 for
+    /// the numpad accessory, see <see cref="NumpadIndex"/>).</summary>
     public int LedIndex { get; }
+
+    /// <summary>Non-null only for a numpad accessory key: its 0-16 identity
+    /// (same as <see cref="Everest60KeyboardLayout"/>'s <c>KeyDef.NumpadIndex</c>
+    /// and <see cref="Everest60Protocol"/>'s <c>NumpadLedIndex</c> array
+    /// position). Null for a main-board key.</summary>
+    public int? NumpadIndex { get; }
 
     private string _label = "";
     /// <summary>Key legend (e.g. "A", "Esc", "Space").</summary>
@@ -67,19 +80,25 @@ public sealed class Ev60Key : INotifyPropertyChanged
 
     public bool HasAction => !string.IsNullOrEmpty(_actionType);
 
-    public string Name => string.IsNullOrWhiteSpace(_label) ? $"Key {LedIndex}" : _label;
+    public string Name => !string.IsNullOrWhiteSpace(_label) ? _label
+                         : NumpadIndex is int npi ? $"Numpad {npi}"
+                         : $"Key {LedIndex}";
 
     /// <summary>Text shown in the key list.</summary>
     public string Display
     {
         get
         {
-            string body = ActionTypeHelper.IsUnrecognized(_actionType) ? Loc.Get("act_unrecognized")
-                        : string.Equals(_actionType, "macro", System.StringComparison.Ordinal) ? ActionTypeHelper.MacroSummary(_actionValue)
-                        : string.IsNullOrEmpty(_actionType) ? "(empty)" : _actionType;
+            string body = string.IsNullOrEmpty(_actionType) ? "(empty)" : ActionSummary;
             return $"{Name}  —  {body}";
         }
     }
+
+    /// <summary>Mirrors DisplayPadKey.ActionSummary/EverestKey.ActionSummary/MacroPadKey.
+    /// ActionSummary — every action type must resolve through ActionTypeHelper.Summary
+    /// instead of falling back to the raw ActionType string (e.g. "oscmd" showing up as
+    /// "oscmd" instead of the assigned command; user report 2026-07-22).</summary>
+    private string ActionSummary => ActionTypeHelper.Summary(_actionType, _actionValue);
 
     public event PropertyChangedEventHandler? PropertyChanged;
     private void OnChanged([CallerMemberName] string? name = null) =>

--- a/K2.App/Models/Everest60KeyboardLayout.cs
+++ b/K2.App/Models/Everest60KeyboardLayout.cs
@@ -20,13 +20,17 @@ namespace K2.App.Models;
 /// 64 keys total, **no backtick key** — confirmed hardware quirk of this
 /// board, not an omission.</para>
 ///
-/// <para><b>Numpad accessory:</b> no source (Base Camp Windows, BaseCampLinux,
-/// or the decompiled DB schema) has ever modeled a LED/remap protocol for
-/// it — <c>has_numpad=False</c> everywhere it's referenced in BaseCampLinux.
-/// This layout is a hand-estimated approximation (same "eyeballed" spirit as
-/// the Makalu hotspots) for **visual/decorative purposes only**: every key
-/// has <see cref="KeyDef.MatrixId"/> = -1 and is not wired to any click
-/// handler or lighting command.</para>
+/// <para><b>Numpad accessory:</b> hand-estimated geometry (same "eyeballed"
+/// spirit as the Makalu hotspots) — no source ever modeled its layout.
+/// <see cref="KeyDef.MatrixId"/> stays -1 (no lighting/remap protocol via
+/// that identity), but each key now carries a real <see cref="KeyDef.NumpadIndex"/>
+/// (0-16, same order as <c>Everest60Protocol.NumpadLedIndex</c>), confirmed
+/// 2026-07-22 via USBPcap capture analysis (see CHANGELOG): the 17 keys speak
+/// standard USB HID boot-keyboard reports when unassigned, and Base Camp's
+/// own remap writes a real per-key binding over the existing lighting
+/// feature-report channel. Key Binding UI wiring (identity/persistence) is
+/// in place; the physical-press detection + device-side write are a
+/// follow-up (Fase 2, pending one more targeted capture) — see the plan.</para>
 /// </summary>
 public static class Everest60KeyboardLayout
 {
@@ -69,8 +73,9 @@ public static class Everest60KeyboardLayout
         return built;
     }
 
-    /// <summary>Decorative-only numpad accessory keys (MatrixId = -1: not
-    /// paintable, not clickable — no known protocol for this block).</summary>
+    /// <summary>Numpad accessory keys — not paintable (MatrixId stays -1, no
+    /// per-key lighting protocol), but each has a real <see cref="KeyDef.NumpadIndex"/>
+    /// (0-16) for Key Binding identity.</summary>
     public static readonly KeyDef[] Numpad = BuildNumpad();
 
     // ======================================================================
@@ -245,13 +250,14 @@ public static class Everest60KeyboardLayout
         const double npL = 14;
         const double npT = 14;
         double y = npT;
+        int idx = 0; // 0-16, same insertion order as Everest60Protocol.NumpadLedIndex
 
         void R(double yy, params (string label, double w)[] keys)
         {
             double x = npL;
             foreach (var (label, w) in keys)
             {
-                k.Add(new KeyDef(-1, label, x, yy, w, U));
+                k.Add(new KeyDef(-1, label, x, yy, w, U, idx++));
                 x += w + G;
             }
         }
@@ -259,12 +265,12 @@ public static class Everest60KeyboardLayout
         R(y, ("Num", U), ("/", U), ("*", U), ("-", U));
         y += RH;
         R(y, ("7", U), ("8", U), ("9", U));
-        k.Add(new KeyDef(-1, "+", npL + 3 * (U + G), y, U, RH + U));
+        k.Add(new KeyDef(-1, "+", npL + 3 * (U + G), y, U, RH + U, idx++));
         y += RH;
         R(y, ("4", U), ("5", U), ("6", U));
         y += RH;
         R(y, ("1", U), ("2", U), ("3", U));
-        k.Add(new KeyDef(-1, "↵", npL + 3 * (U + G), y, U, RH + U));
+        k.Add(new KeyDef(-1, "↵", npL + 3 * (U + G), y, U, RH + U, idx++));
         y += RH;
         R(y, ("0", 62), (".", U));
 

--- a/K2.App/Models/KeyboardLayout.cs
+++ b/K2.App/Models/KeyboardLayout.cs
@@ -13,7 +13,10 @@ public readonly record struct KeyDef(
     double X,         // left position in the Canvas
     double Y,         // top position in the Canvas
     double W,         // width
-    double H          // height
+    double H,         // height
+    int    NumpadIndex = -1  // Everest 60 numpad accessory key index (0-16,
+                              // same order as Everest60Protocol.NumpadLedIndex);
+                              // -1 for every other key on every other board
 );
 
 /// <summary>Physical keyboard layout type. Mirrors Base Camp's selectable set

--- a/K2.App/NewDisplayPadProfileDialog.xaml
+++ b/K2.App/NewDisplayPadProfileDialog.xaml
@@ -24,7 +24,7 @@
             <TextBlock Text="{loc:Get new_profile_dedicated_hint}"
                        Foreground="#AAA" FontSize="11" Margin="0,0,0,6"
                        TextWrapping="Wrap"/>
-            <ComboBox x:Name="CbDedicatedType" SelectedIndex="0"/>
+            <ComboBox x:Name="CbDedicatedType" SelectedIndex="0" SelectionChanged="CbDedicatedType_SelectionChanged" Padding="6,2,5,0" ScrollViewer.CanContentScroll="False"/>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">

--- a/K2.App/NewDisplayPadProfileDialog.xaml.cs
+++ b/K2.App/NewDisplayPadProfileDialog.xaml.cs
@@ -38,4 +38,9 @@ public partial class NewDisplayPadProfileDialog : Window
         DedicatedType = IsDedicated ? CbDedicatedType.SelectedItem as string : null;
         DialogResult = true;
     }
+
+    private void CbDedicatedType_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+
+    }
 }

--- a/K2.App/ProfileSettingsDialog.xaml
+++ b/K2.App/ProfileSettingsDialog.xaml
@@ -14,7 +14,7 @@
                    FontSize="16" FontWeight="Bold" Margin="0,0,0,12"/>
 
         <TextBlock Text="{loc:Get profile_settings_name_label}" Foreground="#AAA" FontSize="11" Margin="0,0,0,4"/>
-        <TextBox x:Name="TxtName" Margin="0,0,0,12" Height="25"/>
+        <TextBox x:Name="TxtName" Margin="0,0,0,12" Height="25" Padding="3,2,3,0"/>
 
         <TextBlock Text="{loc:Get profile_settings_exe_label}" Foreground="#AAA" FontSize="11" Margin="0,0,0,4"/>
         <Grid Margin="0,0,0,4">
@@ -23,7 +23,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBox x:Name="TxtExePath" Grid.Column="0" IsReadOnly="True" Margin="0,0,6,0" Height="25"/>
+            <TextBox x:Name="TxtExePath" Grid.Column="0" IsReadOnly="True" Margin="0,0,6,0" Height="25" Padding="3,2,3,0"/>
             <Button Grid.Column="1" Content="{loc:Get browse}" Click="BtnBrowse_Click" Margin="0,0,4,0" UseLayoutRounding="True" ScrollViewer.CanContentScroll="True" Padding="12,0,12,0"/>
             <Button Grid.Column="2" Content="{loc:Get profile_settings_clear}" Click="BtnClearExe_Click" UseLayoutRounding="True" ScrollViewer.CanContentScroll="True" Padding="12,0,12,0"/>
         </Grid>

--- a/K2.App/Services/Everest60HidNative.cs
+++ b/K2.App/Services/Everest60HidNative.cs
@@ -139,7 +139,7 @@ internal static class Everest60HidNative
     /// 1ms between them — pass a smaller value for read-only polling loops
     /// where 50ms×N would be too slow.
     /// </summary>
-    public static byte[]? SendFeature(SafeFileHandle h, byte[] report65, int retries = 3, int delayMs = 50)
+    public static byte[]? SendFeature(SafeFileHandle h, byte[] report65, int retries = 3, int delayMs = 50, Action<string>? log = null)
     {
         if (report65.Length != ReportSize)
             throw new ArgumentException($"report must be {ReportSize} bytes", nameof(report65));
@@ -149,6 +149,7 @@ internal static class Everest60HidNative
         {
             if (!HidD_SetFeature(h, report65, report65.Length))
             {
+                log?.Invoke($"[Ev60-HID] SendFeature cmd=0x{cmd:X2}: HidD_SetFeature failed, attempt {attempt + 1}/{retries}");
                 Thread.Sleep(delayMs);
                 continue;
             }
@@ -159,9 +160,21 @@ internal static class Everest60HidNative
             {
                 last = resp;
                 if (resp.Length >= 2 && resp[1] == cmd) return resp;
+                // Diagnostic (2026-07-22): a well-formed response for a DIFFERENT
+                // command landed here — either genuine device-side retry/lag, or
+                // (see Everest60Service.WithDevice's doc comment) another session
+                // touching the same physical device outside this call's control
+                // (the vendor SDK's own Everest360_USB.dll handle, not covered by
+                // K2's own _hidLock since it never goes through this class at all).
+                log?.Invoke($"[Ev60-HID] SendFeature cmd=0x{cmd:X2}: got echo 0x{(resp.Length >= 2 ? resp[1] : (byte)0):X2} instead, attempt {attempt + 1}/{retries}");
+            }
+            else
+            {
+                log?.Invoke($"[Ev60-HID] SendFeature cmd=0x{cmd:X2}: HidD_GetFeature failed, attempt {attempt + 1}/{retries}");
             }
             Thread.Sleep(delayMs);
         }
+        if (last is null) log?.Invoke($"[Ev60-HID] SendFeature cmd=0x{cmd:X2}: gave up after {retries} attempts, no response at all");
         return last;
     }
 

--- a/K2.App/Services/Everest60NumpadKeyPoller.cs
+++ b/K2.App/Services/Everest60NumpadKeyPoller.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+
+namespace K2.App.Services;
+
+/// <summary>
+/// Periodic polling for numpad accessory key press events, via
+/// <see cref="Everest60Service.TryQueryNumpadKeyEvent"/> (same raw-HID
+/// feature-report channel as <see cref="Everest60LedColorPoller"/> — see
+/// <see cref="Everest60Protocol.NumpadKeyBinding"/> for the protocol).
+///
+/// <para>
+/// Unlike <see cref="Everest60LedColorPoller"/> (started/stopped with the
+/// Lighting section's visibility), this poller is "always on" once started —
+/// mirrors MainWindow.Everest60.cs's own <c>_ev60PollTimer</c> lifecycle
+/// (started once in InitEverest60Module, never stopped by section changes),
+/// since a numpad key press should fire its action regardless of which
+/// section/tab is currently showing.
+/// </para>
+///
+/// <para>
+/// 100ms interval — tighter than the LED poller's 300ms since this is
+/// direct user input (perceived latency matters more than for a color
+/// preview), and a single cmd 0x08 round-trip is one Feature Report pair,
+/// not a multi-page sweep. Edge-detected on (counter changed AND pressed):
+/// see <see cref="Everest60Protocol.NumpadKeyBinding.QueryNumpadKeyEvent"/>'s
+/// doc comment for the known limitation (a very fast tap could be missed if
+/// the poll only catches the released state) — a missed edge fails toward
+/// "nothing happens", never toward firing the wrong action.
+/// </para>
+/// </summary>
+internal sealed class Everest60NumpadKeyPoller : IDisposable
+{
+    private readonly Everest60Service _ev60;
+    private readonly DispatcherTimer _timer;
+    private volatile bool _inFlight;
+    private int? _lastCounter;
+
+    /// <summary>Raised on the UI thread when a numpad key's press edge is
+    /// detected, with its DLLKeyId (see <see cref="Everest60RemapData.NumpadDllKeyId"/>
+    /// to translate to a <c>KeyDef.NumpadIndex</c>).</summary>
+    public event Action<int>? KeyPressed;
+
+    public Everest60NumpadKeyPoller(Everest60Service ev60)
+    {
+        _ev60 = ev60;
+        _timer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(100),
+        };
+        _timer.Tick += OnTick;
+    }
+
+    public bool IsRunning => _timer.IsEnabled;
+
+    public void Start()
+    {
+        if (_timer.IsEnabled) return;
+        App.WriteLog("[Ev60-NumpadPoll] started");
+        _timer.Start();
+    }
+
+    public void Stop()
+    {
+        if (!_timer.IsEnabled) return;
+        App.WriteLog("[Ev60-NumpadPoll] stopped");
+        _timer.Stop();
+    }
+
+    private void OnTick(object? sender, EventArgs e)
+    {
+        if (_inFlight) return;
+        _inFlight = true;
+        var dispatcher = _timer.Dispatcher;
+        Task.Run(() =>
+        {
+            var result = _ev60.TryQueryNumpadKeyEvent();
+            _inFlight = false;
+            if (result is not { } ev) return;
+
+            bool isNewEvent = _lastCounter != ev.Counter;
+            _lastCounter = ev.Counter;
+            if (isNewEvent && ev.Pressed)
+                dispatcher.BeginInvoke(() => KeyPressed?.Invoke(ev.DllKeyId));
+        });
+    }
+
+    public void Dispose() => _timer.Stop();
+}

--- a/K2.App/Services/Everest60Protocol.cs
+++ b/K2.App/Services/Everest60Protocol.cs
@@ -92,6 +92,14 @@ internal static class Everest60Protocol
         125, 122, 124,
     };
 
+    /// <summary>Offset added to a numpad key's 0-16 <c>KeyDef.NumpadIndex</c>
+    /// to get the <c>LedIndex</c> value used as Everest60Store's Keys-table
+    /// identity, keeping it disjoint from the main board's real LED indices
+    /// (0-63) — the two boards share the same (Profile, LedIndex) primary key
+    /// with no separate discriminator column. Key Binding persistence only;
+    /// unrelated to any hardware address.</summary>
+    public const int NumpadLedIndexBase = 1000;
+
     /// <summary>Every hardware LED address accounted for by <see cref="LedIndex"/>/
     /// <see cref="SideLedIndex"/>/<see cref="NumpadLedIndex"/> — used to spot
     /// non-zero colors at UNKNOWN addresses in a <c>GetColorData2</c> readback
@@ -307,14 +315,225 @@ internal static class Everest60Protocol
     {
         var req = MakeBuf(0x20);
         BitConverter.GetBytes(1).CopyTo(req, 5);
-        var resp = Everest60HidNative.SendFeature(h, req, delayMs: 15);
-        if (resp is null || resp.Length != Everest60HidNative.ReportSize || resp[1] != 0x20)
+        var resp = Everest60HidNative.SendFeature(h, req, delayMs: 15, log: log);
+        // Diagnostic (2026-07-22, see Everest60Service.WithDevice's doc comment):
+        // distinguish WHY a caller sees "not present" — SendFeature giving up
+        // (null), a well-formed reply for the wrong command (retries all
+        // landed on stale/interleaved traffic — echo mismatch), vs a
+        // genuinely all-zero data region. All three currently collapse to
+        // the same bool/null from here, which was hiding which one is
+        // actually happening on real hardware.
+        if (resp is null)
         {
-            log?.Invoke("[Ev60] ReadNumpadPresent: request failed");
+            log?.Invoke("[Ev60] ReadNumpadPresent: SendFeature returned null (no response at all)");
+            return null;
+        }
+        if (resp.Length != Everest60HidNative.ReportSize)
+        {
+            log?.Invoke($"[Ev60] ReadNumpadPresent: unexpected response length {resp.Length}");
+            return null;
+        }
+        if (resp[1] != 0x20)
+        {
+            log?.Invoke($"[Ev60] ReadNumpadPresent: echo mismatch, got cmd=0x{resp[1]:X2} instead of 0x20 " +
+                        "(another poller's response landed here — contention, not this call failing outright)");
             return null;
         }
         for (int i = 9; i < 61; i++) // wire bytes [8..59]: data region, excludes the constant trailer
-            if (resp[i] != 0) return true;
+            if (resp[i] != 0)
+            {
+                log?.Invoke("[Ev60] ReadNumpadPresent: present (non-zero data region)");
+                return true;
+            }
+        log?.Invoke("[Ev60] ReadNumpadPresent: not present (data region genuinely all-zero)");
         return false;
+    }
+
+    /// <summary>Sentinel value for "no action"/disabled — confirmed
+    /// 2026-07-22 via a 4th capture (<c>ev60_del.pcapng</c>, Base Camp itself
+    /// removing a numpad binding) to be plain <c>255</c> (one byte,
+    /// zero-padded to an int32), not <c>0xFFFFFFFF</c> as first misread from
+    /// the raw hex (three "ff 00 00 00" int32 fields in an early query
+    /// response — each one is 255, not 0xFFFFFFFF). Same value as
+    /// <see cref="Everest60RemapData.DisabledKeyId"/>, the main board's own
+    /// "reset/disable" sentinel for <c>ChangeKey</c>/<c>ChangeFnKey</c> — one
+    /// shared convention across both protocols, not a coincidence.</summary>
+    public const int NumpadUnassignedMarker = 255;
+
+    /// <summary>Fixed action-type value K2 writes for any bound numpad key —
+    /// arbitrary from K2's point of view (see class doc below).</summary>
+    public const int NumpadBoundMarker = 1;
+
+    /// <summary>
+    /// Numpad Key Binding protocol (query/write/commit/event-poll) —
+    /// reverse-engineered 2026-07-22 from three real Base Camp USB captures
+    /// (<c>_reference/usb_dumps/ev60_keyconf.pcapng</c>,
+    /// <c>ev60_press.pcapng</c>; see CHANGELOG for the full trace), same
+    /// feature-report channel/magic as the rest of this class — no new
+    /// interface or transport needed.
+    ///
+    /// <para><b>Identity</b>: the "index" every one of these commands takes
+    /// is the numpad key's <b>DLLKeyId</b> (same catalog as
+    /// <see cref="Everest60RemapData.KeyCatalog"/>/<c>ChangeKey</c> for the
+    /// main 64 keys, extracted for the numpad via a fresh decompile of
+    /// <c>Everest60Operations.GetEverest60KeyBindings_English</c> — see
+    /// <see cref="Everest60RemapData.NumpadDllKeyId"/>), NOT a LED index or
+    /// the 0-16 <c>KeyDef.NumpadIndex</c>/array position. Confirmed against
+    /// two independent captures: assigning "7" wrote idx=0x5B=91=DLLKeyId("Numpad 7");
+    /// assigning "4" queried idx=0x5C=92=DLLKeyId("Numpad 4") — exact match,
+    /// not coincidence.
+    /// </para>
+    ///
+    /// <para><b>Write (<see cref="WriteKeyActionType"/>/<see cref="WriteKeyActionParam"/>/
+    /// <see cref="CommitKeyBinding"/>)</b>: captured verbatim assigning
+    /// "Open Folder ...\Braccio robotico" to Numpad 7 — cmd 0x2A writes
+    /// (dllKeyId, actionTypeValue) as two int32 LE fields; cmd 0x2B writes
+    /// the action's string parameter (the real folder path was transmitted
+    /// in clear, chunked ≤56 bytes/packet with a 4-byte LE length prefix);
+    /// cmd 0x2C commits. <b>K2 does not need to replicate Base Camp's real
+    /// action-type numbering</b> (that capture's value 0x3E for "Open
+    /// Folder" is Base Camp's own vocabulary) — K2 executes its OWN
+    /// K2Action via <c>Ev60ActionHost</c>/<c>ButtonActionEngine</c>
+    /// regardless of what this firmware-side value would have meant to Base
+    /// Camp, so <see cref="NumpadBoundMarker"/> (an arbitrary non-sentinel
+    /// constant) is used for every K2-assigned key. A second capture also
+    /// showed a cmd 0x29 with a different 2-int32 shape for a different
+    /// action type (Run Program) — confirms the write command family varies
+    /// by Base Camp's own action type, which is exactly why K2 doesn't try
+    /// to mirror it: cmd 0x2A/0x2B/0x2C is the one fully end-to-end
+    /// confirmed sequence (verified it silences the key's raw HID output),
+    /// so K2 always uses that one path regardless of the K2Action assigned.
+    /// </para>
+    ///
+    /// <para><b>Unassign (<see cref="UnassignKey"/>)</b>: confirmed 2026-07-22
+    /// via a 4th capture (<c>ev60_del.pcapng</c>, Base Camp itself removing a
+    /// numpad binding after a prior real-hardware test showed K2's original
+    /// guess — writing <see cref="NumpadUnassignedMarker"/> via cmd 0x2A —
+    /// did NOT restore the literal keystroke). The capture showed no
+    /// distinct write command at all for the removal: the only relevant
+    /// traffic was a cmd 0x22 call (dllKeyId, value=255), and the boot-
+    /// keyboard HID report for the physical key reappeared shortly after.
+    /// So the real mechanism is cmd 0x22 acting as a combined query/reset
+    /// (255 = <see cref="Everest60RemapData.DisabledKeyId"/>, the SAME
+    /// sentinel already used by the main board's <c>ChangeKey</c>), not a
+    /// cmd 0x2A write — see <see cref="UnassignKey"/>'s own doc comment.
+    /// </para>
+    ///
+    /// <para><b>Physical-press detection (<see cref="QueryNumpadKeyEvent"/>,
+    /// cmd 0x08)</b>: NOT the same as <c>Effect.Yeti = 0x08</c> above (that's
+    /// an unrelated enum value in a completely different command's payload,
+    /// pure coincidence of numbering) — cmd 0x08 is Base Camp's own
+    /// continuous background status poll (never sent by K2 before this),
+    /// whose response happens to carry the last numpad key event inline:
+    /// wire response bytes [4]=0x02 (constant), [5]=an incrementing event
+    /// counter, [6]=the DLLKeyId of the affected key, [7]=1 (pressed) / 0
+    /// (released). Verified across two independent, isolated physical
+    /// presses (Base Camp's own remap dialog fully closed, ~20s of idle
+    /// around them): the counter/dllKeyId/pressed fields are exactly what
+    /// changes, precisely twice, with zero false positives during idle —
+    /// this is NOT the same as the also-present cmd 0x07→0x2D exchange
+    /// (which turned out to be Base Camp's own housekeeping/list-refresh,
+    /// unreliable as a press signal on its own).
+    /// </para>
+    /// </summary>
+    public static class NumpadKeyBinding
+    {
+        /// <summary>Queries a numpad key's current binding (cmd 0x22) —
+        /// diagnostic/logging only, K2 doesn't need the result to decide what
+        /// to write. Returns the raw int32 action-type value, or
+        /// <see cref="NumpadUnassignedMarker"/> if unbound / on failure.</summary>
+        public static int QueryKeyBinding(SafeFileHandle h, int dllKeyId, Action<string>? log = null)
+        {
+            var req = MakeBuf(0x22);
+            BitConverter.GetBytes(dllKeyId).CopyTo(req, 5);
+            var resp = Everest60HidNative.SendFeature(h, req, delayMs: 15, log: log);
+            if (resp is null || resp[1] != 0x22)
+            {
+                log?.Invoke($"[Ev60] NumpadKeyBinding.QueryKeyBinding: dllKeyId={dllKeyId} failed");
+                return NumpadUnassignedMarker;
+            }
+            return BitConverter.ToInt32(resp, 9);
+        }
+
+        /// <summary>Marks a numpad key as bound (cmd 0x2A: dllKeyId at byte
+        /// 5, value at byte 9) — see class doc for why <paramref name="value"/>
+        /// doesn't need to mean anything to Base Camp.</summary>
+        public static void WriteKeyActionType(SafeFileHandle h, int dllKeyId, int value, Action<string>? log = null)
+        {
+            var req = MakeBuf(0x2A);
+            BitConverter.GetBytes(dllKeyId).CopyTo(req, 5);
+            BitConverter.GetBytes(value).CopyTo(req, 9);
+            var resp = Everest60HidNative.SendFeature(h, req, log: log);
+            log?.Invoke($"[Ev60] NumpadKeyBinding.WriteKeyActionType: dllKeyId={dllKeyId} value={value} " +
+                        $"-> {(resp is { Length: > 1 } && resp[1] == 0x2A ? "ack" : "no-ack")}");
+        }
+
+        /// <summary>Writes the action's string parameter (cmd 0x2B), chunked
+        /// ≤56 bytes/packet with a 4-byte LE length prefix per packet — see
+        /// class doc for the one detail (a stray extra byte in the capture's
+        /// first, multi-chunk-needing packet) left unresolved since K2's own
+        /// placeholder text is short enough to normally need a single
+        /// chunk.</summary>
+        public static void WriteKeyActionParam(SafeFileHandle h, string text, Action<string>? log = null)
+        {
+            const int maxChunk = 56;
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(text ?? "");
+            int off = 0;
+            do
+            {
+                int len = Math.Min(maxChunk, bytes.Length - off);
+                var req = MakeBuf(0x2B);
+                BitConverter.GetBytes(len).CopyTo(req, 5);
+                if (len > 0) Array.Copy(bytes, off, req, 9, len);
+                Everest60HidNative.SendFeature(h, req, log: log);
+                off += len;
+            } while (off < bytes.Length);
+            log?.Invoke($"[Ev60] NumpadKeyBinding.WriteKeyActionParam: \"{text}\" ({bytes.Length} bytes)");
+        }
+
+        /// <summary>Commits a binding written via <see cref="WriteKeyActionType"/>/
+        /// <see cref="WriteKeyActionParam"/> (cmd 0x2C, no payload).</summary>
+        public static void CommitKeyBinding(SafeFileHandle h, Action<string>? log = null)
+        {
+            var resp = Everest60HidNative.SendFeature(h, MakeBuf(0x2C), log: log);
+            log?.Invoke($"[Ev60] NumpadKeyBinding.CommitKeyBinding -> {(resp is { Length: > 1 } && resp[1] == 0x2C ? "ack" : "no-ack")}");
+        }
+
+        /// <summary>Restores a numpad key to its unassigned (literal
+        /// keystroke) state — confirmed 2026-07-22 via a 4th capture
+        /// (Base Camp itself removing a numpad binding): despite going
+        /// through Base Camp's "remove" UI, no distinct write command ever
+        /// appeared on the wire — the only relevant traffic was cmd 0x22
+        /// (the SAME shape as <see cref="QueryKeyBinding"/>) with
+        /// <see cref="NumpadUnassignedMarker"/> (255) as its value, and the
+        /// physical key's raw HID boot-keyboard report reappeared moments
+        /// later. So cmd 0x22 is a combined query/reset, not a pure read:
+        /// harmless on an already-unassigned key (255 stays 255), and it
+        /// clears an assigned one. No commit needed — none was seen either.
+        /// </summary>
+        public static void UnassignKey(SafeFileHandle h, int dllKeyId, Action<string>? log = null)
+        {
+            var req = MakeBuf(0x22);
+            BitConverter.GetBytes(dllKeyId).CopyTo(req, 5);
+            BitConverter.GetBytes(NumpadUnassignedMarker).CopyTo(req, 9);
+            var resp = Everest60HidNative.SendFeature(h, req, log: log);
+            log?.Invoke($"[Ev60] NumpadKeyBinding.UnassignKey: dllKeyId={dllKeyId} " +
+                        $"-> {(resp is { Length: > 1 } && resp[1] == 0x22 ? "ack" : "no-ack")}");
+        }
+
+        /// <summary>Polls for a numpad key press/release event (cmd 0x08, no
+        /// request payload). Returns (counter, dllKeyId, pressed) from the
+        /// response, or null on failure — see class doc for the byte layout
+        /// and how it was verified.</summary>
+        public static (int Counter, int DllKeyId, bool Pressed)? QueryNumpadKeyEvent(SafeFileHandle h, Action<string>? log = null)
+        {
+            var resp = Everest60HidNative.SendFeature(h, MakeBuf(0x08), delayMs: 5);
+            if (resp is null || resp[1] != 0x08)
+            {
+                log?.Invoke("[Ev60] NumpadKeyBinding.QueryNumpadKeyEvent: request failed");
+                return null;
+            }
+            return (Counter: resp[6], DllKeyId: resp[7], Pressed: resp[8] == 1);
+        }
     }
 }

--- a/K2.App/Services/Everest60RemapData.cs
+++ b/K2.App/Services/Everest60RemapData.cs
@@ -75,6 +75,28 @@ internal static class Everest60RemapData
         58, 59, 60, 61, 62, 154, 79, 84, 89,
     };
 
+    /// <summary>Numpad accessory's 17 keys → DLLKeyId, same index order as
+    /// <c>Everest60KeyboardLayout.Numpad</c>/<c>KeyDef.NumpadIndex</c>/
+    /// <c>Everest60Protocol.NumpadLedIndex</c> (Num,/,*,-, 7,8,9,+, 4,5,6,
+    /// 1,2,3,Enter, 0,.). Extracted 2026-07-22 by re-decompiling
+    /// <c>Everest60Operations.GetEverest60KeyBindings_English</c> (same
+    /// method as <see cref="KeyCatalog"/> above, whose doc comment originally
+    /// dismissed these ~52 extra catalog entries as "not needed — this
+    /// device has none of those keys", an assumption superseded once the
+    /// accessory numpad's own Key Binding protocol was found via USBPcap —
+    /// see CHANGELOG). Verified against two independent captures assigning a
+    /// real numpad key: "Numpad 7"'s DLLKeyId (91=0x5B) and "Numpad 4"'s
+    /// (92=0x5C) both matched the wire value exactly, not inferred.</summary>
+    public static readonly int[] NumpadDllKeyId =
+    {
+        90, 95, 100, 105,   // Num Lock, /, *, -
+        91, 96, 101, 106,   // 7, 8, 9, +
+        92, 97, 102,        // 4, 5, 6
+        93, 98, 103,        // 1, 2, 3
+        108,                // Enter
+        99, 104,            // 0, .
+    };
+
     /// <summary>Modifier bitmask values for ChangeShortcutKey.</summary>
     public const int ModCtrl = 1;
     public const int ModShift = 2;

--- a/K2.App/Services/Everest60Service.cs
+++ b/K2.App/Services/Everest60Service.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
 namespace K2.App.Services;
@@ -16,24 +18,131 @@ internal sealed class Everest60Service
 {
     private readonly Action<string> _log;
 
+    /// <summary>Serializes every find-open-send-close cycle below. Added
+    /// 2026-07-22 alongside <see cref="Everest60NumpadKeyPoller"/>: with
+    /// three independent background pollers now hitting this same raw-HID
+    /// channel (LED colors every 300ms, numpad key events every 100ms,
+    /// numpad-presence status every 3s), a request from one thread could
+    /// land between another thread's SET and GET — <see cref="Everest60HidNative.SendFeature"/>'s
+    /// retry-until-echo-matches logic tolerates a one-off mismatch, but a
+    /// real-hardware report showed the numpad-presence check occasionally
+    /// losing that race and reading back the WRONG command's response,
+    /// which <see cref="MainWindow"/>'s <c>Ev60RefreshStatus</c> then
+    /// (correctly, given what it got back) interpreted as "no numpad
+    /// present" for one 3s tick — the accessory visibly disappearing from
+    /// the UI for a few seconds before the next tick re-detected it. A
+    /// plain <c>lock</c> is enough: every call here is a short, synchronous,
+    /// already-blocking HID round trip, never awaited.</summary>
+    private readonly object _hidLock = new();
+
+    /// <summary>Last device path/PID resolved by <see cref="Everest60HidNative.FindDevice"/>,
+    /// reused directly (one CreateFile call) instead of re-enumerating the entire system HID
+    /// tree on every single call. Added 2026-07-22: with the LED poller (300ms), numpad poller
+    /// (100ms) and this class's own 3s status poll all going through FindDevice, its
+    /// SetupDiGetClassDevsW walk-and-open-every-candidate was running roughly 14x/second —
+    /// expensive enough on a machine with several HID devices to make the on-screen LED
+    /// preview visibly stutter/stall (user report 2026-07-22). Cleared (so the next call falls
+    /// back to a fresh FindDevice) whenever the cached path fails to open, e.g. an unplug/replug.
+    /// Written under <see cref="_hidLock"/> everywhere for a consistent snapshot, but
+    /// <see cref="IsConnected"/> only holds the lock for that snapshot (not the HID I/O itself)
+    /// — see its own comment for why.</summary>
+    private Everest60HidNative.FoundDevice? _cachedDevice;
+
     public Everest60Service(Action<string>? log = null) => _log = log ?? (_ => { });
 
-    /// <summary>True if an Everest 60 is currently plugged in. Cheap enough to poll.</summary>
+    /// <summary>True if an Everest 60 is currently plugged in. Cheap enough to poll.
+    /// Deliberately does NOT hold <see cref="_hidLock"/> for the actual HID I/O (only for the
+    /// brief <see cref="_cachedDevice"/> snapshot/update) — this runs synchronously on the UI
+    /// thread every 3s (MainWindow.Everest60.cs's Ev60RefreshStatus), so blocking it behind a
+    /// LED/numpad poller's in-progress read would trade one stutter for another.</summary>
     public bool IsConnected(out string model)
     {
-        var found = Everest60HidNative.FindDevice();
+        Everest60HidNative.FoundDevice? cached;
+        lock (_hidLock) { cached = _cachedDevice; }
+
+        if (cached is { } c)
+        {
+            using var hc = Everest60HidNative.Open(c.Path, _log);
+            if (hc != null && !hc.IsInvalid)
+            {
+                model = c.Pid == Everest60HidNative.PidIso ? "Everest 60 ISO" : "Everest 60";
+                return true;
+            }
+            // stale (unplugged/path changed) — fall through to a fresh enumeration below
+            // rather than touch _cachedDevice here, avoiding a race with a poller that may
+            // have already refreshed it.
+        }
+
+        var found = Everest60HidNative.FindDevice(_log);
         model = found?.Pid == Everest60HidNative.PidIso ? "Everest 60 ISO" : "Everest 60";
-        return found != null;
+        if (found is null) return false;
+        lock (_hidLock) { _cachedDevice = found; }
+        return true;
     }
 
-    private bool WithDevice(Action<SafeFileHandle> action)
+    /// <summary>Diagnostic addition 2026-07-22: logs how long each call spent
+    /// WAITING for <see cref="_hidLock"/> vs actually doing HID I/O, tagged
+    /// by <paramref name="op"/> (e.g. "TryGetNumpadPresent") — added to
+    /// narrow down a real-hardware report that the numpad still disappears
+    /// from the UI (and, once, took several seconds to appear at startup)
+    /// even after serializing HID access. If <c>lockWaitMs</c> is
+    /// consistently near zero, the pollers aren't actually contending for
+    /// the lock and the cause is elsewhere (e.g. the firmware itself, or
+    /// <c>Everest60SdkService</c>'s separate vendor-DLL session touching the
+    /// same physical device outside this lock entirely — see its remarks).
+    /// Logs only when <paramref name="op"/> is supplied, so this stays a
+    /// no-op for callers that don't care.</summary>
+    private bool WithDevice(Action<SafeFileHandle> action, string? op = null)
     {
-        var found = Everest60HidNative.FindDevice(_log);
-        if (found is null) { _log("[Ev60] not connected"); return false; }
-        using var h = Everest60HidNative.Open(found.Value.Path, _log);
-        if (h is null || h.IsInvalid) { _log("[Ev60] open failed"); return false; }
-        action(h);
-        return true;
+        var waitSw = op != null ? Stopwatch.StartNew() : null;
+        bool entered = false;
+        try
+        {
+            Monitor.Enter(_hidLock, ref entered);
+            long lockWaitMs = waitSw?.ElapsedMilliseconds ?? 0;
+            var ioSw = op != null ? Stopwatch.StartNew() : null;
+
+            // Fast path: reuse the last resolved device instead of a fresh
+            // FindDevice (full HID-tree enumeration) — see _cachedDevice's doc
+            // comment. Falls through to the slow path below if the cached
+            // handle no longer opens (unplug/replug).
+            if (_cachedDevice is { } cached)
+            {
+                using var hc = Everest60HidNative.Open(cached.Path, _log);
+                if (hc != null && !hc.IsInvalid)
+                {
+                    action(hc);
+                    if (op != null)
+                        _log($"[Ev60-HID] {op}: ok cached (lockWait={lockWaitMs}ms, io={ioSw!.ElapsedMilliseconds}ms)");
+                    return true;
+                }
+                _cachedDevice = null;
+            }
+
+            var found = Everest60HidNative.FindDevice(_log);
+            if (found is null)
+            {
+                _log("[Ev60] not connected");
+                if (op != null) _log($"[Ev60-HID] {op}: not connected (lockWait={lockWaitMs}ms)");
+                return false;
+            }
+            using var h = Everest60HidNative.Open(found.Value.Path, _log);
+            if (h is null || h.IsInvalid)
+            {
+                _log("[Ev60] open failed");
+                if (op != null) _log($"[Ev60-HID] {op}: open failed (lockWait={lockWaitMs}ms)");
+                return false;
+            }
+            _cachedDevice = found;
+            action(h);
+            if (op != null)
+                _log($"[Ev60-HID] {op}: ok (lockWait={lockWaitMs}ms, io={ioSw!.ElapsedMilliseconds}ms)");
+            return true;
+        }
+        finally
+        {
+            if (entered) Monitor.Exit(_hidLock);
+        }
     }
 
     /// <summary>Applies a preset effect. <paramref name="direction"/> is ignored
@@ -88,18 +197,53 @@ internal sealed class Everest60Service
     public bool TryGetColorData(EverestSdkNative.FWColor[] colors)
     {
         bool ok = false;
-        WithDevice(h => ok = Everest60Protocol.ReadColorData(h, colors, _log));
+        WithDevice(h => ok = Everest60Protocol.ReadColorData(h, colors, _log), op: "LedColorRead");
         return ok;
     }
 
     /// <summary>Numpad accessory presence, over raw HID (see
     /// Everest60Protocol.ReadNumpadPresent's doc comment for why — the SDK's
     /// GetSubDeviceInfo was found to reliably fail with a Makalu also
-    /// connected). Returns null if the main keyboard itself isn't reachable.</summary>
+    /// connected). Returns null if the main keyboard itself isn't reachable.
+    /// Logs the raw tri-state result every call (diagnostic, 2026-07-22 —
+    /// see WithDevice's doc comment) since a bare bool return can't tell a
+    /// caller whether "false" meant a clean empty reading or something else.</summary>
     public bool? TryGetNumpadPresent()
     {
         bool? present = null;
-        WithDevice(h => present = Everest60Protocol.ReadNumpadPresent(h, _log));
+        bool reached = WithDevice(h => present = Everest60Protocol.ReadNumpadPresent(h, _log), op: "NumpadPresence");
+        _log($"[Ev60-NumpadPresence] reached={reached} present={present?.ToString() ?? "null"}");
         return present;
+    }
+
+    /// <summary>Binds a numpad accessory key on the device (see
+    /// <see cref="Everest60Protocol.NumpadKeyBinding"/> for the write
+    /// sequence/protocol notes, incl. why <paramref name="label"/> doesn't
+    /// need to mean anything to Base Camp). Call once per key when the user
+    /// assigns a K2Action to it, and again for every already-bound numpad
+    /// key on profile load/device reconnect (the firmware doesn't persist
+    /// this across a replug, same reason lighting needs re-applying).</summary>
+    public bool WriteNumpadKeyBinding(int dllKeyId, string label) =>
+        WithDevice(h =>
+        {
+            Everest60Protocol.NumpadKeyBinding.WriteKeyActionType(h, dllKeyId, Everest60Protocol.NumpadBoundMarker, _log);
+            Everest60Protocol.NumpadKeyBinding.WriteKeyActionParam(h, label, _log);
+            Everest60Protocol.NumpadKeyBinding.CommitKeyBinding(h, _log);
+        }, op: "WriteNumpadKeyBinding");
+
+    /// <summary>Restores a numpad accessory key to its factory (unassigned,
+    /// literal-keystroke) state — see
+    /// <see cref="Everest60Protocol.NumpadKeyBinding"/>'s doc comment.</summary>
+    public bool UnassignNumpadKey(int dllKeyId) =>
+        WithDevice(h => Everest60Protocol.NumpadKeyBinding.UnassignKey(h, dllKeyId, _log), op: "UnassignNumpadKey");
+
+    /// <summary>Polls for a numpad accessory key press/release event (see
+    /// <see cref="Everest60Protocol.NumpadKeyBinding.QueryNumpadKeyEvent"/>).
+    /// Powers <see cref="Everest60NumpadKeyPoller"/>.</summary>
+    public (int Counter, int DllKeyId, bool Pressed)? TryQueryNumpadKeyEvent()
+    {
+        (int Counter, int DllKeyId, bool Pressed)? result = null;
+        WithDevice(h => result = Everest60Protocol.NumpadKeyBinding.QueryNumpadKeyEvent(h, _log), op: "NumpadKeyEventPoll");
+        return result;
     }
 }

--- a/K2.Core/AppSettings.cs
+++ b/K2.Core/AppSettings.cs
@@ -29,7 +29,7 @@ public static class AppSettings
     private sealed class Data
     {
         public bool DebugMode { get; set; }
-        public K2LogLevel LogLevel { get; set; } = K2LogLevel.Normal;
+        public K2LogLevel LogLevel { get; set; } = K2LogLevel.Off;
         public bool KillBaseCampWorker { get; set; } = true;
         public bool AutoStopBaseCamp { get; set; } = true;
         public bool CloseToTray { get; set; }

--- a/K2.Core/Strings.it.xml
+++ b/K2.Core/Strings.it.xml
@@ -26,6 +26,7 @@
   <string name="backlight_auto_off_group">Spegnimento automatico retroilluminazione</string>
   <string name="backlight_auto_off_enable">Spegni retroilluminazione se inattivo</string>
   <string name="backlight_auto_off_seconds">Dopo</string>
+  <string name="keyboard_language_layout">Impostazioni lingua</string>
   <string name="pos_horizontal">Orizzontale ({0}°)</string>
   <string name="pos_vertical">Verticale ({0}°)</string>
   <string name="brightness">Luminosità:</string>


### PR DESCRIPTION
Adds numpad accessory key-press polling (Everest60NumpadKeyPoller, 100ms edge-detected) and the remap protocol/data needed to bind actions to those keys, plus supporting Everest60 HID/service/layout changes and minor DisplayPad new-profile/settings dialog tweaks.