### PR TITLE
1.1.1: System monitor widget, media dock/display dial improvements, Everest Max fixes

### DIFF
--- a/K2.App/K2.App.csproj
+++ b/K2.App/K2.App.csproj
@@ -94,6 +94,7 @@
   <ItemGroup>
     <Resource Include="Assets\K2_logo.png" />
     <Resource Include="Assets\K2_icon.png" />
+    <Resource Include="Assets\K2_icon.ico" />
     <Resource Include="Assets\setting_keyboard.png" />
     <Resource Include="Assets\MKD_setting.png" />
     <Resource Include="Assets\DKD_Setting.png" />

--- a/K2.App/MainWindow.DisplayDial.cs
+++ b/K2.App/MainWindow.DisplayDial.cs
@@ -1,4 +1,4 @@
-// MainWindow.DisplayDial.cs — partial class: "Display Dial" panel
+﻿// MainWindow.DisplayDial.cs — partial class: "Display Dial" panel
 // Controls the visible pages on the Everest Max rotary display
 // and clock, screensaver, auto-off, menu color settings.
 //
@@ -31,10 +31,20 @@
 //                      actual wire framing has a few more header bytes than
 //                      assumed; doesn't matter now that the field identity is
 //                      confirmed from source, not inferred from offsets).
-//   byMMDockMenuIndex = ALWAYS hardcoded to 0 by Base Camp's own apply logic
-//                      (`stfld byMMDockMenuIndex` right after `initobj`, no
-//                      DisplayDial field feeds it) — not writable through this
-//                      path, full stop. Confirmed dead end; not used at all.
+//   byMMDockMenuIndex = write-only-as-zero, READ-ONLY as state. Base Camp's apply
+//                      logic always hardcodes it to 0 (`stfld byMMDockMenuIndex`
+//                      right after `initobj`, no DisplayDial field feeds it), so
+//                      there is nothing to send here — but that is only half the
+//                      story, and an earlier version of this comment ("confirmed
+//                      dead end; not used at all") wrote the field off entirely.
+//                      READ BACK, it reports the page the dock is currently
+//                      showing: 33..37 profile 1..5, 49..57 effect, 65 volume,
+//                      81 brightness, 97..101 PC info CPU/GPU/HDD/Internet/RAM,
+//                      113 APM. That is how Base Camp feeds the dock's live pages
+//                      and how it notices profile/effect changes made on the
+//                      keyboard (BaseCampService.PcInfo_timer, Common._dicEffects
+//                      — decompiled 2026-08-22). K2 reads it in
+//                      MainWindow.MediaDock.cs; do not delete it as unused.
 //   wMMDockScreenSaver / wMMDockTurnOff = timeout in seconds, ALWAYS sent as
 //                      the real configured value (Base Camp does NOT zero
 //                      these to represent "disabled" — that's carried
@@ -87,15 +97,27 @@ public partial class MainWindow
     private bool _dialInitialized;
 
     /// <summary>
-    /// Ticks the Media Dock clock every second (<c>EverestService.UpdateClock</c>) —
-    /// see that method's remarks (real Base Camp sends the format on every
-    /// periodic clock call, not via SetExtendInfo). Runs for the app's lifetime;
-    /// the Tick handler no-ops if the driver isn't open, same tolerance as other
-    /// pollers in this codebase. Unlike the RbDialClockType radio buttons
-    /// themselves, this always carries <see cref="_dialAppliedFormat24h"/> — the
-    /// clock must keep ticking continuously (it's not a one-shot setting write),
-    /// but which format it uses only changes on "Apply to device", same as
-    /// every other Display Dial field.
+    /// Re-syncs the Media Dock clock (<c>EverestService.UpdateClock</c>) — see that
+    /// method's remarks (real Base Camp carries the 12h/24h format on the clock call
+    /// itself, not via SetExtendInfo). Runs for the app's lifetime; the Tick handler
+    /// no-ops if the driver isn't open, same tolerance as other pollers in this
+    /// codebase. Always carries <see cref="_dialAppliedFormat24h"/>, which only
+    /// changes on "Apply to device" like every other Display Dial field.
+    /// <para>
+    /// <b>Interval = 30 minutes, NOT 1 second (2026-08-22 bug fix).</b> The dock has
+    /// an on-board RTC: <c>SetClockInfo</c> sets the time, the firmware ticks it on
+    /// its own. Ticking this every second was a K2 invention, and it kept the dock's
+    /// idle counter permanently reset — user report: "the screensaver never starts".
+    /// Confirmed against the real thing by decompiling <c>BaseCamp.Service.exe</c>
+    /// (<c>BaseCampService.Clock_timer</c>): <c>Interval = 1800000.0</c> ms, handler
+    /// <c>Clock_timer_Elapsed</c> → <c>Common.SetClockInfoInHW()</c>. Base Camp's own
+    /// 1-second timer (<c>PcInfo_timer</c>) only ever <i>reads</i> FW_EXTEND_INFO and
+    /// writes exclusively to the page the dock is currently showing — it never writes
+    /// the clock periodically. Extra clock pushes still happen exactly where Base Camp
+    /// does them: at session logon/unlock and when the Display Dial data is applied
+    /// (see <see cref="ApplyDialToDevice"/> and the one-shot sync in
+    /// <see cref="InitDisplayDialPanel"/>).
+    /// </para>
     /// </summary>
     private DispatcherTimer? _dialClockTimer;
 
@@ -190,13 +212,20 @@ public partial class MainWindow
 
         if (_dialClockTimer is null)
         {
-            _dialClockTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            // 30 min, same as Base Camp's own Clock_timer — see _dialClockTimer's docs
+            // for why a 1s tick broke the dock screensaver.
+            _dialClockTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(30) };
             _dialClockTimer.Tick += (_, _) =>
             {
                 if (_everest is { IsOpen: true })
                     _everest.UpdateClock(format24h: _dialAppliedFormat24h);
             };
             _dialClockTimer.Start();
+            // First sync now: with a 30-minute period the first Tick is far too late
+            // to put the right time on the dock at startup (Base Camp does the same
+            // one-shot push when the service starts / the Display Dial page opens).
+            if (_everest is { IsOpen: true })
+                _everest.UpdateClock(format24h: _dialAppliedFormat24h);
         }
         _dialInitialized = true;
     }

--- a/K2.App/MainWindow.MediaDock.cs
+++ b/K2.App/MainWindow.MediaDock.cs
@@ -1,34 +1,316 @@
-// MainWindow.MediaDock.cs — partial: Media Dock stub (UI panel removed).
-// Keeps only init/cleanup to avoid breaking references in MainWindow.Everest.cs.
-// Dock detection remains available via _everest.IsMMDockPlugged().
+// MainWindow.MediaDock.cs — partial: the Media Dock's live data feed.
+//
+// The dock's own pages (Volume, PC Info: CPU/GPU/HDD/Internet/RAM, APM) hold no
+// data of their own — the host has to push a number into them, and only into the
+// one the dock is currently showing. `FW_EXTEND_INFO.byMMDockMenuIndex` is what
+// says which page that is.
+//
+// That field is READ-ONLY state, and this is the one place K2 reads it. Writing
+// it is a dead end (Base Camp hardcodes it to 0 in every apply path — see
+// MainWindow.DisplayDial.cs's header), which is why it looked useless for a long
+// time. Reading it back tells you what the user is doing ON the keyboard:
+//
+//   33..37  Profile 1..5 page      49..57  Effect page (Static..Off)
+//   65      Volume                 81      Brightness
+//   97..101 PC Info CPU/GPU/HDD/Internet/RAM
+//   113     APM                    130     (guard value in BC's macro path, unknown)
+//
+// Confirmed 2026-08-22 by decompiling BaseCamp.Service.exe: BaseCampService's
+// `PcInfo_timer` (1000 ms) reads FW_EXTEND_INFO and calls SetPCInfo/SetVolumeInfo
+// for the matching page only, and `Common._dicEffects` supplies the 49..57 names.
+//
+// Writing ONLY the visible page is not an optimisation, it is the constraint:
+// every host write resets the dock's idle counter, so blanket per-second writes
+// stop the screensaver from ever starting (the bug fixed the same day in
+// MainWindow.DisplayDial.cs — a 1 Hz clock resync did exactly that).
 
-using System.Runtime.InteropServices;
+using System;
+using System.Collections.Generic;
+using System.Windows.Threading;
+using K2.App.Services;
 
 namespace K2.App;
 
 public partial class MainWindow
 {
-    /// <summary>Stub — UI panel removed. No initialization needed.</summary>
-    private void InitMediaDockPanel() { }
+    // Page codes as read back from byMMDockMenuIndex.
+    private const byte DockPageProfileFirst = 33, DockPageProfileLast = 37;
+    private const byte DockPageEffectFirst  = 49, DockPageEffectLast  = 57;
+    private const byte DockPageVolume       = 65;
+    private const byte DockPageBrightness   = 81;
+    private const byte DockPageCpu          = 97;
+    private const byte DockPageGpu          = 98;
+    private const byte DockPageDisk         = 99;
+    private const byte DockPageNet          = 100;
+    private const byte DockPageRam          = 101;
+    private const byte DockPageApm          = 113;
 
-    private void CleanupMediaDock() { }
+    // SetPCInfo's infoType, per Base Camp's own call sites.
+    private const int PcInfoCpu = 0, PcInfoGpu = 1, PcInfoDisk = 2,
+                      PcInfoNet = 3, PcInfoRam = 4, PcInfoApm = 5;
 
-    // Win32 for RAM monitoring (kept for future use)
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GlobalMemoryStatusEx(ref MEMORYSTATUSEX lpBuffer);
+    private DispatcherTimer? _dockPollTimer;
 
-    [StructLayout(LayoutKind.Sequential)]
-    private struct MEMORYSTATUSEX
+    /// <summary>Last page seen, so a change can be acted on once instead of every tick.</summary>
+    private int _dockLastPage = -1;
+
+    /// <summary>When the dock last changed page — the only idle signal available from
+    /// here. See <see cref="DockShouldStopFeeding"/>.</summary>
+    private DateTime _dockPageSince = DateTime.UtcNow;
+
+    /// <summary>Starts the 1 Hz dock feed. Same period as Base Camp's PcInfo_timer: the
+    /// dock's pages are live readouts, and the tick is mostly a single read
+    /// (GetExtendInfo) with a write only when a data page is actually on screen.</summary>
+    private void InitMediaDockPanel()
     {
-        public uint   dwLength;
-        public uint   dwMemoryLoad;
-        public ulong  ullTotalPhys;
-        public ulong  ullAvailPhys;
-        public ulong  ullTotalPageFile;
-        public ulong  ullAvailPageFile;
-        public ulong  ullTotalVirtual;
-        public ulong  ullAvailVirtual;
-        public ulong  ullAvailExtendedVirtual;
+        if (_dockPollTimer is not null) return;
+        _dockPollTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _dockPollTimer.Tick += (_, _) => DockPollTick();
+        _dockPollTimer.Start();
+    }
+
+    private void CleanupMediaDock()
+    {
+        _dockPollTimer?.Stop();
+        _dockPollTimer = null;
+    }
+
+    private void DockPollTick()
+    {
+        if (_everest is not { IsOpen: true }) return;
+        // A flash write (icon/screensaver upload) makes the firmware unresponsive on
+        // both transports — same guard as the accessory poll in MainWindow.Layout.cs.
+        if (_ndkUploadBusy) return;
+        if (!_everest.TryGetExtendInfo(out var info)) return;
+
+        byte page = info.byMMDockMenuIndex;
+
+        if (page != _dockLastPage)
+            _dockPageSince = DateTime.UtcNow;
+
+        if (!DockShouldStopFeeding(info))
+            FeedDockPage(page);
+
+        // Normally only a page CHANGE is worth reacting to. Brightness is the exception:
+        // its page code stays 81 while the user turns the dial through the whole range,
+        // so there is no edge to catch and it has to be re-read while it is on screen.
+        if (page != _dockLastPage || page == DockPageBrightness)
+        {
+            _dockLastPage = page;
+            SyncUiFromDockPage(page);
+        }
+    }
+
+    /// <summary>
+    /// True once the dock has sat on the same page for at least as long as its own
+    /// screensaver / turn-off timeout — at which point K2 stops writing to it entirely.
+    /// <para>
+    /// The firmware counts idle time to decide when to blank or take over the screen, and
+    /// a host write is activity. Feeding a live number into a page nobody has touched for
+    /// longer than the timeout is exactly the kind of write that can hold those timeouts
+    /// off forever, and a stale reading on a screen nobody is looking at costs nothing.
+    /// Base Camp has no such back-off (its PcInfo_timer writes to the visible page
+    /// unconditionally); K2 does, because "the screensaver never starts" is the bug this
+    /// whole area came from and this is the one way the app could still cause it.
+    /// </para>
+    /// <para>
+    /// A page change resets the clock, so normal use is unaffected: the numbers stay live
+    /// the whole time the user is actually moving through the dock's pages.
+    /// </para>
+    /// </summary>
+    private bool DockShouldStopFeeding(EverestSdkNative.FW_EXTEND_INFO info)
+    {
+        // Low two bits of byMMDockScreenSetup: bit0 screensaver, bit1 turn-off (see
+        // MainWindow.DisplayDial.cs's header).
+        bool ssOn  = (info.byMMDockScreenSetup & 0x01) != 0;
+        bool offOn = (info.byMMDockScreenSetup & 0x02) != 0;
+
+        int timeout = int.MaxValue;
+        if (ssOn  && info.wMMDockScreenSaver > 0) timeout = Math.Min(timeout, info.wMMDockScreenSaver);
+        if (offOn && info.wMMDockTurnOff     > 0) timeout = Math.Min(timeout, info.wMMDockTurnOff);
+        if (timeout == int.MaxValue) return false;   // neither timeout is armed
+
+        return (DateTime.UtcNow - _dockPageSince).TotalSeconds >= timeout;
+    }
+
+    /// <summary>Pushes the current value of whichever page the dock is showing. Anything
+    /// else (clock, profile list, lighting menu…) the firmware draws by itself and needs
+    /// no host data, so those ticks write nothing at all.</summary>
+    private void FeedDockPage(byte page)
+    {
+        switch (page)
+        {
+            case DockPageCpu:    _everest.SetPCInfo(PcInfoCpu,  SystemMonitor.CpuPercent());        break;
+            case DockPageGpu:    _everest.SetPCInfo(PcInfoGpu,  SystemMonitor.GpuPercent());        break;
+            case DockPageDisk:   _everest.SetPCInfo(PcInfoDisk, SystemMonitor.DiskPercent());       break;
+            case DockPageNet:    _everest.SetPCInfo(PcInfoNet,  SystemMonitor.DownloadMbPerSec());  break;
+            case DockPageRam:    _everest.SetPCInfo(PcInfoRam,  SystemMonitor.RamPercent());        break;
+            case DockPageApm:    _everest.SetPCInfo(PcInfoApm,  ApmLastMinute());                   break;
+            case DockPageVolume: _everest.SetVolume(SystemMonitor.VolumePercent());                 break;
+        }
+    }
+
+    // ─────────────────────── Device → UI sync ───────────────────────
+
+    /// <summary>
+    /// Follows changes the user makes on the keyboard itself. The dial can switch
+    /// profile, effect and brightness with no involvement from K2, which otherwise keeps
+    /// showing the previous state until something else reloads it.
+    /// <para>
+    /// The state being read is never echoed back: the firmware has already switched, so
+    /// re-pushing it would be pointless. That rules out reusing
+    /// <c>EvActivateProfileSlot</c>, whose SwitchProfile call and display-key flash work
+    /// are far too heavy to hang off a poll. Base Camp draws the same line — with its UI
+    /// running, <c>Common.ChangeEverestProfile</c> only tells the UI to refresh and
+    /// returns. What DOES follow is a profile's own K2-side settings: reloading a profile
+    /// re-applies its Display Dial config and disabled keys, exactly as when the user
+    /// picks it in the list, once per switch rather than per tick.
+    /// </para>
+    /// </summary>
+    private void SyncUiFromDockPage(byte page)
+    {
+        try
+        {
+            if (page is >= DockPageProfileFirst and <= DockPageProfileLast)
+                SyncUiProfileFromDevice();
+            else if (page is >= DockPageEffectFirst and <= DockPageEffectLast or DockPageBrightness)
+                SyncUiEffectFromDevice();
+        }
+        catch (Exception ex)
+        {
+            App.WriteLog("[DOCK] SyncUiFromDockPage threw: " + ex);
+        }
+    }
+
+    /// <summary>Re-selects the profile the firmware reports as active and reloads its data
+    /// into the panels. The page code says which profile page is on screen, but the
+    /// firmware's own <c>currentlyProfileIndex</c> says which one is actually running —
+    /// Base Camp reads the same field for the same reason.</summary>
+    private void SyncUiProfileFromDevice()
+    {
+        int fwSlot = _everest.CurrentProfile();
+        if (fwSlot is < 1 or > 5) return;
+        if (fwSlot == EvCurrentProfile()) return;
+        if (LstEvProfile.ItemsSource is not List<EvProfileItem> items) return;
+        if (items.Find(x => x.Slot == fwSlot && !x.IsNew) is null)
+        {
+            // The keyboard is on a firmware slot K2 has no profile for — nothing sensible
+            // to show, and creating one behind the user's back would be worse.
+            LogEverest($"[DOCK] device switched to firmware profile {fwSlot}, which has no K2 profile");
+            return;
+        }
+
+        LogEverest($"[DOCK] profile changed on the device -> slot {fwSlot}, following in the UI");
+        _evStore.SetCurrentProfile(fwSlot);
+        EvSelectProfileSlot(fwSlot);      // suppressed: won't re-enter the click path
+        ReloadEverestProfile(applyRgb: false);
+    }
+
+    /// <summary>Follows an effect or brightness change made on the dial, by reading back
+    /// what the firmware actually has stored for the active profile.</summary>
+    private void SyncUiEffectFromDevice()
+    {
+        if (!_evRgbInitialized) return;
+        int fwSlot = _everest.CurrentProfile();
+        if (!_everest.TryGetCurrentEffect(fwSlot, out var eff)) return;
+
+        int idx = -1;
+        for (int i = 0; i < EvEffectList.Length; i++)
+            if ((byte)EvEffectList[i].Eff == eff.byEffectIndex) { idx = i; break; }
+        if (idx < 0)
+        {
+            LogEverest($"[DOCK] device reports effect 0x{eff.byEffectIndex:X2}, not in K2's list");
+            return;
+        }
+
+        // byLightness is a BrightT, whose values ARE percentages (0/25/50/75/100), so it
+        // drops straight into the slider.
+        int bright = eff.byLightness is >= 0 and <= 100 ? eff.byLightness : (int)SldEvBrightness.Value;
+        if (idx == CbEvEffect.SelectedIndex && bright == (int)SldEvBrightness.Value) return;
+
+        LogEverest($"[DOCK] lighting changed on the device -> {EvEffectList[idx].Label} @ {bright}%");
+        bool prev = _evRgbSuppress;
+        _evRgbSuppress = true;
+        try
+        {
+            // Selecting fires EvReapplySelectedEffect, which restores that effect's saved
+            // parameters — brightness has to be written after it, not before.
+            CbEvEffect.SelectedIndex = idx;
+            SldEvBrightness.Value = bright;
+        }
+        finally { _evRgbSuppress = prev; }
+        // Suppression also blocks the save inside ApplyCurrentEffect, so persist here:
+        // the device's state is now K2's state and must survive a restart.
+        SaveEverestRgbToStore();
+    }
+
+    // ─────────────────────── Dial events (SDKDLL messages) ───────────────────────
+
+    /// <summary>
+    /// Handles <c>WM_KEY_STATUS</c> from SDKDLL.dll. A key matrix of 0 marks a Display
+    /// Dial action, with the action in wParam — codes from the decompiled Base Camp
+    /// service (<c>BaseCamp.Service.Helpers/MessageHandler.cs</c>): 107 and 179 = effect
+    /// changed on the dial, 171..175 = profile changed, 177/178 = brightness changed.
+    /// Everything here is a shortcut for the 1 Hz poll above, which reaches the same
+    /// state on its own within a second — so a dead message channel costs latency, not
+    /// correctness. Whether SDKDLL.dll delivers these at all on real hardware is still
+    /// unverified (K2 never gave it a window to post to until 2026-08-22 — see
+    /// EverestSdkNative.OpenUSBDriver).
+    /// </summary>
+    private void HandleEverestDockMessage(IntPtr wParam, IntPtr lParam)
+    {
+        if (_everest is not { IsOpen: true }) return;
+        if (lParam.ToInt32() != 0) return;          // a normal key, not a dial action
+
+        int code = wParam.ToInt32();
+        switch (code)
+        {
+            case 107:
+            case 179:
+                SyncUiEffectFromDevice();
+                break;
+            case >= 171 and <= 175:
+                SyncUiProfileFromDevice();
+                break;
+            case 177:
+            case 178:
+                SyncUiEffectFromDevice();           // brightness lives in the effect data
+                break;
+            default:
+                LogEverest($"[DOCK] dial action code {code} (no K2 handler)");
+                break;
+        }
+    }
+
+    // ─────────────────────────── APM ───────────────────────────
+
+    /// <summary>Timestamps of the last minute's key presses, oldest first.</summary>
+    private readonly Queue<DateTime> _apmPresses = new();
+
+    /// <summary>Keys currently held, so auto-repeat counts as the single press it is.</summary>
+    private readonly HashSet<ushort> _apmKeysDown = new();
+
+    /// <summary>
+    /// Fed from the WndProc's raw-input hook. Base Camp's APM counts entries its SDK
+    /// message pump recorded over the last minute; K2 counts physical key presses from
+    /// Raw Input instead, because SDKDLL.dll's event channel has never been observed
+    /// working here (see RawKeyboardActivityWatcher's own remarks). The number means
+    /// roughly the same thing and, unlike the SDK-based one, it is actually non-zero.
+    /// Raw Input is system-wide, so a second keyboard would count too.
+    /// </summary>
+    private void RegisterApmKey(bool keyDown, ushort vKey)
+    {
+        if (!keyDown) { _apmKeysDown.Remove(vKey); return; }
+        if (!_apmKeysDown.Add(vKey)) return;        // auto-repeat of a held key
+        _apmPresses.Enqueue(DateTime.UtcNow);
+        if (_apmPresses.Count > 4000) _apmPresses.Dequeue();   // pathological input flood
+    }
+
+    private int ApmLastMinute()
+    {
+        var cutoff = DateTime.UtcNow.AddMinutes(-1);
+        while (_apmPresses.Count > 0 && _apmPresses.Peek() < cutoff)
+            _apmPresses.Dequeue();
+        return _apmPresses.Count;
     }
 }

--- a/K2.App/MainWindow.Settings.cs
+++ b/K2.App/MainWindow.Settings.cs
@@ -91,8 +91,15 @@ public partial class MainWindow
         try
         {
             BtnAppUpdateInstall.IsEnabled = false;
+            PbAppUpdateDownload.Value = 0;
+            PbAppUpdateDownload.Visibility = Visibility.Visible;
+            var progress = new Progress<double>(p =>
+            {
+                PbAppUpdateDownload.Value = p * 100;
+                TxtAppUpdateStatus.Text = Loc.Get("settings_update_downloading_pct", (int)Math.Round(p * 100));
+            });
             TxtAppUpdateStatus.Text = Loc.Get("settings_update_downloading");
-            string path = await UpdateInstaller.DownloadInstallerAsync(asset, null);
+            string path = await UpdateInstaller.DownloadInstallerAsync(asset, progress);
 
             UpdateInstaller.LaunchInstaller(path);
             _reallyClosing = true;
@@ -102,6 +109,7 @@ public partial class MainWindow
         {
             MessageBox.Show(this, ex.Message, Loc.Get("settings_update_group"), MessageBoxButton.OK, MessageBoxImage.Error);
             BtnAppUpdateInstall.IsEnabled = true;
+            PbAppUpdateDownload.Visibility = Visibility.Collapsed;
         }
     }
 
@@ -125,8 +133,15 @@ public partial class MainWindow
         try
         {
             BtnAppUpdateZip.IsEnabled = false;
+            PbAppUpdateDownload.Value = 0;
+            PbAppUpdateDownload.Visibility = Visibility.Visible;
+            var progress = new Progress<double>(p =>
+            {
+                PbAppUpdateDownload.Value = p * 100;
+                TxtAppUpdateStatus.Text = Loc.Get("settings_update_downloading_pct", (int)Math.Round(p * 100));
+            });
             TxtAppUpdateStatus.Text = Loc.Get("settings_update_downloading");
-            await UpdateInstaller.DownloadAsync(asset, dlg.FileName, null);
+            await UpdateInstaller.DownloadAsync(asset, dlg.FileName, progress);
             TxtAppUpdateStatus.Text = Loc.Get("settings_update_zip_done", dlg.FileName);
             Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{dlg.FileName}\"") { UseShellExecute = true });
         }
@@ -137,6 +152,7 @@ public partial class MainWindow
         finally
         {
             BtnAppUpdateZip.IsEnabled = true;
+            PbAppUpdateDownload.Visibility = Visibility.Collapsed;
         }
     }
 

--- a/K2.App/MainWindow.xaml
+++ b/K2.App/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:local="clr-namespace:K2.App"
         xmlns:themes="clr-namespace:K2.Core.Themes;assembly=K2.Core"
         Title="{loc:Get app_title}"
-        Icon="Assets/K2_icon.png"
+        Icon="Assets/K2_icon.ico"
         Tag="hide-titlebar-brand"
         Height="1024" Width="1600"
         MinHeight="768" MinWidth="1280"
@@ -1587,8 +1587,8 @@
                                                             <Grid Margin="0,6,0,12">
                                                                 <Grid.ColumnDefinitions>
                                                                     <!-- Fixed-width label column so both rows' entries share the same left edge -->
-                                                                    <ColumnDefinition Width="130"/>
-                                                                    <ColumnDefinition Width="60"/>
+                                                                    <ColumnDefinition Width="150"/>
+                                                                    <ColumnDefinition Width="50"/>
                                                                     <ColumnDefinition Width="20"/>
                                                                     <ColumnDefinition Width="Auto"/>
                                                                     <ColumnDefinition Width="*"/>
@@ -1603,7 +1603,7 @@
                                                                   Content="{loc:Get dial_screensaver}" VerticalAlignment="Center"
                                                                   ToolTip="{loc:Get dial_screensaver_enable_tip}"
                                                                   Click="CkDialScreenSaverEnable_Click" HorizontalAlignment="Left"/>
-                                                                <TextBox  Grid.Row="0" Grid.Column="1" x:Name="TxtDialScreenSaver" Width="48" Height="25" Padding="3,0,3,0" VerticalContentAlignment="Center"
+                                                                <TextBox  Grid.Row="0" Grid.Column="1" x:Name="TxtDialScreenSaver" Width="38" Height="25" Padding="3,0,3,0" VerticalContentAlignment="Center"
                                                                   TextChanged="TxtDialScreenSaver_TextChanged" TextAlignment="Center" Text="5"/>
                                                                 <TextBlock Grid.Row="0" Grid.Column="2" Text="{loc:Get unit_seconds}" VerticalAlignment="Center" HorizontalAlignment="Left"/>
 
@@ -1611,7 +1611,7 @@
                                                                   Content="{loc:Get dial_autooff}" VerticalAlignment="Center"
                                                                   ToolTip="{loc:Get dial_turnoff_enable_tip}"
                                                                   Click="CkDialTurnOffEnable_Click" HorizontalAlignment="Left"/>
-                                                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="TxtDialTurnOff" Width="48" Height="25" Padding="3,0,3,0" VerticalContentAlignment="Center"
+                                                                <TextBox Grid.Row="1" Grid.Column="1" x:Name="TxtDialTurnOff" Width="38" Height="25" Padding="3,0,3,0" VerticalContentAlignment="Center"
                                                                   VerticalAlignment="Center"
                                                                   TextChanged="TxtDialTurnOff_TextChanged"  HorizontalAlignment="Center" TextAlignment="Center"/>
                                                                 <TextBlock Grid.Row="1" Grid.Column="2" Text="{loc:Get unit_seconds}"
@@ -3587,6 +3587,8 @@
                                     Style="{StaticResource K2IconButton}" Tag="&#xE895;"/>
                                     <TextBlock x:Name="TxtAppUpdateStatus" Foreground="#9A9AA2"
                                        TextWrapping="Wrap" Margin="0,8,0,0" FontSize="12"/>
+                                    <ProgressBar x:Name="PbAppUpdateDownload" Height="6" Margin="0,6,0,0"
+                                         Minimum="0" Maximum="100" Visibility="Collapsed"/>
 
                                     <StackPanel x:Name="PnlAppUpdateAvailable" Visibility="Collapsed" Margin="0,12,0,0">
                                         <TextBlock x:Name="TxtAppUpdateNotes" Foreground="#C8C8CE"

--- a/K2.App/MainWindow.xaml.cs
+++ b/K2.App/MainWindow.xaml.cs
@@ -134,6 +134,9 @@ public partial class MainWindow : Window
         _hWnd = new WindowInteropHelper(this).Handle;
         HwndSource.FromHwnd(_hWnd)?.AddHook(WndProc);
         App.WriteLog($"[MainWindow] HWND=0x{_hWnd.ToInt64():X}, WndProc hooked");
+        // SDKDLL.dll posts its key/dial notifications to the handle given to
+        // OpenUSBDriver — has to be set before the drivers auto-open just below.
+        Services.EverestService.HostWindow = _hWnd;
         Services.RawKeyboardActivityWatcher.Register(_hWnd);
         Services.RawMouseActivityWatcher.Register(_hWnd);
 
@@ -573,11 +576,20 @@ public partial class MainWindow : Window
         if (msg == MacroPadSdkNative.WM_DEVICE_PLUG || msg == MacroPadSdkNative.WM_FW_PROGRESS)
             _macroPad.HandleWindowMessage(msg, wParam, lParam);
 
+        // Everest Max Display Dial actions (profile/effect/brightness changed ON the
+        // keyboard) — see HandleEverestDockMessage in MainWindow.MediaDock.cs. Only the
+        // Everest is a consumer of this message today; the MacroPad SDK shares the
+        // message number but K2 has never read it for that device.
+        if (msg == Services.EverestSdkNative.WM_KEY_STATUS)
+            HandleEverestDockMessage(wParam, lParam);
+
         // Backlight auto-off wake, decoupled from SDKDLL.dll's own (unreliable
         // after idle, see RawKeyboardActivityWatcher's doc comment) KeyEvent —
         // real physical keyboard activity via Windows Raw Input.
-        if (Services.RawKeyboardActivityWatcher.IsKeyboardInput(msg, lParam))
+        if (Services.RawKeyboardActivityWatcher.IsKeyboardInput(msg, lParam, out bool keyDown, out ushort vKey))
         {
+            // Also the source for the Media Dock's APM page (MainWindow.MediaDock.cs).
+            RegisterApmKey(keyDown, vKey);
             _evAutoOffTimer?.RegisterActivity();
             // Everest 60 (2026-07-21, user report): same symptom as Everest Max's
             // original bug (see above) — after the auto-off timer's own native

--- a/K2.App/MakaluRgbSettingsPanel.xaml
+++ b/K2.App/MakaluRgbSettingsPanel.xaml
@@ -105,7 +105,7 @@
              as cramped/overlapping. -->
         <Grid x:Name="SecSettings" Visibility="Collapsed">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="24"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
@@ -182,10 +182,10 @@
                     <Slider x:Name="SldMkDpi" Minimum="50" Maximum="19000"
                             TickFrequency="50" ValueChanged="SldMkDpi_ValueChanged" VerticalAlignment="Center"/>
                 </DockPanel>
-                <TextBlock x:Name="LblMkDpiStatus" Margin="0,0,0,14" FontSize="11" Foreground="{StaticResource K2TextMutedBrush}"/>
+                <TextBlock x:Name="LblMkDpiStatus" Margin="0,0,0,4" FontSize="11" Foreground="{StaticResource K2TextMutedBrush}"/>
 
-                <WrapPanel Orientation="Horizontal" Margin="0,0,0,16">
-                    <TextBlock Text="{loc:Get makalu_setting_angle}" VerticalAlignment="Center" Width="130"/>
+                <WrapPanel Orientation="Horizontal">
+                    <TextBlock Text="{loc:Get makalu_setting_angle}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <Border Style="{StaticResource K2SegmentedGroupBorder}" Width="120">
                         <UniformGrid Rows="1">
                             <RadioButton x:Name="RbMkAngleOff" Content="{loc:Get makalu_setting_off}" GroupName="MkAngle"
@@ -196,10 +196,8 @@
                                          themes:K2Segment.CornerRadius="0,6,6,0"/>
                         </UniformGrid>
                     </Border>
-                    <TextBlock x:Name="LblMkAngleStatus" VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource K2TextMutedBrush}" Margin="8,0,0,0"/>
-                </WrapPanel>
-                <WrapPanel Orientation="Horizontal">
-                    <TextBlock Text="{loc:Get makalu_setting_liftoff}" VerticalAlignment="Center" Width="130"/>
+                    <TextBlock x:Name="LblMkAngleStatus" VerticalAlignment="Center" FontSize="11" Foreground="{StaticResource K2TextMutedBrush}" Margin="8,0,24,0"/>
+                    <TextBlock Text="{loc:Get makalu_setting_liftoff}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <Border Style="{StaticResource K2SegmentedGroupBorder}" Width="225">
                         <UniformGrid Rows="1">
                             <RadioButton x:Name="RbMkLiftLow" Content="{loc:Get makalu_setting_liftoff_low}" GroupName="MkLift"

--- a/K2.App/Services/EverestHidNative.cs
+++ b/K2.App/Services/EverestHidNative.cs
@@ -338,9 +338,14 @@ internal static class EverestHidNative
         ///   first chunk:  17 [0xAA+key] [1+dataLen] [flag] [type] [ASCII data ≤59]
         ///   next chunks:  17 [0xAA+key] [dataLen]   [flag]        [ASCII data ≤60]
         /// flag: 00 = single chunk, 01 = first of many, 03 = final (02 = middle, inferred).
-        /// type: 01 = executable path, 02 = URL. For K2 action types the firmware has no
-        /// concept of, callers pass a synthetic type-01 payload — the point is flipping
-        /// the key to custom mode, execution stays in K2 either way.
+        /// type: 01 = executable path, 02 = URL. type=01 is genuinely LAUNCHED by the
+        /// firmware, not just stored — see EverestService.WriteNumpadBinding's doc
+        /// comment (2026-08-22 regression: a non-empty placeholder payload here made
+        /// Windows pop its "no app for this link" dialog on every press). For K2
+        /// action types the firmware has no concept of, callers pass type=01 with an
+        /// EMPTY payload — the point is flipping the key to custom mode, execution
+        /// stays in K2 either way, and an empty payload gives the firmware nothing to
+        /// try to open.
         /// </summary>
         /// <summary>Per-key firmware output mode: what the physical key emits, before
         /// any host-side action runs. See <see cref="WriteKeyOutputMode"/>.</summary>

--- a/K2.App/Services/EverestSdkNative.cs
+++ b/K2.App/Services/EverestSdkNative.cs
@@ -129,8 +129,17 @@ internal static class EverestSdkNative
     /// convention, parameters (key matrix, pressed/released, id).
     /// Called on an SDK internal thread.
     /// </summary>
+    /// <remarks>
+    /// TWO parameters, not three (fixed 2026-08-22). Thethree-parameter form was copied
+    /// from the MacroPad SDK, whose callback really does carry a device id; SDKDLL.dll's
+    /// does not — the decompiled Base Camp service declares
+    /// <c>void KEY_CALLBACK(ushort wMatrix, bool bPressed)</c>
+    /// (<c>BaseCamp.Service.Helpers/SDKDLL_Helper.cs</c>). Under __stdcall the callee
+    /// pops its own arguments, so the extra parameter made the managed stub unbalance
+    /// the stack on every invocation.
+    /// </remarks>
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate void KEY_CALLBACK(ushort wMatrix, bool bPressed, uint ID);
+    public delegate void KEY_CALLBACK(ushort wMatrix, bool bPressed);
 
     // ---- Exported functions (__cdecl) ----------------------------------------
 
@@ -139,12 +148,30 @@ internal static class EverestSdkNative
     public static extern int GetDLLVersion();
 
     /// <summary>
-    /// Opens the keyboard USB driver. Unlike MacroPad/DisplayPad,
-    /// does NOT require an HWND.
+    /// Opens the keyboard USB driver. Takes the window handle the DLL posts its
+    /// notifications to (<see cref="WM_KEY_STATUS"/> and friends).
+    /// <para>
+    /// Corrected 2026-08-22: this was declared without parameters, on the assumption
+    /// that the Everest — unlike MacroPad/DisplayPad — needed no HWND. The decompiled
+    /// Base Camp service says otherwise: <c>OpenUSBDriver(IntPtr handle)</c>
+    /// (<c>BaseCamp.Service.Helpers/SDKDLL_Helper.cs</c>). With no handle supplied, the
+    /// DLL read whatever happened to be on the stack and posted its key/dial messages
+    /// into the void — the most likely reason nothing from SDKDLL.dll's event channel
+    /// has ever reached K2 on real hardware. __cdecl, so passing the argument was always
+    /// safe either way: the caller cleans the stack.
+    /// </para>
     /// </summary>
     [DllImport(Dll, CallingConvention = Cdecl)]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static extern bool OpenUSBDriver();
+    public static extern bool OpenUSBDriver(IntPtr hWnd);
+
+    /// <summary>Window message SDKDLL.dll posts to the HWND given to
+    /// <see cref="OpenUSBDriver"/> when a key or Display Dial action fires:
+    /// <c>lParam</c> = key matrix, <c>wParam</c> = action code. A matrix of 0 marks a
+    /// Display Dial / Media Dock event — see <c>MainWindow.MediaDock.cs</c> for the
+    /// action codes. Same numeric value as the MacroPad SDK's message of the same name;
+    /// the two DLLs simply share the convention.</summary>
+    public const int WM_KEY_STATUS = 25600;
 
     /// <summary>Closes the USB driver.</summary>
     [DllImport(Dll, CallingConvention = Cdecl)]
@@ -173,6 +200,21 @@ internal static class EverestSdkNative
     [DllImport(Dll, CallingConvention = Cdecl)]
     [return: MarshalAs(UnmanagedType.I1)]
     public static extern bool GetProfileEffectTable(ref EffectMenu effectMenu);
+
+    /// <summary>
+    /// Reads back one stored effect: <paramref name="fwProfile"/> is 1-based and
+    /// <paramref name="menuIndex"/> is the profile's <c>EffectTable.curIndex</c> (from
+    /// <see cref="GetProfileEffectTable"/>). The counterpart of ChangeEffect — the only
+    /// way to learn which effect the keyboard is actually running after the user changed
+    /// it on the Display Dial instead of in the app.
+    /// <para>Signature from the decompiled Base Camp service (2026-08-22,
+    /// <c>BaseCamp.Service.Helpers/Everest.cs</c>:
+    /// <c>GetEffectContent(int iFWProfile, int iMenuIndex, ref EffData effData)</c>),
+    /// which is also where <see cref="EffData"/>'s layout came from.</para>
+    /// </summary>
+    [DllImport(Dll, CallingConvention = Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    public static extern bool GetEffectContent(int fwProfile, int menuIndex, ref EffData effData);
 
     /// <summary>
     /// Reads the keyboard layout from the firmware (HID <c>11 12</c>).

--- a/K2.App/Services/EverestService.cs
+++ b/K2.App/Services/EverestService.cs
@@ -80,6 +80,13 @@ public sealed class EverestService : IDisposable
     /// <summary>True if the USB driver was opened successfully and the DLL has not crashed.</summary>
     public bool IsOpen => _opened && !App.SdkCrashRecoveryNeeded;
 
+    /// <summary>Window SDKDLL.dll posts its key/dial notifications to — assign the main
+    /// window's HWND once it exists (OnSourceInitialized), before the driver is opened.
+    /// See <see cref="EverestSdkNative.OpenUSBDriver"/> for why the DLL needs one.
+    /// Zero is tolerated (the DLL simply has nowhere to post) so the service stays usable
+    /// from contexts without a window.</summary>
+    public static IntPtr HostWindow { get; set; } = IntPtr.Zero;
+
     /// <summary>
     /// Opens the keyboard's USB driver and registers the key callback.
     /// </summary>
@@ -103,7 +110,7 @@ public sealed class EverestService : IDisposable
 
         try
         {
-            _opened = EverestSdkNative.OpenUSBDriver();
+            _opened = EverestSdkNative.OpenUSBDriver(HostWindow);
         }
         catch (Exception ex)
         {
@@ -169,6 +176,30 @@ public sealed class EverestService : IDisposable
             _opened = true;
             App.WriteLog("[Everest.Open] (native) OK");
 
+            // Open SDKDLL.dll's own driver handle as well. The native engine replaces
+            // SDKDLL for driver open/close, init and the 4 numpad display keys, but
+            // everything else on the Max still goes through SDKDLL (RGB, numpad icons,
+            // Media Dock, Display Dial) — see the class header. Those calls need the
+            // DLL's handle open.
+            //
+            // MEASURED 2026-08-22 on the real keyboard, because this used to be
+            // documented the other way round ("SDKDLL calls work without OpenUSBDriver"):
+            // from a process that never calls OpenUSBDriver, GetExtendInfo/GetFWInfo
+            // return false forever (20+ consecutive one-second attempts); issue
+            // OpenUSBDriver once and the very next call succeeds and keeps succeeding.
+            // With it missing, every SDKDLL-only feature on the Max silently no-ops —
+            // most visibly ApplyDialToDevice, which bails out on its opening
+            // TryGetExtendInfo and so never writes the Display Dial's own settings
+            // (screensaver included) to the firmware.
+            //
+            // Two transports to one firmware is the intended design here (see
+            // _PROJECT_MAP.md), and every SDKDLL call is already serialized under
+            // _sdkLock, so this adds a handle, not a race.
+            bool sdkOpen = false;
+            try { sdkOpen = EverestSdkNative.OpenUSBDriver(HostWindow); }
+            catch (Exception ex) { App.WriteLog("[Everest.Open] (native) OpenUSBDriver threw: " + ex); }
+            App.WriteLog($"[Everest.Open] (native) SDKDLL OpenUSBDriver(0x{HostWindow.ToInt64():X}) -> {sdkOpen}");
+
             // Run Base Camp's own post-open init through SDKDLL even on the native path.
             // Rationale (2026-07-19): the display-key reset sequence, replicated byte-for-
             // byte from a real BC capture (evprofiles.pcapng) with identical pacing and
@@ -177,11 +208,7 @@ public sealed class EverestService : IDisposable
             // BC. Both BC captures start with Base Camp already running, so its session
             // init has never been seen on the wire; the one known candidate for the
             // missing device-side state is exactly this init (its doc comment already
-            // records that ChangeEffect is silently ignored without it). SDKDLL calls
-            // work without OpenUSBDriver (StartPicUpdate/GetExtendInfo already prove it
-            // in this very mode), and the DLL gets loaded ~3s later anyway by the first
-            // GetExtendInfo poll — so this adds no new crash surface, it only front-loads
-            // the same calls BC makes.
+            // records that ChangeEffect is silently ignored without it).
             InitDllState();
             return true;
         }
@@ -292,7 +319,11 @@ public sealed class EverestService : IDisposable
             try { _nativePad.Dispose(); }
             catch (Exception ex) { App.WriteLog("[Everest.Close] (native) threw: " + ex); }
             _nativePad = null;
+            // OpenNative also opens SDKDLL's handle (see its comment) — give it back.
+            try { EverestSdkNative.CloseUSBDriver(); }
+            catch (Exception ex) { App.WriteLog("[Everest.Close] (native) CloseUSBDriver threw: " + ex); }
             _opened = false;
+            _apEnabled = false;
             App.WriteLog("[Everest.Close] (native) driver closed");
             return;
         }
@@ -308,7 +339,9 @@ public sealed class EverestService : IDisposable
     /// <summary>Version of the SDK's native DLL.</summary>
     public int SdkVersion()
     {
-        if (_nativePad is not null) return -1; // native engine: SDKDLL.dll not loaded
+        // Used to short-circuit to -1 in native-engine mode on the assumption that
+        // SDKDLL.dll wasn't loaded there. It is: the native path opens it too (see
+        // OpenNative), so report the real version.
         lock (_sdkLock)
         try { return EverestSdkNative.GetDLLVersion(); }
         catch (Exception ex)
@@ -375,6 +408,34 @@ public sealed class EverestService : IDisposable
     public int CurrentProfile()
     {
         return TryGetFirmwareInfo(out var fw) ? fw.currentlyProfileIndex : 0;
+    }
+
+    /// <summary>
+    /// Reads back the effect the firmware is currently running for
+    /// <paramref name="fwProfile"/> (1-based): the profile's <c>curIndex</c> from the
+    /// effect table, then that slot's stored <c>EffData</c>. Two chained reads, exactly
+    /// as Base Camp's <c>Common.ChangeEverestBrightness</c>/<c>ChangeEffectOnUI</c> do it.
+    /// Used to follow effect/brightness changes the user makes on the Display Dial rather
+    /// than in the app — see <c>MainWindow.MediaDock.cs</c>.
+    /// <c>internal</c>: exposes a P/Invoke layer type (also internal).
+    /// </summary>
+    internal bool TryGetCurrentEffect(int fwProfile, out EverestSdkNative.EffData eff)
+    {
+        eff = default;
+        if (fwProfile is < 1 or > 5) return false;
+        lock (_sdkLock)
+        try
+        {
+            var menu = new EverestSdkNative.EffectMenu();
+            if (!EverestSdkNative.GetProfileEffectTable(ref menu) || menu.table is null) return false;
+            byte curIndex = menu.table[fwProfile - 1].curIndex;
+            return EverestSdkNative.GetEffectContent(fwProfile, curIndex, ref eff);
+        }
+        catch (Exception ex)
+        {
+            App.WriteLog("[Everest.TryGetCurrentEffect] threw: " + ex);
+            return false;
+        }
     }
 
     /// <summary>
@@ -1295,8 +1356,15 @@ public sealed class EverestService : IDisposable
     /// Writes a display key's action binding into the firmware, flipping the key to
     /// "custom" mode so its built-in default action stops firing on press — see
     /// <see cref="EverestHidNative.Pad.WriteDisplayKeyBinding"/>. Only meaningful in
-    /// native-engine mode; K2 action types the firmware can't express are written as a
-    /// synthetic type-01 marker (suppression is the goal, K2 executes the action itself).
+    /// native-engine mode; K2 action types the firmware can't express get an EMPTY
+    /// type-01 payload (suppression is the goal, K2 executes the action itself).
+    /// A non-empty payload here is NOT inert: type=0x01 makes the firmware actually
+    /// try to launch it (like a real Base Camp exec binding), independent of K2 — the
+    /// previous "K2:" + actionType placeholder (e.g. "K2:oscmd") made every display
+    /// key bound to a non-exec/url action (Calculator, shell commands, ...) pop
+    /// Windows' "get an app to open this 'k2' link" dialog on every press, since
+    /// "K2:oscmd" parses as a URI with an unregistered "K2" scheme (user report
+    /// 2026-08-22). An empty payload gives the firmware nothing to resolve.
     /// </summary>
     public bool WriteNumpadBinding(int keyIndex, string actionType, string? actionValue)
     {
@@ -1314,7 +1382,7 @@ public sealed class EverestService : IDisposable
         }
         else
         {
-            type = 0x01; payload = "K2:" + actionType;   // synthetic — see doc comment
+            type = 0x01; payload = "";   // suppression only — must NOT look like a launchable path/URI
         }
         // Serialized against SDKDLL traffic like every other native-transport call —
         // see SwitchProfile's comment.
@@ -1482,7 +1550,12 @@ public sealed class EverestService : IDisposable
 
     /// <summary>
     /// Updates the clock on the Media Dock's display with the current time and
-    /// format. Call periodically (every second, as Base Camp does).
+    /// format. The dock has its own RTC and ticks on its own, so this is a
+    /// *resync*, not a per-second refresh: call it every 30 minutes (the interval
+    /// of Base Camp's own <c>Clock_timer</c>) plus on the events that need it
+    /// (apply, profile switch, startup). Calling it every second keeps the dock's
+    /// idle counter permanently reset, so the screensaver never fires — see
+    /// <c>MainWindow.DisplayDial.cs</c>'s <c>_dialClockTimer</c> (2026-08-22).
     /// </summary>
     /// <remarks>
     /// <b>2026-07-15, real Base Camp USB capture (_reference/usb_dumps/evclock.pcapng):</b>
@@ -1765,14 +1838,16 @@ public sealed class EverestService : IDisposable
 
     // ---- native callback (SDK thread) ---------------------------------
 
-    private void OnKeyCallback(ushort wMatrix, bool bPressed, uint id)
+    private void OnKeyCallback(ushort wMatrix, bool bPressed)
     {
         try
         {
             // We emit the event without a lock: consumers might
             // call back into other EverestService methods (deadlock).
             // Key logging removed — too noisy in normal use.
-            KeyEvent?.Invoke(this, new EverestKeyEventArgs(id, wMatrix, bPressed));
+            // DeviceId is always 0: the Everest is single-device and its callback
+            // carries no id (see EverestSdkNative.KEY_CALLBACK's remarks).
+            KeyEvent?.Invoke(this, new EverestKeyEventArgs(0, wMatrix, bPressed));
         }
         catch (Exception ex)
         {

--- a/K2.App/Services/RawKeyboardActivityWatcher.cs
+++ b/K2.App/Services/RawKeyboardActivityWatcher.cs
@@ -27,6 +27,7 @@ internal static class RawKeyboardActivityWatcher
     private const uint RIDEV_INPUTSINK = 0x00000100;
     private const uint RID_INPUT = 0x10000003;
     private const uint RIM_TYPEKEYBOARD = 1;
+    private const ushort RI_KEY_BREAK = 0x0001;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct RAWINPUTDEVICE
@@ -75,8 +76,19 @@ internal static class RawKeyboardActivityWatcher
 
     /// <summary>Call from the window's WndProc for every message. Returns true if this
     /// message is a raw keyboard input event (i.e. real physical key activity).</summary>
-    public static bool IsKeyboardInput(int msg, IntPtr lParam)
+    public static bool IsKeyboardInput(int msg, IntPtr lParam) =>
+        IsKeyboardInput(msg, lParam, out _, out _);
+
+    /// <summary>
+    /// Same as <see cref="IsKeyboardInput(int, IntPtr)"/>, but also reports whether the
+    /// event was a press (<paramref name="keyDown"/>) or a release, and which virtual key
+    /// it was. Needed by the Media Dock's APM counter, which must count presses only —
+    /// counting every raw keyboard message would double every keystroke.
+    /// </summary>
+    public static bool IsKeyboardInput(int msg, IntPtr lParam, out bool keyDown, out ushort vKey)
     {
+        keyDown = false;
+        vKey = 0;
         if (msg != WM_INPUT) return false;
 
         uint headerSize = (uint)Marshal.SizeOf<RAWINPUTHEADER>();
@@ -90,7 +102,20 @@ internal static class RawKeyboardActivityWatcher
             if (GetRawInputData(lParam, RID_INPUT, buffer, ref size, headerSize) != size)
                 return false;
             var header = Marshal.PtrToStructure<RAWINPUTHEADER>(buffer);
-            return header.dwType == RIM_TYPEKEYBOARD;
+            if (header.dwType != RIM_TYPEKEYBOARD) return false;
+
+            // RAWINPUT = { RAWINPUTHEADER header; union { RAWMOUSE, RAWKEYBOARD, RAWHID } }.
+            // No member of that union is wider than 4 bytes, so the payload starts right
+            // after the header on both x86 and x64. RAWKEYBOARD's first fields are
+            // USHORT MakeCode, USHORT Flags, USHORT Reserved, USHORT VKey — and Flags bit 0
+            // (RI_KEY_BREAK) marks a release.
+            if (size >= headerSize + 8)
+            {
+                ushort flags = (ushort)Marshal.ReadInt16(buffer, (int)headerSize + 2);
+                vKey = (ushort)Marshal.ReadInt16(buffer, (int)headerSize + 6);
+                keyDown = (flags & RI_KEY_BREAK) == 0;
+            }
+            return true;
         }
         finally
         {

--- a/K2.App/Services/SystemMonitor.cs
+++ b/K2.App/Services/SystemMonitor.cs
@@ -1,0 +1,332 @@
+// SystemMonitor.cs — PC metrics for the Everest Max Media Dock's "PC Info" pages.
+//
+// Base Camp's own numbers (ground truth, decompiled 2026-08-22 from
+// BaseCamp.ResourceMonitorHelper/PCResourceMonitorHelper.cs and
+// BaseCamp.LibreHardwareMonitor/LibreHWMonitorHelper.cs — the values its
+// BaseCampService.PcInfo_timer feeds to Everest.SetPCInfo):
+//
+//   CPU  (SetPCInfo type 0) = "\Processor(_Total)\% Processor Time",  ceil -> int %
+//   GPU  (type 1)           = LibreHardwareMonitor "GPU Core" Load sensor -> int %
+//   Disk (type 2)           = "\PhysicalDisk(_Total)\% Disk Time",    ceil -> int
+//   Net  (type 3)           = LHM "Download Speed" (bytes/s) / 1e6    -> int MB/s
+//   RAM  (type 4)           = (Total - Free) / Total * 100            -> int %
+//   Volume (SetVolumeInfo)  = master volume scalar * 100              -> int %
+//
+// K2 reproduces those numbers WITHOUT taking LibreHardwareMonitor as a
+// dependency: CPU comes from GetSystemTimes, RAM from GlobalMemoryStatusEx,
+// disk and GPU from PDH (the same performance counters BC reads through the
+// PerformanceCounter class, minus the System.Diagnostics.PerformanceCounter
+// package), download speed from NetworkInterface statistics, and volume from
+// Core Audio. PDH counters are added with PdhAddEnglishCounter, not
+// PdhAddCounter: counter paths are localized on a non-English Windows and the
+// English form is the only one that works everywhere.
+//
+// Every getter is best-effort and returns 0 on any failure — a dead metric must
+// never take down the dock poller (MainWindow.MediaDock.cs) that calls it.
+
+using System;
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+
+namespace K2.App.Services;
+
+internal static class SystemMonitor
+{
+    // ─────────────────────────── CPU ───────────────────────────
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetSystemTimes(out long idle, out long kernel, out long user);
+
+    private static long _prevIdle, _prevKernel, _prevUser;
+
+    /// <summary>Total CPU load, 0..100. Derived from GetSystemTimes deltas between
+    /// calls (kernel time already includes idle time), so the first call after
+    /// startup has no baseline and reports 0.</summary>
+    public static int CpuPercent()
+    {
+        try
+        {
+            if (!GetSystemTimes(out long idle, out long kernel, out long user)) return 0;
+            long dIdle = idle - _prevIdle, dKernel = kernel - _prevKernel, dUser = user - _prevUser;
+            _prevIdle = idle; _prevKernel = kernel; _prevUser = user;
+            long total = dKernel + dUser;
+            if (total <= 0) return 0;
+            return Clamp((int)Math.Ceiling((total - dIdle) * 100.0 / total));
+        }
+        catch { return 0; }
+    }
+
+    // ─────────────────────────── RAM ───────────────────────────
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GlobalMemoryStatusEx(ref MEMORYSTATUSEX buffer);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MEMORYSTATUSEX
+    {
+        public uint  dwLength;
+        public uint  dwMemoryLoad;
+        public ulong ullTotalPhys;
+        public ulong ullAvailPhys;
+        public ulong ullTotalPageFile;
+        public ulong ullAvailPageFile;
+        public ulong ullTotalVirtual;
+        public ulong ullAvailVirtual;
+        public ulong ullAvailExtendedVirtual;
+    }
+
+    /// <summary>Physical memory in use, 0..100 — <c>dwMemoryLoad</c> is exactly the
+    /// (total-free)/total ratio Base Camp computes from Win32_OperatingSystem, without
+    /// the WMI query.</summary>
+    public static int RamPercent()
+    {
+        try
+        {
+            var st = new MEMORYSTATUSEX { dwLength = (uint)Marshal.SizeOf<MEMORYSTATUSEX>() };
+            return GlobalMemoryStatusEx(ref st) ? Clamp((int)st.dwMemoryLoad) : 0;
+        }
+        catch { return 0; }
+    }
+
+    // ─────────────────────── Network download ───────────────────────
+
+    private static long _prevRxBytes;
+    private static DateTime _prevRxAt;
+
+    /// <summary>Download speed in whole MB/s across all interfaces that are up — the unit
+    /// Base Camp sends (LHM's bytes/s "Download Speed" divided by 1e6 and rounded).
+    /// Loopback and tunnels are excluded, as in any real throughput reading.</summary>
+    public static int DownloadMbPerSec()
+    {
+        try
+        {
+            long rx = 0;
+            foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                if (ni.OperationalStatus != OperationalStatus.Up) continue;
+                if (ni.NetworkInterfaceType is NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel)
+                    continue;
+                rx += ni.GetIPv4Statistics().BytesReceived;
+            }
+            var now = DateTime.UtcNow;
+            long prev = _prevRxBytes;
+            var prevAt = _prevRxAt;
+            _prevRxBytes = rx;
+            _prevRxAt = now;
+            if (prevAt == default) return 0;             // no baseline yet
+            double secs = (now - prevAt).TotalSeconds;
+            if (secs <= 0 || rx < prev) return 0;        // clock jump / counter reset
+            return Clamp((int)Math.Round((rx - prev) / secs / 1_000_000.0), 0, int.MaxValue);
+        }
+        catch { return 0; }
+    }
+
+    // ─────────────────────────── PDH ───────────────────────────
+    //
+    // Disk and GPU come from performance counters. PDH lives in pdh.dll and ships with
+    // every supported Windows, so this needs no NuGet package.
+
+    private const uint PDH_FMT_DOUBLE   = 0x00000200;
+    private const uint PDH_FMT_NOCAP100 = 0x00008000;
+    private const int  PDH_MORE_DATA    = unchecked((int)0x800007D2);
+
+    [DllImport("pdh.dll", CharSet = CharSet.Unicode)]
+    private static extern int PdhOpenQueryW(string? dataSource, IntPtr userData, out IntPtr query);
+
+    [DllImport("pdh.dll", CharSet = CharSet.Unicode)]
+    private static extern int PdhAddEnglishCounterW(IntPtr query, string counterPath,
+                                                    IntPtr userData, out IntPtr counter);
+
+    [DllImport("pdh.dll")]
+    private static extern int PdhCollectQueryData(IntPtr query);
+
+    [DllImport("pdh.dll")]
+    private static extern int PdhGetFormattedCounterValue(IntPtr counter, uint format,
+                                                          out uint type, out PDH_FMT_COUNTERVALUE value);
+
+    [DllImport("pdh.dll", CharSet = CharSet.Unicode)]
+    private static extern int PdhGetFormattedCounterArrayW(IntPtr counter, uint format,
+                                                           ref uint bufferSize, out uint itemCount,
+                                                           IntPtr itemBuffer);
+
+    // PDH_FMT_COUNTERVALUE = { DWORD CStatus; union { ... double doubleValue; ... }; }
+    // The union is 8-byte aligned (a double is its widest member), so the value sits at
+    // offset 8 and the struct is 16 bytes on x86 as well as x64 — hence explicit offsets
+    // rather than a sequential layout, which would place it at 4 on x86.
+    [StructLayout(LayoutKind.Explicit, Size = 16)]
+    private struct PDH_FMT_COUNTERVALUE
+    {
+        [FieldOffset(0)] public int CStatus;
+        [FieldOffset(8)] public double doubleValue;
+    }
+
+    // PDH_FMT_COUNTERVALUE_ITEM = { LPWSTR szName; PDH_FMT_COUNTERVALUE FmtValue; }
+    // Same alignment story: the embedded value starts at 8 even on x86, where the name
+    // pointer is only 4 bytes wide.
+    [StructLayout(LayoutKind.Explicit, Size = 24)]
+    private struct PDH_FMT_COUNTERVALUE_ITEM
+    {
+        [FieldOffset(0)] public IntPtr szName;
+        [FieldOffset(8)] public PDH_FMT_COUNTERVALUE FmtValue;
+    }
+
+    /// <summary>One PDH query + counter pair, opened lazily and never reopened after a
+    /// failure (a counter set that isn't there stays missing for the process's life).</summary>
+    private sealed class PdhCounter
+    {
+        private readonly string _path;
+        private IntPtr _query, _counter;
+        private bool _tried, _ok;
+
+        public PdhCounter(string path) => _path = path;
+
+        public bool Ready
+        {
+            get
+            {
+                if (_tried) return _ok;
+                _tried = true;
+                try
+                {
+                    if (PdhOpenQueryW(null, IntPtr.Zero, out _query) != 0) return false;
+                    if (PdhAddEnglishCounterW(_query, _path, IntPtr.Zero, out _counter) != 0) return false;
+                    PdhCollectQueryData(_query);   // rate counters need a first sample
+                    _ok = true;
+                }
+                catch { _ok = false; }
+                return _ok;
+            }
+        }
+
+        public IntPtr Handle => _counter;
+
+        public bool Collect() => Ready && PdhCollectQueryData(_query) == 0;
+    }
+
+    private static readonly PdhCounter _diskCounter = new(@"\PhysicalDisk(_Total)\% Disk Time");
+
+    /// <summary>Disk activity, 0..100. "% Disk Time" can read above 100 on a busy
+    /// multi-queue disk (Base Camp doesn't clamp it either), but the dock draws a
+    /// percentage, so it is capped here.</summary>
+    public static int DiskPercent()
+    {
+        try
+        {
+            if (!_diskCounter.Collect()) return 0;
+            if (PdhGetFormattedCounterValue(_diskCounter.Handle, PDH_FMT_DOUBLE, out _, out var v) != 0)
+                return 0;
+            return Clamp((int)Math.Ceiling(v.doubleValue));
+        }
+        catch { return 0; }
+    }
+
+    // Windows exposes GPU load per engine instance, e.g.
+    //   pid_1234_luid_0x00000000_0x0000C7B4_phys_0_eng_0_engtype_3D
+    // There is no _Total instance, so this is a wildcard counter whose 3D-engine
+    // instances get summed — the closest equivalent to the LibreHardwareMonitor
+    // "GPU Core" load that Base Camp reads.
+    private static readonly PdhCounter _gpuCounter = new(@"\GPU Engine(*)\Utilization Percentage");
+
+    /// <summary>GPU 3D-engine load, 0..100 (summed across processes).</summary>
+    public static int GpuPercent()
+    {
+        try
+        {
+            if (!_gpuCounter.Collect()) return 0;
+
+            uint size = 0;
+            int rc = PdhGetFormattedCounterArrayW(_gpuCounter.Handle,
+                PDH_FMT_DOUBLE | PDH_FMT_NOCAP100, ref size, out _, IntPtr.Zero);
+            if (rc != PDH_MORE_DATA || size == 0) return 0;
+
+            IntPtr buf = Marshal.AllocHGlobal((int)size);
+            try
+            {
+                rc = PdhGetFormattedCounterArrayW(_gpuCounter.Handle,
+                    PDH_FMT_DOUBLE | PDH_FMT_NOCAP100, ref size, out uint count, buf);
+                if (rc != 0) return 0;
+
+                double total = 0;
+                int stride = Marshal.SizeOf<PDH_FMT_COUNTERVALUE_ITEM>();
+                for (int i = 0; i < count; i++)
+                {
+                    var item = Marshal.PtrToStructure<PDH_FMT_COUNTERVALUE_ITEM>(buf + i * stride);
+                    if (item.FmtValue.CStatus != 0) continue;
+                    string name = Marshal.PtrToStringUni(item.szName) ?? "";
+                    if (!name.EndsWith("engtype_3D", StringComparison.OrdinalIgnoreCase)) continue;
+                    total += item.FmtValue.doubleValue;
+                }
+                return Clamp((int)Math.Round(total));
+            }
+            finally { Marshal.FreeHGlobal(buf); }
+        }
+        catch { return 0; }
+    }
+
+    // ────────────────────────── Volume ──────────────────────────
+
+    [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+    private class MMDeviceEnumerator { }
+
+    [ComImport, Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"),
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDeviceEnumerator
+    {
+        int EnumAudioEndpoints(int dataFlow, int stateMask, out IntPtr devices);
+        int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice device);
+    }
+
+    [ComImport, Guid("D666063F-1587-4E43-81F1-B948E807363F"),
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDevice
+    {
+        int Activate(ref Guid iid, int clsCtx, IntPtr activationParams,
+                     [MarshalAs(UnmanagedType.IUnknown)] out object iface);
+    }
+
+    // Only the slots up to GetMasterVolumeLevelScalar are used, but every earlier vtable
+    // entry still has to be declared, in order, for the offsets to line up.
+    [ComImport, Guid("5CDF2C82-841E-4546-9722-0CF74078229A"),
+     InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IAudioEndpointVolume
+    {
+        int RegisterControlChangeNotify(IntPtr notify);
+        int UnregisterControlChangeNotify(IntPtr notify);
+        int GetChannelCount(out uint count);
+        int SetMasterVolumeLevel(float leveldB, ref Guid eventContext);
+        int SetMasterVolumeLevelScalar(float level, ref Guid eventContext);
+        int GetMasterVolumeLevel(out float leveldB);
+        int GetMasterVolumeLevelScalar(out float level);
+    }
+
+    private const int ERender = 0, EMultimedia = 1, ClsCtxAll = 23;
+
+    /// <summary>Master output volume, 0..100 — the value Base Camp's PcInfo_timer sends
+    /// with SetVolumeInfo while the dock shows its Volume page.</summary>
+    public static int VolumePercent()
+    {
+        object? volObj = null;
+        try
+        {
+            var enumerator = (IMMDeviceEnumerator)new MMDeviceEnumerator();
+            if (enumerator.GetDefaultAudioEndpoint(ERender, EMultimedia, out var device) != 0 || device is null)
+                return 0;
+            var iid = typeof(IAudioEndpointVolume).GUID;
+            if (device.Activate(ref iid, ClsCtxAll, IntPtr.Zero, out volObj) != 0) return 0;
+            if (volObj is not IAudioEndpointVolume vol) return 0;
+            if (vol.GetMasterVolumeLevelScalar(out float level) != 0) return 0;
+            return Clamp((int)Math.Round(level * 100f));
+        }
+        catch { return 0; }
+        finally
+        {
+            if (volObj is not null && Marshal.IsComObject(volObj))
+                Marshal.ReleaseComObject(volObj);
+        }
+    }
+
+    private static int Clamp(int v, int min = 0, int max = 100)
+        => v < min ? min : v > max ? max : v;
+}

--- a/K2.App/Services/TrayIconNative.cs
+++ b/K2.App/Services/TrayIconNative.cs
@@ -42,9 +42,13 @@ internal sealed class TrayIconNative : IDisposable
     private const int WM_APP      = 0x8000;
     private const int CallbackMsg = WM_APP + 0x21;
 
+    private const int WM_USER          = 0x0400;
     private const int WM_LBUTTONDBLCLK = 0x0203;
     private const int WM_CONTEXTMENU   = 0x007B;
-    private const int NIN_SELECT       = WM_APP + 0;
+    // NIN_SELECT is WM_USER-based (shellapi.h), not WM_APP-based — do not confuse
+    // with CallbackMsg above, which IS WM_APP-based (that's the outer message id;
+    // this is the notification code carried in its lParam).
+    private const int NIN_SELECT       = WM_USER + 0;
 
     private const int NIM_ADD        = 0x00;
     private const int NIM_MODIFY     = 0x01;

--- a/K2.Core/Strings.de.xml
+++ b/K2.Core/Strings.de.xml
@@ -208,7 +208,27 @@
   <string name="youtube_chat_message_label">Live-Chat-Nachricht:</string>
   <string name="act_command">Shell-Befehl</string>
   <string name="act_text">Text einfügen</string>
+  <string name="act_emoji">Emoji</string>
   <string name="act_macro">Makro abspielen</string>
+
+  <!-- Emoji-Aktion + Emoji-Browser (EmojiPickerDialog) -->
+  <string name="emoji_picker_title">Emoji auswählen</string>
+  <string name="emoji_choose_button">Emoji auswählen…</string>
+  <string name="emoji_none_selected">Kein Emoji ausgewählt</string>
+  <string name="emoji_search_label">Suche:</string>
+  <string name="emoji_category_label">Kategorie:</string>
+  <string name="emoji_category_all">Alle</string>
+  <string name="emoji_no_results">Kein Emoji gefunden</string>
+  <string name="emoji_hint">Das Emoji wird beim Drücken der Taste in die aktive Anwendung eingegeben. Bei einer Display-Taste (DisplayPad, Everest-Max-Nummernblock) wird es zusätzlich als Tastenbild verwendet.</string>
+  <string name="emoji_grp_smileys">Smileys &amp; Emotionen</string>
+  <string name="emoji_grp_people">Personen &amp; Körper</string>
+  <string name="emoji_grp_animals">Tiere &amp; Natur</string>
+  <string name="emoji_grp_food">Essen &amp; Trinken</string>
+  <string name="emoji_grp_travel">Reisen &amp; Orte</string>
+  <string name="emoji_grp_activities">Aktivitäten</string>
+  <string name="emoji_grp_objects">Objekte</string>
+  <string name="emoji_grp_symbols">Symbole</string>
+  <string name="emoji_grp_flags">Flaggen</string>
   <string name="act_macro_unresolved">Makro abspielen (nicht zugewiesen)</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Python-Skript</string>
@@ -351,6 +371,19 @@
   <string name="settings_k2_autostart_hint">K2 benötigt jetzt Administratorrechte (um BaseCampService zu steuern). Windows erhöht Apps, die beim Anmelden über den Run-Registrierungsschlüssel gestartet werden, nicht automatisch, daher kann dieser Eintrag allein dazu führen, dass K2 nicht stillschweigend startet — verwende in diesem Fall stattdessen die Aufgabenplanung (eine Aufgabe, die bei der Anmeldung mit "Mit höchsten Privilegien ausführen" eingestellt ist).</string>
   <string name="settings_start_min_tray">Direkt minimiert in die Taskleiste starten</string>
   <string name="settings_start_min_tray_hint">K2 startet mit aktiven Treibern, aber das Fenster bleibt in der Taskleiste verborgen — jederzeit über das Taskleistensymbol zu öffnen.</string>
+  <!-- DisplayPad-Gerätezuordnung -->
+  <string name="settings_dp_devicemap_group">DisplayPad-Gerätezuordnung</string>
+  <string name="settings_dp_devicemap_btn">Zuordnung konfigurieren…</string>
+  <string name="settings_dp_devicemap_hint">Wenn du ein DisplayPad an einen anderen USB-Port angeschlossen hast und dessen gespeicherte Profile jetzt auf dem falschen Panel erscheinen (z. B. "DisplayPad 2" und "DisplayPad 3" vertauscht), kannst du hiermit neu zuweisen, welches Panel jedes angeschlossene Pad darstellt.</string>
+  <string name="dp_devicemap_title">DisplayPad-Gerätezuordnung</string>
+  <string name="dp_devicemap_hint">Jedes angeschlossene Pad wird unten mit seiner Firmware-Version aufgeführt. Klicke auf "Identifizieren", um die Hintergrundbeleuchtung eines Pads blinken zu lassen und die passende Zeile zu erkennen, und lege dann die zu verwendende Board-Nummer fest. Zwei Zeilen dürfen nicht dieselbe Board-Nummer verwenden.</string>
+  <string name="dp_devicemap_col_current">Derzeit angezeigt als</string>
+  <string name="dp_devicemap_col_firmware">Firmware</string>
+  <string name="dp_devicemap_col_board">Board-Nr.</string>
+  <string name="dp_devicemap_identify_btn">Identifizieren</string>
+  <string name="dp_devicemap_none_connected">Aktuell ist kein DisplayPad angeschlossen — schließe die neu zuzuordnenden Pads an und öffne dieses Fenster erneut.</string>
+  <string name="dp_devicemap_duplicate_error">Zwei Pads können nicht dieselbe Board-Nummer verwenden. Vergib für jedes eine andere Nummer.</string>
+  <string name="dp_devicemap_invalid_number">Board-Nummern müssen positive ganze Zahlen sein.</string>
   <string name="settings_font_family">Schriftart</string>
   <string name="settings_font_family_hint">Ändert die App-weite UI-Schriftart sofort, kein Neustart erforderlich.</string>
   <string name="tray_show">K2 anzeigen</string>
@@ -394,7 +427,7 @@
   <string name="rgb_single_tip">Verwendet eine einzelne Farbe für den Effekt.</string>
   <string name="rgb_double">Doppelfarbe</string>
   <string name="rgb_double_tip">Verwendet zwei Farben für den Effekt (nicht von jedem Effekt unterstützt).</string>
-  <string name="rgb_sync_profiles">Profile synchronisieren</string>
+  <string name="rgb_sync_profiles">Profilübergreifend synchronisieren</string>
   <string name="rgb_primary">Primär:</string>
   <string name="rgb_secondary">Sekundär:</string>
   <string name="rgb_tertiary">Tertiär:</string>
@@ -487,7 +520,7 @@
   <string name="makalu_remap_btn_5">Taste 5</string>
   <string name="makalu_remap_btn_6">Taste 6</string>
 
-  <string name="makalu_settings_title">Geräteeinstellungen</string>
+  <string name="makalu_settings_title">Einstellungen</string>
   <string name="makalu_setting_poll">Abfragerate:</string>
   <string name="makalu_setting_debounce">Tastenreaktion:</string>
   <string name="makalu_setting_angle">Winkelkorrektur:</string>
@@ -559,6 +592,7 @@
 
   <!-- Einstellungen (Everest-Seitenleiste: Tastatur-Layout) -->
   <string name="ev_settings">Einstellungen</string>
+  <string name="appearance">Erscheinungsbild</string>
   <string name="ev_layout">Layout</string>
   <string name="settings_sync_profiles">Profilübergreifend synchronisieren</string>
   <string name="settings_game_mode">Spielmodus</string>
@@ -594,9 +628,12 @@
   <string name="keycap_customize_use_mountain_logo">Mountain-Logo verwenden (fest)</string>
   <string name="keycap_customize_clear_all">Anpassungen zurücksetzen</string>
   <string name="keycap_customize_close">Schließen</string>
-  <string name="settings_factory_reset">Auf Werkseinstellungen zurücksetzen</string>
-  <string name="settings_factory_reset_confirm">Dies setzt Spielmodus, Anzeige-LEDs und Beleuchtungseffekte der Tastatur auf die Werkseinstellungen zurück. Fortfahren?</string>
-
+  <string name="settings_factory_reset">Alle Einstellungen auf Werkseinstellungen zurücksetzen</string>
+  <string name="settings_factory_reset_hint">Löscht den eigenen Speicher der Tastatur — Firmware-Profile, Tastenbelegungen, Display-Tasten-Bilder und Beleuchtung — und setzt die in K2 gespeicherte Konfiguration dafür zurück. Nicht zu verwechseln mit "Standardwerte wiederherstellen" in der Seitenleiste, das nur die K2-Profile zurücksetzt und das Gerät unangetastet lässt.</string>
+  <string name="settings_factory_reset_confirm">Dadurch wird der eigene Speicher der Tastatur auf den Werkszustand zurückgesetzt: jedes Firmware-Profil, jede Tastenbelegung, jedes Display-Tasten-Bild und jeder auf dem Gerät gespeicherte Beleuchtungseffekt wird gelöscht, und die in K2 gespeicherte Konfiguration für diese Tastatur wird passend dazu entfernt. Anschließend startet K2 die Beleuchtung der Tastatur nur mit dem ersten Effekt der Liste neu — es wird nichts weiter an das Gerät übertragen. Dies kann nicht rückgängig gemacht werden. Fortfahren?</string>
+  <string name="settings_factory_reset_busy">Tastatur wird auf Werkseinstellungen zurückgesetzt, bitte warten…</string>
+  <string name="settings_factory_reset_done">Die Tastatur wurde auf Werkseinstellungen zurückgesetzt und die in K2 gespeicherte Konfiguration dafür wurde gelöscht. Ihre Beleuchtung wurde mit dem ersten Effekt der Liste neu gestartet; es wurde nichts weiter an das Gerät übertragen.</string>
+  <string name="settings_factory_reset_failed">Die Tastatur hat den Werksreset nicht bestätigt. Es wurde weder am Gerät noch an der in K2 gespeicherten Konfiguration etwas geändert.</string>
   <!-- Tastatur-Makro -->
   <string name="keyboard_macro">Tastatur-Makro</string>
   <string name="macro_library">Makro-Bibliothek</string>
@@ -792,6 +829,7 @@
   <string name="bc_pick_device_none">Wähle ein Gerät, von dem importiert werden soll.</string>
   <string name="bc_pick_device_label">Gerät #{0} — {1} Profil(e): {2}</string>
   <string name="bc_import_will_wipe">Dadurch werden vor dem Import alle vorhandenen K2-Profile auf "{0}" GELÖSCHT.</string>
+  <string name="ev_bc_import_will_wipe_firmware">Außerdem wird die Tastatur selbst auf WERKSEINSTELLUNGEN ZURÜCKGESETZT, wobei Beleuchtung, Tastenbelegungen und Display-Tasten-Bilder in allen 5 Firmware-Slots gelöscht werden.</string>
   <string name="bc_import_read_failed">Die Base-Camp-Datenbank konnte nicht gelesen werden ({0}). Es wurde nichts importiert, deine vorhandenen K2-Profile blieben unverändert.</string>
   <!-- Everest-Import -->
   <string name="ev_no_profiles_in_bc">Keine Everest-Profile in der Base-Camp-Datenbank gefunden.</string>

--- a/K2.Core/Strings.es.xml
+++ b/K2.Core/Strings.es.xml
@@ -210,7 +210,27 @@
   <string name="youtube_chat_message_label">Mensaje de chat en vivo:</string>
   <string name="act_command">Comando de shell</string>
   <string name="act_text">Pegar texto</string>
+  <string name="act_emoji">Emoji</string>
   <string name="act_macro">Reproducir macro</string>
+
+  <!-- Acción de emoji + selector de emojis (EmojiPickerDialog) -->
+  <string name="emoji_picker_title">Elige un emoji</string>
+  <string name="emoji_choose_button">Elegir emoji…</string>
+  <string name="emoji_none_selected">Ningún emoji seleccionado</string>
+  <string name="emoji_search_label">Buscar:</string>
+  <string name="emoji_category_label">Categoría:</string>
+  <string name="emoji_category_all">Todas</string>
+  <string name="emoji_no_results">No se encontraron emojis</string>
+  <string name="emoji_hint">El emoji se escribe en la aplicación activa al pulsar la tecla. En una tecla de pantalla (DisplayPad, teclado numérico de Everest Max) también se usa como imagen de la tecla.</string>
+  <string name="emoji_grp_smileys">Caras y emociones</string>
+  <string name="emoji_grp_people">Personas y cuerpo</string>
+  <string name="emoji_grp_animals">Animales y naturaleza</string>
+  <string name="emoji_grp_food">Comida y bebida</string>
+  <string name="emoji_grp_travel">Viajes y lugares</string>
+  <string name="emoji_grp_activities">Actividades</string>
+  <string name="emoji_grp_objects">Objetos</string>
+  <string name="emoji_grp_symbols">Símbolos</string>
+  <string name="emoji_grp_flags">Banderas</string>
   <string name="act_macro_unresolved">Reproducir macro (sin asignar)</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Script Python</string>
@@ -353,6 +373,19 @@
   <string name="settings_k2_autostart_hint">K2 ahora requiere derechos de administrador (para controlar BaseCampService). Windows no eleva automáticamente las apps iniciadas desde la clave de registro Run al iniciar sesión, así que esta entrada por sí sola puede no lograr iniciar K2 en silencio — si eso ocurre, usa el Programador de tareas en su lugar (una tarea configurada para "Ejecutar con los privilegios más altos" al iniciar sesión).</string>
   <string name="settings_start_min_tray">Iniciar directamente minimizado en la bandeja</string>
   <string name="settings_start_min_tray_hint">K2 se inicia con sus drivers activos pero con la ventana oculta en la bandeja — ábrela en cualquier momento desde el icono de la bandeja.</string>
+  <!-- Asignación de dispositivos DisplayPad -->
+  <string name="settings_dp_devicemap_group">Asignación de dispositivos DisplayPad</string>
+  <string name="settings_dp_devicemap_btn">Configurar asignación…</string>
+  <string name="settings_dp_devicemap_hint">Si moviste un DisplayPad a otro puerto USB y sus perfiles guardados ahora aparecen en el panel equivocado (p. ej. "DisplayPad 2" y "DisplayPad 3" intercambiados), usa esto para reasignar qué panel representa cada pad conectado.</string>
+  <string name="dp_devicemap_title">Asignación de dispositivos DisplayPad</string>
+  <string name="dp_devicemap_hint">Cada pad conectado se muestra abajo con su versión de firmware. Haz clic en "Identificar" para que parpadee la retroiluminación de un pad y así reconocer su fila, luego establece el número de placa que debe usar. Dos filas no pueden compartir el mismo número de placa.</string>
+  <string name="dp_devicemap_col_current">Mostrado actualmente como</string>
+  <string name="dp_devicemap_col_firmware">Firmware</string>
+  <string name="dp_devicemap_col_board">Placa n.º</string>
+  <string name="dp_devicemap_identify_btn">Identificar</string>
+  <string name="dp_devicemap_none_connected">No hay ningún DisplayPad conectado actualmente — conecta los pads que quieras reasignar y vuelve a abrir esta ventana.</string>
+  <string name="dp_devicemap_duplicate_error">Dos pads no pueden usar el mismo número de placa. Asigna un número distinto a cada uno.</string>
+  <string name="dp_devicemap_invalid_number">Los números de placa deben ser enteros positivos.</string>
   <string name="settings_font_family">Fuente</string>
   <string name="settings_font_family_hint">Cambia la fuente de la interfaz de toda la app al instante, sin necesidad de reiniciar.</string>
   <string name="tray_show">Mostrar K2</string>
@@ -373,7 +406,7 @@
   <string name="hw_busy_uploading_image">Subiendo imagen al dispositivo, espera…</string>
   <string name="hw_busy_importing_profile">Importando perfil, espera…</string>
   <string name="hw_busy_importing_profiles">Importando perfiles, espera…</string>
-  <string name="hw_busy_restoring_defaults">Restaurando los valores predeterminados, espera…</string>
+  <string name="hw_busy_restoring_defaults">Restableciendo valores predeterminados, espera…</string>
   <string name="ev_crash_recovering">El driver ha fallado — intentando recuperación automática en 3 s…</string>
   <string name="ev_crash_recovered">Driver recuperado — vista previa LED reiniciada.</string>
   <string name="ev_crash_recovery_failed">La recuperación del driver ha fallado — reinicia K2.App.</string>
@@ -396,7 +429,7 @@
   <string name="rgb_single_tip">Usa un solo color sólido para el efecto.</string>
   <string name="rgb_double">Color doble</string>
   <string name="rgb_double_tip">Usa dos colores para el efecto (no compatible con todos los efectos).</string>
-  <string name="rgb_sync_profiles">Sincronizar perfiles</string>
+  <string name="rgb_sync_profiles">Sincronizar entre perfiles</string>
   <string name="rgb_primary">Principal:</string>
   <string name="rgb_secondary">Secundario:</string>
   <string name="rgb_tertiary">Terciario:</string>
@@ -489,7 +522,7 @@
   <string name="makalu_remap_btn_5">Botón 5</string>
   <string name="makalu_remap_btn_6">Botón 6</string>
 
-  <string name="makalu_settings_title">Ajustes del dispositivo</string>
+  <string name="makalu_settings_title">Ajustes</string>
   <string name="makalu_setting_poll">Frecuencia de sondeo:</string>
   <string name="makalu_setting_debounce">Respuesta de los botones:</string>
   <string name="makalu_setting_angle">Corrección de ángulo:</string>
@@ -561,6 +594,7 @@
 
   <!-- Ajustes (sección de la barra lateral de Everest: distribución del teclado) -->
   <string name="ev_settings">Ajustes</string>
+  <string name="appearance">Apariencia</string>
   <string name="ev_layout">Distribución</string>
   <string name="settings_sync_profiles">Sincronizar entre perfiles</string>
   <string name="settings_game_mode">Modo juego</string>
@@ -596,9 +630,12 @@
   <string name="keycap_customize_use_mountain_logo">Usar logo de Mountain (fijo)</string>
   <string name="keycap_customize_clear_all">Quitar personalizaciones</string>
   <string name="keycap_customize_close">Cerrar</string>
-  <string name="settings_factory_reset">Restablecer a valores de fábrica</string>
-  <string name="settings_factory_reset_confirm">Esto restablece el Modo juego, los LED indicadores y los efectos de iluminación del teclado a los valores de fábrica. ¿Continuar?</string>
-
+  <string name="settings_factory_reset">Restablecer todos los ajustes a los valores de fábrica</string>
+  <string name="settings_factory_reset_hint">Borra la memoria propia del teclado — perfiles de firmware, asignaciones de teclas, imágenes de teclas de pantalla e iluminación — y borra la configuración guardada en K2 para él. No es lo mismo que "Restablecer valores predeterminados" de la barra lateral, que solo restablece los perfiles de K2 y deja el dispositivo intacto.</string>
+  <string name="settings_factory_reset_confirm">Esto borra la memoria propia del teclado devolviéndola al estado de fábrica: se elimina cada perfil de firmware, asignación de teclas, imagen de tecla de pantalla y efecto de iluminación guardado en el dispositivo, y se elimina la configuración guardada en K2 para este teclado en consecuencia. Después, K2 solo reinicia la iluminación del teclado con el primer efecto de la lista — no se envía nada más al dispositivo. Esto no se puede deshacer. ¿Continuar?</string>
+  <string name="settings_factory_reset_busy">Restableciendo el teclado a los valores de fábrica, espera…</string>
+  <string name="settings_factory_reset_done">El teclado se ha restablecido a los valores de fábrica y se ha borrado la configuración guardada en K2 para él. Su iluminación se ha reiniciado con el primer efecto de la lista; no se ha enviado nada más al dispositivo.</string>
+  <string name="settings_factory_reset_failed">El teclado no confirmó el restablecimiento de fábrica. No se realizó ningún cambio en el dispositivo ni en la configuración guardada en K2.</string>
   <!-- Macro de teclado -->
   <string name="keyboard_macro">Macro de teclado</string>
   <string name="macro_library">Biblioteca de macros</string>
@@ -794,6 +831,7 @@
   <string name="bc_pick_device_none">Elige un dispositivo desde el cual importar.</string>
   <string name="bc_pick_device_label">Dispositivo n.º {0} — {1} perfil(es): {2}</string>
   <string name="bc_import_will_wipe">Esto ELIMINARÁ todos los perfiles K2 existentes en "{0}" antes de importar.</string>
+  <string name="ev_bc_import_will_wipe_firmware">Además, se RESTABLECERÁN LOS VALORES DE FÁBRICA del propio teclado, borrando la iluminación, las asignaciones de teclas y las imágenes de teclas de pantalla guardadas en las 5 ranuras de firmware.</string>
   <string name="bc_import_read_failed">No se pudo leer la base de datos de Base Camp ({0}). No se importó nada y tus perfiles K2 existentes se dejaron intactos.</string>
   <!-- Importación de Everest -->
   <string name="ev_no_profiles_in_bc">No se encontraron perfiles Everest en la base de datos de Base Camp.</string>

--- a/K2.Core/Strings.fr.xml
+++ b/K2.Core/Strings.fr.xml
@@ -209,7 +209,27 @@
   <string name="youtube_chat_message_label">Message de chat en direct :</string>
   <string name="act_command">Commande shell</string>
   <string name="act_text">Coller du texte</string>
+  <string name="act_emoji">Emoji</string>
   <string name="act_macro">Lire une macro</string>
+
+  <!-- Action emoji + sélecteur d'emoji (EmojiPickerDialog) -->
+  <string name="emoji_picker_title">Choisir un emoji</string>
+  <string name="emoji_choose_button">Choisir un emoji…</string>
+  <string name="emoji_none_selected">Aucun emoji sélectionné</string>
+  <string name="emoji_search_label">Rechercher :</string>
+  <string name="emoji_category_label">Catégorie :</string>
+  <string name="emoji_category_all">Toutes</string>
+  <string name="emoji_no_results">Aucun emoji trouvé</string>
+  <string name="emoji_hint">L'emoji est saisi dans l'application au premier plan lorsque la touche est pressée. Sur une touche d'affichage (DisplayPad, pavé numérique Everest Max), il est également utilisé comme image de la touche.</string>
+  <string name="emoji_grp_smileys">Émoticônes et émotions</string>
+  <string name="emoji_grp_people">Personnes et corps</string>
+  <string name="emoji_grp_animals">Animaux et nature</string>
+  <string name="emoji_grp_food">Nourriture et boissons</string>
+  <string name="emoji_grp_travel">Voyages et lieux</string>
+  <string name="emoji_grp_activities">Activités</string>
+  <string name="emoji_grp_objects">Objets</string>
+  <string name="emoji_grp_symbols">Symboles</string>
+  <string name="emoji_grp_flags">Drapeaux</string>
   <string name="act_macro_unresolved">Lire une macro (non assignée)</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Script Python</string>
@@ -352,6 +372,19 @@
   <string name="settings_k2_autostart_hint">K2 nécessite désormais les droits administrateur (pour contrôler BaseCampService). Windows n'élève pas automatiquement les applications lancées depuis la clé de registre Run à l'ouverture de session, donc cette entrée seule peut échouer à démarrer K2 silencieusement — si cela se produit, utilisez plutôt le Planificateur de tâches (une tâche définie sur "Exécuter avec les privilèges les plus élevés" à l'ouverture de session).</string>
   <string name="settings_start_min_tray">Démarrer directement réduit dans la zone de notification</string>
   <string name="settings_start_min_tray_hint">K2 démarre avec ses pilotes actifs mais la fenêtre cachée dans la zone de notification — rouvrez-la à tout moment depuis l'icône.</string>
+  <!-- Mappage des appareils DisplayPad -->
+  <string name="settings_dp_devicemap_group">Mappage des appareils DisplayPad</string>
+  <string name="settings_dp_devicemap_btn">Configurer le mappage…</string>
+  <string name="settings_dp_devicemap_hint">Si vous avez déplacé un DisplayPad sur un autre port USB et que ses profils enregistrés apparaissent maintenant sur le mauvais panneau (par ex. "DisplayPad 2" et "DisplayPad 3" inversés), utilisez ceci pour réattribuer le panneau représenté par chaque pad connecté.</string>
+  <string name="dp_devicemap_title">Mappage des appareils DisplayPad</string>
+  <string name="dp_devicemap_hint">Chaque pad connecté est listé ci-dessous avec sa version de firmware. Cliquez sur "Identifier" pour faire clignoter le rétroéclairage d'un pad afin de reconnaître sa ligne, puis définissez le numéro de carte à utiliser. Deux lignes ne peuvent pas partager le même numéro de carte.</string>
+  <string name="dp_devicemap_col_current">Actuellement affiché comme</string>
+  <string name="dp_devicemap_col_firmware">Firmware</string>
+  <string name="dp_devicemap_col_board">N° de carte</string>
+  <string name="dp_devicemap_identify_btn">Identifier</string>
+  <string name="dp_devicemap_none_connected">Aucun DisplayPad n'est actuellement connecté — branchez les pads à réattribuer puis rouvrez cette fenêtre.</string>
+  <string name="dp_devicemap_duplicate_error">Deux pads ne peuvent pas utiliser le même numéro de carte. Attribuez un numéro différent à chacun.</string>
+  <string name="dp_devicemap_invalid_number">Les numéros de carte doivent être des entiers positifs.</string>
   <string name="settings_font_family">Police</string>
   <string name="settings_font_family_hint">Change immédiatement la police de l'interface dans toute l'application, sans redémarrage.</string>
   <string name="tray_show">Afficher K2</string>
@@ -394,7 +427,7 @@
   <string name="rgb_single_tip">Utilise une seule couleur unie pour l'effet.</string>
   <string name="rgb_double">Double couleur</string>
   <string name="rgb_double_tip">Utilise deux couleurs pour l'effet (non pris en charge par tous les effets).</string>
-  <string name="rgb_sync_profiles">Synchroniser les profils</string>
+  <string name="rgb_sync_profiles">Synchroniser entre les profils</string>
   <string name="rgb_primary">Principal :</string>
   <string name="rgb_secondary">Secondaire :</string>
   <string name="rgb_tertiary">Tertiaire :</string>
@@ -482,7 +515,7 @@
   <string name="makalu_remap_btn_dpi">Bouton DPI</string>
   <string name="makalu_remap_btn_5">Bouton 5</string>
   <string name="makalu_remap_btn_6">Bouton 6</string>
-  <string name="makalu_settings_title">Paramètres de l'appareil</string>
+  <string name="makalu_settings_title">Paramètres</string>
   <string name="makalu_setting_poll">Fréquence de scrutation :</string>
   <string name="makalu_setting_debounce">Réponse des boutons :</string>
   <string name="makalu_setting_angle">Angle snapping :</string>
@@ -550,6 +583,7 @@
   <string name="dock_remove_action">Supprimer l'action</string>
   <!-- Paramètres (section barre latérale Everest : disposition du clavier) -->
   <string name="ev_settings">Paramètres</string>
+  <string name="appearance">Apparence</string>
   <string name="ev_layout">Disposition</string>
   <string name="settings_sync_profiles">Synchroniser entre les profils</string>
   <string name="settings_game_mode">Mode jeu</string>
@@ -585,9 +619,12 @@
   <string name="keycap_customize_use_mountain_logo">Utiliser le logo Mountain (fixe)</string>
   <string name="keycap_customize_clear_all">Supprimer les personnalisations</string>
   <string name="keycap_customize_close">Fermer</string>
-  <string name="settings_factory_reset">Rétablir les paramètres d'usine</string>
-  <string name="settings_factory_reset_confirm">Cette opération réinitialise le Mode jeu, les LED indicatrices et les effets d'éclairage du clavier aux paramètres d'usine. Continuer ?</string>
-  <!-- Macro clavier -->
+  <string name="settings_factory_reset">Réinitialiser tous les paramètres aux valeurs d'usine</string>
+  <string name="settings_factory_reset_hint">Efface la mémoire propre du clavier — profils firmware, associations de touches, images des touches d'affichage et éclairage — et réinitialise la configuration enregistrée dans K2 pour celui-ci. Ce n'est pas la même chose que "Restaurer les valeurs par défaut" de la barre latérale, qui ne réinitialise que les profils K2 sans toucher à l'appareil.</string>
+  <string name="settings_factory_reset_confirm">Ceci réinitialise la mémoire propre du clavier à l'état d'usine : chaque profil firmware, association de touches, image de touche d'affichage et effet d'éclairage enregistré sur l'appareil est effacé, et la configuration enregistrée dans K2 pour ce clavier est supprimée en conséquence. Ensuite, K2 relance uniquement l'éclairage du clavier avec le premier effet de la liste — rien d'autre n'est renvoyé à l'appareil. Cette action est irréversible. Continuer ?</string>
+  <string name="settings_factory_reset_busy">Réinitialisation du clavier aux valeurs d'usine, veuillez patienter…</string>
+  <string name="settings_factory_reset_done">Le clavier a été réinitialisé aux valeurs d'usine et la configuration enregistrée dans K2 pour celui-ci a été effacée. Son éclairage a été relancé avec le premier effet de la liste ; rien d'autre n'a été renvoyé à l'appareil.</string>
+  <string name="settings_factory_reset_failed">Le clavier n'a pas confirmé la réinitialisation d'usine. Rien n'a été modifié sur l'appareil ni dans la configuration enregistrée dans K2.</string>  <!-- Macro clavier -->
   <string name="keyboard_macro">Macro clavier</string>
   <string name="macro_library">Bibliothèque de macros</string>
   <string name="macro_new">Nouveau</string>
@@ -780,6 +817,7 @@
   <string name="bc_pick_device_none">Choisissez un appareil depuis lequel importer.</string>
   <string name="bc_pick_device_label">Appareil n°{0} — {1} profil(s) : {2}</string>
   <string name="bc_import_will_wipe">Cette opération SUPPRIMERA tous les profils K2 existants sur "{0}" avant l'importation.</string>
+  <string name="ev_bc_import_will_wipe_firmware">Le clavier lui-même sera également RÉINITIALISÉ AUX VALEURS D'USINE, effaçant l'éclairage, les associations de touches et les images des touches d'affichage stockées dans les 5 emplacements de firmware.</string>
   <string name="bc_import_read_failed">Impossible de lire la base de données Base Camp ({0}). Rien n'a été importé et vos profils K2 existants n'ont pas été modifiés.</string>
   <!-- Importation Everest -->
   <string name="ev_no_profiles_in_bc">Aucun profil Everest trouvé dans la base de données Base Camp.</string>

--- a/K2.Core/Strings.it.xml
+++ b/K2.Core/Strings.it.xml
@@ -356,6 +356,7 @@
   <string name="settings_update_zip_btn">Scarica ZIP…</string>
   <string name="settings_update_view_release_btn">Vedi note di rilascio</string>
   <string name="settings_update_downloading">Download in corso…</string>
+  <string name="settings_update_downloading_pct">Download in corso… {0}%</string>
   <string name="settings_update_install_confirm">Scaricare la versione {0} e avviare l'installer? K2 si chiuderà non appena l'installer parte, per permettere l'aggiornamento.</string>
   <string name="settings_update_zip_done">Salvato in {0}</string>
   <string name="settings_danger_zone">Zona pericolosa</string>
@@ -529,7 +530,7 @@
   <string name="makalu_remap_btn_5">Tasto 5</string>
   <string name="makalu_remap_btn_6">Tasto 6</string>
 
-  <string name="makalu_settings_title">Impostazioni dispositivo</string>
+  <string name="makalu_settings_title">Impostazioni</string>
   <string name="makalu_setting_poll">Frequenza polling:</string>
   <string name="makalu_setting_debounce">Risposta tasti:</string>
   <string name="makalu_setting_angle">Angle snapping:</string>

--- a/K2.Core/Strings.ja.xml
+++ b/K2.Core/Strings.ja.xml
@@ -208,7 +208,27 @@
   <string name="youtube_chat_message_label">ライブチャットメッセージ:</string>
   <string name="act_command">シェルコマンド</string>
   <string name="act_text">テキストを貼り付ける</string>
+  <string name="act_emoji">絵文字</string>
   <string name="act_macro">マクロを再生</string>
+
+  <!-- 絵文字アクション + 絵文字ブラウザー（EmojiPickerDialog） -->
+  <string name="emoji_picker_title">絵文字を選択</string>
+  <string name="emoji_choose_button">絵文字を選択…</string>
+  <string name="emoji_none_selected">絵文字が選択されていません</string>
+  <string name="emoji_search_label">検索:</string>
+  <string name="emoji_category_label">カテゴリー:</string>
+  <string name="emoji_category_all">すべて</string>
+  <string name="emoji_no_results">絵文字が見つかりません</string>
+  <string name="emoji_hint">キーを押すと、フォーカスされているアプリケーションに絵文字が入力されます。ディスプレイキー（DisplayPad、Everest Max のテンキー）では、キーの画像としても使用されます。</string>
+  <string name="emoji_grp_smileys">スマイリーと感情</string>
+  <string name="emoji_grp_people">人々と体</string>
+  <string name="emoji_grp_animals">動物と自然</string>
+  <string name="emoji_grp_food">食べ物と飲み物</string>
+  <string name="emoji_grp_travel">旅行と場所</string>
+  <string name="emoji_grp_activities">アクティビティ</string>
+  <string name="emoji_grp_objects">物</string>
+  <string name="emoji_grp_symbols">記号</string>
+  <string name="emoji_grp_flags">旗</string>
   <string name="act_macro_unresolved">マクロを再生（未割り当て）</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Python スクリプト</string>
@@ -350,6 +370,19 @@
   <string name="settings_k2_autostart_hint">K2 は現在、管理者権限を必要とします（BaseCampService の制御のため）。Windows はログオン時に Run レジストリキーから起動するアプリを自動昇格しないため、この設定だけでは K2 がサイレントに起動できないことがあります — その場合はタスクスケジューラを使用してください（ログオン時に「最上位の特権で実行」を設定したタスク）。</string>
   <string name="settings_start_min_tray">トレイに最小化した状態で起動</string>
   <string name="settings_start_min_tray_hint">K2 はドライバーを有効にした状態で起動しますが、ウィンドウはトレイに隠れています — トレイアイコンからいつでも開けます。</string>
+  <!-- DisplayPad デバイスマッピング -->
+  <string name="settings_dp_devicemap_group">DisplayPad デバイスマッピング</string>
+  <string name="settings_dp_devicemap_btn">マッピングを設定…</string>
+  <string name="settings_dp_devicemap_hint">DisplayPad を別の USB ポートに移動し、保存済みのプロファイルが誤ったパネルに表示されるようになった場合（例："DisplayPad 2" と "DisplayPad 3" が入れ替わっている）、これを使って各接続パッドが扱われるパネルを再割り当てできます。</string>
+  <string name="dp_devicemap_title">DisplayPad デバイスマッピング</string>
+  <string name="dp_devicemap_hint">接続されている各パッドがファームウェアバージョンとともに以下に一覧表示されます。「識別」をクリックしてパッドのバックライトを点滅させ、どの行かを確認してから、使用するボード番号を設定してください。2 つの行が同じボード番号を共有することはできません。</string>
+  <string name="dp_devicemap_col_current">現在の表示</string>
+  <string name="dp_devicemap_col_firmware">ファームウェア</string>
+  <string name="dp_devicemap_col_board">ボード番号</string>
+  <string name="dp_devicemap_identify_btn">識別</string>
+  <string name="dp_devicemap_none_connected">現在接続されている DisplayPad はありません — 再割り当てしたいパッドを接続してから、このウィンドウを開き直してください。</string>
+  <string name="dp_devicemap_duplicate_error">2 つのパッドが同じボード番号を使用することはできません。それぞれに異なる番号を割り当ててください。</string>
+  <string name="dp_devicemap_invalid_number">ボード番号は正の整数である必要があります。</string>
   <string name="settings_font_family">フォント</string>
   <string name="settings_font_family_hint">アプリ全体の UI フォントを即座に変更します。再起動は不要です。</string>
   <string name="tray_show">K2 を表示</string>
@@ -369,7 +402,7 @@
   <string name="hw_busy_uploading_image">デバイスに画像をアップロードしています。しばらくお待ちください…</string>
   <string name="hw_busy_importing_profile">プロファイルをインポートしています。しばらくお待ちください…</string>
   <string name="hw_busy_importing_profiles">プロファイルをインポートしています。しばらくお待ちください…</string>
-  <string name="hw_busy_restoring_defaults">デフォルトに戻しています。しばらくお待ちください…</string>
+  <string name="hw_busy_restoring_defaults">デフォルト設定を復元しています。しばらくお待ちください…</string>
   <string name="ev_crash_recovering">ドライバーがクラッシュしました — 3 秒後に自動回復を試みます…</string>
   <string name="ev_crash_recovered">ドライバーが回復しました — LED プレビューを再起動しました。</string>
   <string name="ev_crash_recovery_failed">ドライバーの回復に失敗しました — K2.App を再起動してください。</string>
@@ -391,7 +424,7 @@
   <string name="rgb_single_tip">エフェクトに単色を使用します。</string>
   <string name="rgb_double">2色</string>
   <string name="rgb_double_tip">エフェクトに2色を使用します（すべてのエフェクトに対応しているわけではありません）。</string>
-  <string name="rgb_sync_profiles">プロファイルを同期</string>
+  <string name="rgb_sync_profiles">プロファイル間で同期</string>
   <string name="rgb_primary">プライマリ:</string>
   <string name="rgb_secondary">セカンダリ:</string>
   <string name="rgb_tertiary">ターシャリ:</string>
@@ -477,7 +510,7 @@
   <string name="makalu_remap_btn_dpi">DPI ボタン</string>
   <string name="makalu_remap_btn_5">ボタン 5</string>
   <string name="makalu_remap_btn_6">ボタン 6</string>
-  <string name="makalu_settings_title">デバイス設定</string>
+  <string name="makalu_settings_title">設定</string>
   <string name="makalu_setting_poll">ポーリングレート:</string>
   <string name="makalu_setting_debounce">ボタンの反応:</string>
   <string name="makalu_setting_angle">アングルスナッピング:</string>
@@ -545,6 +578,7 @@
   <string name="dock_remove_action">アクションを削除</string>
   <!-- 設定（Everest サイドバーセクション: キーボードレイアウト） -->
   <string name="ev_settings">設定</string>
+  <string name="appearance">外観</string>
   <string name="ev_layout">レイアウト</string>
   <string name="settings_sync_profiles">プロファイル間で同期</string>
   <string name="settings_game_mode">ゲームモード</string>
@@ -580,9 +614,12 @@
   <string name="keycap_customize_use_mountain_logo">Mountain ロゴを使用（固定）</string>
   <string name="keycap_customize_clear_all">上書きをクリア</string>
   <string name="keycap_customize_close">閉じる</string>
-  <string name="settings_factory_reset">工場出荷時の設定に戻す</string>
-  <string name="settings_factory_reset_confirm">キーボードのゲームモード、インジケーター LED、ライティングエフェクトを工場出荷時の設定に戻します。続行しますか？</string>
-  <!-- キーボードマクロ -->
+  <string name="settings_factory_reset">すべての設定を工場出荷時の状態に戻す</string>
+  <string name="settings_factory_reset_hint">キーボード自体のメモリー（ファームウェアプロファイル、キー割り当て、ディスプレイキーの画像、照明）を消去し、K2 に保存されているこのキーボードの設定もクリアします。サイドバーの「デフォルトに戻す」とは異なり、こちらは K2 のプロファイルのみをリセットし、デバイスには影響しません。</string>
+  <string name="settings_factory_reset_confirm">これにより、キーボード自体のメモリーが工場出荷時の状態に戻ります。デバイスに保存されているすべてのファームウェアプロファイル、キー割り当て、ディスプレイキーの画像、照明エフェクトが消去され、K2 に保存されているこのキーボードの設定も合わせて削除されます。その後 K2 は、リストの最初のエフェクトでキーボードの照明を再起動するだけで、それ以外は何もデバイスに送信されません。この操作は元に戻せません。続行しますか？</string>
+  <string name="settings_factory_reset_busy">キーボードを工場出荷時の設定にリセットしています。しばらくお待ちください…</string>
+  <string name="settings_factory_reset_done">キーボードは工場出荷時の設定にリセットされ、K2 に保存されているこのキーボードの設定もクリアされました。照明はリストの最初のエフェクトで再起動されました。それ以外はデバイスに送信されていません。</string>
+  <string name="settings_factory_reset_failed">キーボードが工場出荷時リセットを確認しませんでした。デバイスにも、K2 に保存されている設定にも変更は加えられていません。</string>  <!-- キーボードマクロ -->
   <string name="keyboard_macro">キーボードマクロ</string>
   <string name="macro_library">マクロライブラリ</string>
   <string name="macro_new">新規</string>
@@ -773,6 +810,7 @@
   <string name="bc_pick_device_none">インポート元のデバイスを選択してください。</string>
   <string name="bc_pick_device_label">デバイス #{0} — {1} 件のプロファイル: {2}</string>
   <string name="bc_import_will_wipe">インポートの前に、"{0}" 上の既存の K2 プロファイルはすべて削除されます。</string>
+  <string name="ev_bc_import_will_wipe_firmware">さらに、キーボード自体も工場出荷時の状態にリセットされ、5 つすべてのファームウェアスロットに保存されている照明、キー割り当て、ディスプレイキーの画像が消去されます。</string>
   <string name="bc_import_read_failed">Base Camp のデータベースを読み込めませんでした（{0}）。何もインポートされておらず、既存の K2 プロファイルはそのまま残っています。</string>
   <!-- Everest インポート -->
   <string name="ev_no_profiles_in_bc">Base Camp データベースに Everest プロファイルが見つかりません。</string>

--- a/K2.Core/Strings.ko.xml
+++ b/K2.Core/Strings.ko.xml
@@ -207,7 +207,27 @@
   <string name="youtube_chat_message_label">실시간 채팅 메시지:</string>
   <string name="act_command">셸 명령</string>
   <string name="act_text">텍스트 붙여넣기</string>
+  <string name="act_emoji">이모지</string>
   <string name="act_macro">매크로 재생</string>
+
+  <!-- 이모지 동작 + 이모지 브라우저(EmojiPickerDialog) -->
+  <string name="emoji_picker_title">이모지 선택</string>
+  <string name="emoji_choose_button">이모지 선택…</string>
+  <string name="emoji_none_selected">선택된 이모지 없음</string>
+  <string name="emoji_search_label">검색:</string>
+  <string name="emoji_category_label">카테고리:</string>
+  <string name="emoji_category_all">전체</string>
+  <string name="emoji_no_results">이모지를 찾을 수 없습니다</string>
+  <string name="emoji_hint">키를 누르면 현재 포커스된 애플리케이션에 이모지가 입력됩니다. 디스플레이 키(DisplayPad, Everest Max 넘패드)에서는 키 이미지로도 사용됩니다.</string>
+  <string name="emoji_grp_smileys">스마일리 및 감정</string>
+  <string name="emoji_grp_people">사람 및 신체</string>
+  <string name="emoji_grp_animals">동물 및 자연</string>
+  <string name="emoji_grp_food">음식 및 음료</string>
+  <string name="emoji_grp_travel">여행 및 장소</string>
+  <string name="emoji_grp_activities">활동</string>
+  <string name="emoji_grp_objects">사물</string>
+  <string name="emoji_grp_symbols">기호</string>
+  <string name="emoji_grp_flags">깃발</string>
   <string name="act_macro_unresolved">매크로 재생 (할당되지 않음)</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Python 스크립트</string>
@@ -349,6 +369,19 @@
   <string name="settings_k2_autostart_hint">K2는 이제 관리자 권한이 필요합니다 (BaseCampService 제어를 위해). Windows는 로그온 시 Run 레지스트리 키로 실행되는 앱을 자동으로 상승시키지 않으므로, 이 항목만으로는 K2가 자동으로 시작되지 않을 수 있습니다 — 이 경우 대신 작업 스케줄러를 사용하세요 (로그온 시 "가장 높은 권한으로 실행"으로 설정된 작업).</string>
   <string name="settings_start_min_tray">트레이로 최소화된 상태로 바로 시작</string>
   <string name="settings_start_min_tray_hint">K2가 드라이버는 활성화된 상태로 시작되지만 창은 트레이에 숨겨집니다 — 트레이 아이콘에서 언제든지 열 수 있습니다.</string>
+  <!-- DisplayPad 장치 매핑 -->
+  <string name="settings_dp_devicemap_group">DisplayPad 장치 매핑</string>
+  <string name="settings_dp_devicemap_btn">매핑 구성…</string>
+  <string name="settings_dp_devicemap_hint">DisplayPad를 다른 USB 포트로 옮긴 후 저장된 프로파일이 잘못된 패널에 표시되는 경우(예: "DisplayPad 2"와 "DisplayPad 3"이 바뀐 경우), 이 기능을 사용하여 연결된 각 패드가 어떤 패널로 처리될지 다시 지정할 수 있습니다.</string>
+  <string name="dp_devicemap_title">DisplayPad 장치 매핑</string>
+  <string name="dp_devicemap_hint">연결된 각 패드가 펌웨어 버전과 함께 아래에 나열됩니다. "식별"을 클릭하면 패드의 백라이트가 깜박여 어느 행인지 확인할 수 있으며, 그 후 사용할 보드 번호를 설정하세요. 두 행이 같은 보드 번호를 공유할 수 없습니다.</string>
+  <string name="dp_devicemap_col_current">현재 표시</string>
+  <string name="dp_devicemap_col_firmware">펌웨어</string>
+  <string name="dp_devicemap_col_board">보드 번호</string>
+  <string name="dp_devicemap_identify_btn">식별</string>
+  <string name="dp_devicemap_none_connected">현재 연결된 DisplayPad가 없습니다 — 다시 매핑할 패드를 연결한 후 이 창을 다시 여세요.</string>
+  <string name="dp_devicemap_duplicate_error">두 패드가 같은 보드 번호를 사용할 수 없습니다. 각각 다른 번호를 지정하세요.</string>
+  <string name="dp_devicemap_invalid_number">보드 번호는 양의 정수여야 합니다.</string>
   <string name="settings_font_family">글꼴</string>
   <string name="settings_font_family_hint">재시작 없이 앱 전체 UI 글꼴을 즉시 변경합니다.</string>
   <string name="tray_show">K2 표시</string>
@@ -368,7 +401,7 @@
   <string name="hw_busy_uploading_image">장치에 이미지를 업로드하는 중입니다. 잠시만 기다려 주세요…</string>
   <string name="hw_busy_importing_profile">프로파일을 가져오는 중입니다. 잠시만 기다려 주세요…</string>
   <string name="hw_busy_importing_profiles">프로파일을 가져오는 중입니다. 잠시만 기다려 주세요…</string>
-  <string name="hw_busy_restoring_defaults">기본값으로 복원하는 중입니다. 잠시만 기다려 주세요…</string>
+  <string name="hw_busy_restoring_defaults">기본값을 복원하는 중입니다. 잠시만 기다려 주세요…</string>
   <string name="ev_crash_recovering">드라이버가 충돌했습니다 — 3초 후 자동 복구를 시도합니다…</string>
   <string name="ev_crash_recovered">드라이버가 복구되었습니다 — LED 미리보기가 다시 시작되었습니다.</string>
   <string name="ev_crash_recovery_failed">드라이버 복구에 실패했습니다 — K2.App을 다시 시작하세요.</string>
@@ -390,7 +423,7 @@
   <string name="rgb_single_tip">효과에 단색 하나만 사용합니다.</string>
   <string name="rgb_double">이중 색상</string>
   <string name="rgb_double_tip">효과에 두 가지 색상을 사용합니다 (일부 효과에서는 지원되지 않음).</string>
-  <string name="rgb_sync_profiles">프로파일 동기화</string>
+  <string name="rgb_sync_profiles">프로파일 간 동기화</string>
   <string name="rgb_primary">기본색:</string>
   <string name="rgb_secondary">보조색:</string>
   <string name="rgb_tertiary">제3색:</string>
@@ -476,7 +509,7 @@
   <string name="makalu_remap_btn_dpi">DPI 버튼</string>
   <string name="makalu_remap_btn_5">버튼 5</string>
   <string name="makalu_remap_btn_6">버튼 6</string>
-  <string name="makalu_settings_title">장치 설정</string>
+  <string name="makalu_settings_title">설정</string>
   <string name="makalu_setting_poll">폴링 속도:</string>
   <string name="makalu_setting_debounce">버튼 반응 속도:</string>
   <string name="makalu_setting_angle">각도 스냅:</string>
@@ -544,6 +577,7 @@
   <string name="dock_remove_action">동작 삭제</string>
   <!--설정 (Everest 사이드바 섹션: 키보드 레이아웃)-->
   <string name="ev_settings">설정</string>
+  <string name="appearance">외관</string>
   <string name="ev_layout">레이아웃</string>
   <string name="settings_sync_profiles">프로파일 간 동기화</string>
   <string name="settings_game_mode">게임 모드</string>
@@ -579,9 +613,12 @@
   <string name="keycap_customize_use_mountain_logo">Mountain 로고 사용 (고정)</string>
   <string name="keycap_customize_clear_all">재정의 지우기</string>
   <string name="keycap_customize_close">닫기</string>
-  <string name="settings_factory_reset">공장 기본값으로 초기화</string>
-  <string name="settings_factory_reset_confirm">키보드의 게임 모드, 표시등 LED, 조명 효과를 공장 기본값으로 초기화합니다. 계속하시겠습니까?</string>
-  <!--키보드 매크로-->
+  <string name="settings_factory_reset">모든 설정을 공장 기본값으로 재설정</string>
+  <string name="settings_factory_reset_hint">키보드 자체 메모리(펌웨어 프로파일, 키 바인딩, 디스플레이 키 이미지 및 조명)를 지우고 K2에 저장된 해당 구성도 초기화합니다. 사이드바의 "기본값 복원"과는 다르며, 그것은 K2 프로파일만 재설정하고 장치는 그대로 둡니다.</string>
+  <string name="settings_factory_reset_confirm">이 작업은 키보드 자체 메모리를 공장 상태로 초기화합니다. 장치에 저장된 모든 펌웨어 프로파일, 키 바인딩, 디스플레이 키 이미지 및 조명 효과가 지워지며, 이 키보드에 대해 K2에 저장된 구성도 그에 맞춰 삭제됩니다. 이후 K2는 목록의 첫 번째 효과로 키보드 조명만 다시 시작하며, 그 외에는 장치로 아무것도 전송되지 않습니다. 이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?</string>
+  <string name="settings_factory_reset_busy">키보드를 공장 기본값으로 재설정하는 중입니다. 잠시만 기다려 주세요…</string>
+  <string name="settings_factory_reset_done">키보드가 공장 기본값으로 재설정되었으며 K2에 저장된 해당 구성도 삭제되었습니다. 조명은 목록의 첫 번째 효과로 다시 시작되었으며, 그 외에는 장치로 아무것도 전송되지 않았습니다.</string>
+  <string name="settings_factory_reset_failed">키보드가 공장 초기화를 확인하지 않았습니다. 장치나 K2에 저장된 구성에 변경된 내용이 없습니다.</string>  <!--키보드 매크로-->
   <string name="keyboard_macro">키보드 매크로</string>
   <string name="macro_library">매크로 라이브러리</string>
   <string name="macro_new">새로 만들기</string>
@@ -772,6 +809,7 @@
   <string name="bc_pick_device_none">가져올 장치를 선택하세요.</string>
   <string name="bc_pick_device_label">장치 #{0} — 프로파일 {1}개: {2}</string>
   <string name="bc_import_will_wipe">가져오기 전에 "{0}"의 기존 K2 프로파일이 모두 삭제됩니다.</string>
+  <string name="ev_bc_import_will_wipe_firmware">또한 키보드 자체가 공장 초기화되어 5개의 모든 펌웨어 슬롯에 저장된 조명, 키 바인딩 및 디스플레이 키 이미지가 지워집니다.</string>
   <string name="bc_import_read_failed">Base Camp 데이터베이스({0})를 읽을 수 없습니다. 아무것도 가져오지 않았으며 기존 K2 프로파일은 그대로 유지됩니다.</string>
   <!--Everest 가져오기-->
   <string name="ev_no_profiles_in_bc">Base Camp 데이터베이스에서 Everest 프로파일을 찾을 수 없습니다.</string>

--- a/K2.Core/Strings.pl.xml
+++ b/K2.Core/Strings.pl.xml
@@ -208,7 +208,27 @@
   <string name="youtube_chat_message_label">Wiadomość na czacie na żywo:</string>
   <string name="act_command">Polecenie powłoki</string>
   <string name="act_text">Wklej tekst</string>
+  <string name="act_emoji">Emoji</string>
   <string name="act_macro">Odtwórz makro</string>
+
+  <!-- Akcja emoji + przeglądarka emoji (EmojiPickerDialog) -->
+  <string name="emoji_picker_title">Wybierz emoji</string>
+  <string name="emoji_choose_button">Wybierz emoji…</string>
+  <string name="emoji_none_selected">Nie wybrano emoji</string>
+  <string name="emoji_search_label">Szukaj:</string>
+  <string name="emoji_category_label">Kategoria:</string>
+  <string name="emoji_category_all">Wszystkie</string>
+  <string name="emoji_no_results">Nie znaleziono emoji</string>
+  <string name="emoji_hint">Emoji jest wpisywane do aktywnej aplikacji po naciśnięciu klawisza. Na klawiszu wyświetlacza (DisplayPad, klawiatura numeryczna Everest Max) jest ono również używane jako obraz klawisza.</string>
+  <string name="emoji_grp_smileys">Uśmiechy i emocje</string>
+  <string name="emoji_grp_people">Ludzie i ciało</string>
+  <string name="emoji_grp_animals">Zwierzęta i przyroda</string>
+  <string name="emoji_grp_food">Jedzenie i napoje</string>
+  <string name="emoji_grp_travel">Podróże i miejsca</string>
+  <string name="emoji_grp_activities">Czynności</string>
+  <string name="emoji_grp_objects">Obiekty</string>
+  <string name="emoji_grp_symbols">Symbole</string>
+  <string name="emoji_grp_flags">Flagi</string>
   <string name="act_macro_unresolved">Odtwórz makro (nieprzypisane)</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Skrypt Python</string>
@@ -351,6 +371,19 @@
   <string name="settings_k2_autostart_hint">K2 wymaga teraz uprawnień administratora (do sterowania BaseCampService). Windows nie podnosi automatycznie uprawnień aplikacji uruchamianych z klucza rejestru Run przy logowaniu, więc sam ten wpis może nie uruchomić K2 po cichu — jeśli tak się stanie, użyj Harmonogramu zadań (zadanie ustawione na "Uruchom z najwyższymi uprawnieniami" przy logowaniu).</string>
   <string name="settings_start_min_tray">Uruchamiaj od razu zminimalizowane do zasobnika</string>
   <string name="settings_start_min_tray_hint">K2 uruchamia się z aktywnymi sterownikami, ale z oknem ukrytym w zasobniku systemowym — otwórz je w dowolnym momencie z ikony w zasobniku.</string>
+  <!-- Mapowanie urządzeń DisplayPad -->
+  <string name="settings_dp_devicemap_group">Mapowanie urządzeń DisplayPad</string>
+  <string name="settings_dp_devicemap_btn">Skonfiguruj mapowanie…</string>
+  <string name="settings_dp_devicemap_hint">Jeśli podłączyłeś DisplayPad do innego portu USB i jego zapisane profile pojawiają się teraz na niewłaściwym panelu (np. "DisplayPad 2" i "DisplayPad 3" zamienione miejscami), użyj tej opcji, aby ponownie przypisać, jaki panel reprezentuje każdy podłączony pad.</string>
+  <string name="dp_devicemap_title">Mapowanie urządzeń DisplayPad</string>
+  <string name="dp_devicemap_hint">Każdy podłączony pad jest wymieniony poniżej wraz z wersją firmware. Kliknij "Zidentyfikuj", aby podświetlenie pada zamigało i można było rozpoznać odpowiedni wiersz, a następnie ustaw numer płytki, którego ma używać. Dwa wiersze nie mogą mieć tego samego numeru płytki.</string>
+  <string name="dp_devicemap_col_current">Obecnie wyświetlany jako</string>
+  <string name="dp_devicemap_col_firmware">Firmware</string>
+  <string name="dp_devicemap_col_board">Nr płytki</string>
+  <string name="dp_devicemap_identify_btn">Zidentyfikuj</string>
+  <string name="dp_devicemap_none_connected">Obecnie nie jest podłączony żaden DisplayPad — podłącz pady, które chcesz przemapować, i otwórz ponownie to okno.</string>
+  <string name="dp_devicemap_duplicate_error">Dwa pady nie mogą używać tego samego numeru płytki. Nadaj każdemu inny numer.</string>
+  <string name="dp_devicemap_invalid_number">Numery płytek muszą być dodatnimi liczbami całkowitymi.</string>
   <string name="settings_font_family">Czcionka</string>
   <string name="settings_font_family_hint">Natychmiast zmienia czcionkę interfejsu w całej aplikacji, bez potrzeby ponownego uruchamiania.</string>
   <string name="tray_show">Pokaż K2</string>
@@ -487,7 +520,7 @@
   <string name="makalu_remap_btn_5">Przycisk 5</string>
   <string name="makalu_remap_btn_6">Przycisk 6</string>
 
-  <string name="makalu_settings_title">Ustawienia urządzenia</string>
+  <string name="makalu_settings_title">Ustawienia</string>
   <string name="makalu_setting_poll">Częstotliwość odpytywania:</string>
   <string name="makalu_setting_debounce">Odpowiedź przycisków:</string>
   <string name="makalu_setting_angle">Angle snapping:</string>
@@ -559,6 +592,7 @@
 
   <!-- Ustawienia (sekcja paska bocznego Everest: układ klawiatury) -->
   <string name="ev_settings">Ustawienia</string>
+  <string name="appearance">Wygląd</string>
   <string name="ev_layout">Układ</string>
   <string name="settings_sync_profiles">Synchronizuj między profilami</string>
   <string name="settings_game_mode">Tryb gry</string>
@@ -594,8 +628,12 @@
   <string name="keycap_customize_use_mountain_logo">Użyj logo Mountain (stałe)</string>
   <string name="keycap_customize_clear_all">Usuń wszystkie personalizacje</string>
   <string name="keycap_customize_close">Zamknij</string>
-  <string name="settings_factory_reset">Przywróć ustawienia fabryczne</string>
-  <string name="settings_factory_reset_confirm">To przywraca Tryb gry, diody wskaźnikowe i efekty podświetlenia klawiatury do ustawień fabrycznych. Kontynuować?</string>
+  <string name="settings_factory_reset">Przywróć wszystkie ustawienia do wartości fabrycznych</string>
+  <string name="settings_factory_reset_hint">Czyści własną pamięć klawiatury — profile firmware, przypisania klawiszy, obrazy klawiszy wyświetlacza i podświetlenie — oraz czyści zapisaną w K2 konfigurację tego urządzenia. To nie to samo co "Przywróć ustawienia domyślne" w panelu bocznym, które resetuje tylko profile K2 i nie dotyka urządzenia.</string>
+  <string name="settings_factory_reset_confirm">To przywraca własną pamięć klawiatury do stanu fabrycznego: każdy profil firmware, przypisanie klawiszy, obraz klawisza wyświetlacza i efekt podświetlenia zapisany na urządzeniu zostaje usunięty, a zapisana w K2 konfiguracja tej klawiatury zostaje odpowiednio skasowana. Następnie K2 uruchamia ponownie podświetlenie klawiatury tylko z pierwszym efektem z listy — nic więcej nie jest wysyłane do urządzenia. Tej operacji nie można cofnąć. Kontynuować?</string>
+  <string name="settings_factory_reset_busy">Przywracanie klawiatury do ustawień fabrycznych, proszę czekać…</string>
+  <string name="settings_factory_reset_done">Klawiatura została przywrócona do ustawień fabrycznych, a zapisana w K2 konfiguracja tego urządzenia została wyczyszczona. Jej podświetlenie zostało uruchomione ponownie z pierwszym efektem z listy; nic więcej nie zostało wysłane do urządzenia.</string>
+  <string name="settings_factory_reset_failed">Klawiatura nie potwierdziła przywrócenia ustawień fabrycznych. Nie wprowadzono żadnych zmian na urządzeniu ani w konfiguracji zapisanej w K2.</string>
 
   <!-- Makro klawiatury -->
   <string name="keyboard_macro">Makro klawiatury</string>
@@ -792,6 +830,7 @@
   <string name="bc_pick_device_none">Wybierz urządzenie, z którego chcesz importować.</string>
   <string name="bc_pick_device_label">Urządzenie #{0} — {1} profil(e/i): {2}</string>
   <string name="bc_import_will_wipe">To USUNIE wszystkie istniejące profile K2 na "{0}" przed importem.</string>
+  <string name="ev_bc_import_will_wipe_firmware">Spowoduje to również PRZYWRÓCENIE USTAWIEŃ FABRYCZNYCH samej klawiatury, czyszcząc podświetlenie, przypisania klawiszy i obrazy klawiszy wyświetlacza zapisane we wszystkich 5 slotach firmware.</string>
   <string name="bc_import_read_failed">Nie udało się odczytać bazy danych Base Camp ({0}). Nic nie zostało zaimportowane, a istniejące profile K2 pozostały nietknięte.</string>
   <!-- Import Everest -->
   <string name="ev_no_profiles_in_bc">Nie znaleziono profili Everest w bazie danych Base Camp.</string>

--- a/K2.Core/Strings.pt.xml
+++ b/K2.Core/Strings.pt.xml
@@ -207,7 +207,27 @@
   <string name="youtube_chat_message_label">Mensagem de chat ao vivo:</string>
   <string name="act_command">Comando shell</string>
   <string name="act_text">Colar texto</string>
+  <string name="act_emoji">Emoji</string>
   <string name="act_macro">Reproduzir macro</string>
+
+  <!-- Ação de emoji + navegador de emoji (EmojiPickerDialog) -->
+  <string name="emoji_picker_title">Escolher um emoji</string>
+  <string name="emoji_choose_button">Escolher emoji…</string>
+  <string name="emoji_none_selected">Nenhum emoji selecionado</string>
+  <string name="emoji_search_label">Pesquisar:</string>
+  <string name="emoji_category_label">Categoria:</string>
+  <string name="emoji_category_all">Todas</string>
+  <string name="emoji_no_results">Nenhum emoji encontrado</string>
+  <string name="emoji_hint">O emoji é digitado na aplicação em foco quando a tecla é premida. Numa tecla de ecrã (DisplayPad, teclado numérico do Everest Max), também é usado como imagem da tecla.</string>
+  <string name="emoji_grp_smileys">Smileys e emoções</string>
+  <string name="emoji_grp_people">Pessoas e corpo</string>
+  <string name="emoji_grp_animals">Animais e natureza</string>
+  <string name="emoji_grp_food">Comida e bebida</string>
+  <string name="emoji_grp_travel">Viagens e lugares</string>
+  <string name="emoji_grp_activities">Atividades</string>
+  <string name="emoji_grp_objects">Objetos</string>
+  <string name="emoji_grp_symbols">Símbolos</string>
+  <string name="emoji_grp_flags">Bandeiras</string>
   <string name="act_macro_unresolved">Reproduzir macro (não atribuído)</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Script Python</string>
@@ -349,6 +369,19 @@
   <string name="settings_k2_autostart_hint">O K2 agora requer privilégios de administrador (para controlar o BaseCampService). O Windows não eleva automaticamente as apps iniciadas a partir da chave de registo Run no início de sessão, por isso esta entrada por si só pode não conseguir iniciar o K2 em silêncio — se isso acontecer, use o Agendador de Tarefas (uma tarefa definida para "Executar com privilégios mais elevados" no início de sessão).</string>
   <string name="settings_start_min_tray">Iniciar diretamente minimizado na tray</string>
   <string name="settings_start_min_tray_hint">O K2 inicia com os seus drivers ativos mas com a janela escondida na tray — abra-a a qualquer momento a partir do ícone da tray.</string>
+  <!-- Mapeamento de dispositivos DisplayPad -->
+  <string name="settings_dp_devicemap_group">Mapeamento de dispositivos DisplayPad</string>
+  <string name="settings_dp_devicemap_btn">Configurar mapeamento…</string>
+  <string name="settings_dp_devicemap_hint">Se moveu um DisplayPad para outra porta USB e os perfis guardados agora aparecem no painel errado (por ex. "DisplayPad 2" e "DisplayPad 3" trocados), use isto para reatribuir o painel que cada pad ligado representa.</string>
+  <string name="dp_devicemap_title">Mapeamento de dispositivos DisplayPad</string>
+  <string name="dp_devicemap_hint">Cada pad ligado é listado abaixo com a sua versão de firmware. Clique em "Identificar" para fazer piscar a retroiluminação de um pad e reconhecer a linha correspondente, depois defina o número de placa que deve usar. Duas linhas não podem partilhar o mesmo número de placa.</string>
+  <string name="dp_devicemap_col_current">Atualmente mostrado como</string>
+  <string name="dp_devicemap_col_firmware">Firmware</string>
+  <string name="dp_devicemap_col_board">N.º da placa</string>
+  <string name="dp_devicemap_identify_btn">Identificar</string>
+  <string name="dp_devicemap_none_connected">Nenhum DisplayPad está atualmente ligado — ligue os pads que pretende reatribuir e reabra esta janela.</string>
+  <string name="dp_devicemap_duplicate_error">Dois pads não podem usar o mesmo número de placa. Atribua um número diferente a cada um.</string>
+  <string name="dp_devicemap_invalid_number">Os números de placa devem ser números inteiros positivos.</string>
   <string name="settings_font_family">Tipo de letra</string>
   <string name="settings_font_family_hint">Altera imediatamente o tipo de letra da interface em toda a app, sem necessidade de reiniciar.</string>
   <string name="tray_show">Mostrar K2</string>
@@ -476,7 +509,7 @@
   <string name="makalu_remap_btn_dpi">Botão DPI</string>
   <string name="makalu_remap_btn_5">Botão 5</string>
   <string name="makalu_remap_btn_6">Botão 6</string>
-  <string name="makalu_settings_title">Definições do dispositivo</string>
+  <string name="makalu_settings_title">Definições</string>
   <string name="makalu_setting_poll">Taxa de polling:</string>
   <string name="makalu_setting_debounce">Resposta dos botões:</string>
   <string name="makalu_setting_angle">Angle snapping:</string>
@@ -544,6 +577,7 @@
   <string name="dock_remove_action">Remover ação</string>
   <!-- Definições (secção da barra lateral Everest: esquema do teclado) -->
   <string name="ev_settings">Definições</string>
+  <string name="appearance">Aparência</string>
   <string name="ev_layout">Layout</string>
   <string name="settings_sync_profiles">Sincronizar entre perfis</string>
   <string name="settings_game_mode">Modo de jogo</string>
@@ -579,8 +613,12 @@
   <string name="keycap_customize_use_mountain_logo">Usar logótipo Mountain (fixo)</string>
   <string name="keycap_customize_clear_all">Remover personalizações</string>
   <string name="keycap_customize_close">Fechar</string>
-  <string name="settings_factory_reset">Repor predefinições de fábrica</string>
-  <string name="settings_factory_reset_confirm">Isto repõe o Modo de jogo, os LEDs indicadores e os efeitos de iluminação do teclado para as predefinições de fábrica. Continuar?</string>
+  <string name="settings_factory_reset">Repor todas as definições de fábrica</string>
+  <string name="settings_factory_reset_hint">Apaga a memória própria do teclado — perfis de firmware, atribuições de teclas, imagens das teclas de ecrã e iluminação — e limpa a configuração guardada no K2 para o mesmo. Não é o mesmo que "Repor predefinições" na barra lateral, que apenas repõe os perfis do K2 e não toca no dispositivo.</string>
+  <string name="settings_factory_reset_confirm">Isto repõe a memória própria do teclado ao estado de fábrica: todos os perfis de firmware, atribuições de teclas, imagens de teclas de ecrã e efeitos de iluminação guardados no dispositivo são apagados, e a configuração guardada no K2 para este teclado é eliminada em conformidade. Depois disso, o K2 apenas reinicia a iluminação do teclado com o primeiro efeito da lista — nada mais é enviado para o dispositivo. Esta ação não pode ser desfeita. Continuar?</string>
+  <string name="settings_factory_reset_busy">A repor o teclado para as predefinições de fábrica, aguarde…</string>
+  <string name="settings_factory_reset_done">O teclado foi reposto para as predefinições de fábrica e a configuração guardada no K2 para o mesmo foi limpa. A sua iluminação foi reiniciada com o primeiro efeito da lista; nada mais foi enviado para o dispositivo.</string>
+  <string name="settings_factory_reset_failed">O teclado não confirmou a reposição de fábrica. Não foi feita nenhuma alteração no dispositivo nem na configuração guardada no K2.</string>
   <!-- Macro de teclado -->
   <string name="keyboard_macro">Macro de teclado</string>
   <string name="macro_library">Biblioteca de macros</string>
@@ -772,6 +810,7 @@
   <string name="bc_pick_device_none">Escolha um dispositivo a partir do qual importar.</string>
   <string name="bc_pick_device_label">Dispositivo #{0} — {1} perfil(is): {2}</string>
   <string name="bc_import_will_wipe">Isto irá ELIMINAR todos os perfis K2 existentes em "{0}" antes de importar.</string>
+  <string name="ev_bc_import_will_wipe_firmware">Isto também irá REPOR DE FÁBRICA o próprio teclado, apagando a iluminação, as atribuições de teclas e as imagens das teclas de ecrã guardadas nos 5 slots de firmware.</string>
   <string name="bc_import_read_failed">Não foi possível ler a base de dados do Base Camp ({0}). Nada foi importado e os seus perfis K2 existentes não foram alterados.</string>
   <!-- Importação Everest -->
   <string name="ev_no_profiles_in_bc">Não foram encontrados perfis Everest na base de dados do Base Camp.</string>

--- a/K2.Core/Strings.xml
+++ b/K2.Core/Strings.xml
@@ -356,6 +356,7 @@
   <string name="settings_update_zip_btn">Download ZIP…</string>
   <string name="settings_update_view_release_btn">View release notes</string>
   <string name="settings_update_downloading">Downloading…</string>
+  <string name="settings_update_downloading_pct">Downloading… {0}%</string>
   <string name="settings_update_install_confirm">Download version {0} and run the installer? K2 will close as soon as the installer starts, so it can update.</string>
   <string name="settings_update_zip_done">Saved to {0}</string>
   <!-- Restore defaults -->
@@ -530,7 +531,7 @@
   <string name="makalu_remap_btn_5">Button 5</string>
   <string name="makalu_remap_btn_6">Button 6</string>
 
-  <string name="makalu_settings_title">Device settings</string>
+  <string name="makalu_settings_title">Settings</string>
   <string name="makalu_setting_poll">Polling rate:</string>
   <string name="makalu_setting_debounce">Button response:</string>
   <string name="makalu_setting_angle">Angle snapping:</string>

--- a/K2.Core/Strings.zh.xml
+++ b/K2.Core/Strings.zh.xml
@@ -208,7 +208,27 @@
   <string name="youtube_chat_message_label">实时聊天消息:</string>
   <string name="act_command">Shell 命令</string>
   <string name="act_text">粘贴文本</string>
+  <string name="act_emoji">表情符号</string>
   <string name="act_macro">播放宏</string>
+
+  <!-- 表情符号操作 + 表情符号浏览器 (EmojiPickerDialog) -->
+  <string name="emoji_picker_title">选择表情符号</string>
+  <string name="emoji_choose_button">选择表情符号…</string>
+  <string name="emoji_none_selected">未选择表情符号</string>
+  <string name="emoji_search_label">搜索:</string>
+  <string name="emoji_category_label">类别:</string>
+  <string name="emoji_category_all">全部</string>
+  <string name="emoji_no_results">未找到表情符号</string>
+  <string name="emoji_hint">按下按键时，表情符号会输入到当前聚焦的应用程序中。在显示按键（DisplayPad、Everest Max 数字键盘）上，它还会用作按键图像。</string>
+  <string name="emoji_grp_smileys">表情与情绪</string>
+  <string name="emoji_grp_people">人物与身体</string>
+  <string name="emoji_grp_animals">动物与自然</string>
+  <string name="emoji_grp_food">食物与饮料</string>
+  <string name="emoji_grp_travel">旅行与地点</string>
+  <string name="emoji_grp_activities">活动</string>
+  <string name="emoji_grp_objects">物品</string>
+  <string name="emoji_grp_symbols">符号</string>
+  <string name="emoji_grp_flags">旗帜</string>
   <string name="act_macro_unresolved">播放宏（未分配）</string>
   <string name="act_googlehome">Google Home</string>
   <string name="act_pyscript">Python 脚本</string>
@@ -351,6 +371,19 @@
   <string name="settings_k2_autostart_hint">K2 现在需要管理员权限（以控制 BaseCampService）。Windows 不会自动提升通过登录时 Run 注册表项启动的应用权限，因此仅靠此设置可能无法静默启动 K2 — 如果发生这种情况，请改用任务计划程序（将任务设置为登录时“以最高权限运行”）。</string>
   <string name="settings_start_min_tray">启动时直接最小化到托盘</string>
   <string name="settings_start_min_tray_hint">K2 启动时驱动程序保持激活，但窗口隐藏在托盘中 — 可随时从托盘图标打开。</string>
+  <!-- DisplayPad 设备映射 -->
+  <string name="settings_dp_devicemap_group">DisplayPad 设备映射</string>
+  <string name="settings_dp_devicemap_btn">配置映射…</string>
+  <string name="settings_dp_devicemap_hint">如果你将 DisplayPad 移动到了另一个 USB 端口，导致其已保存的配置文件现在显示在错误的面板上（例如 "DisplayPad 2" 和 "DisplayPad 3" 互换），可使用此功能重新指定每个已连接面板对应的编号。</string>
+  <string name="dp_devicemap_title">DisplayPad 设备映射</string>
+  <string name="dp_devicemap_hint">下方列出了每个已连接的面板及其固件版本。点击"识别"可使某个面板的背光闪烁，以便分辨对应的行，然后设置它应使用的板编号。两行不能使用相同的板编号。</string>
+  <string name="dp_devicemap_col_current">当前显示为</string>
+  <string name="dp_devicemap_col_firmware">固件</string>
+  <string name="dp_devicemap_col_board">板编号</string>
+  <string name="dp_devicemap_identify_btn">识别</string>
+  <string name="dp_devicemap_none_connected">当前没有连接任何 DisplayPad — 请连接要重新映射的面板，然后重新打开此窗口。</string>
+  <string name="dp_devicemap_duplicate_error">两个面板不能使用相同的板编号。请为每个面板指定不同的编号。</string>
+  <string name="dp_devicemap_invalid_number">板编号必须是正整数。</string>
   <string name="settings_font_family">字体</string>
   <string name="settings_font_family_hint">立即更改整个应用的界面字体，无需重启。</string>
   <string name="tray_show">显示 K2</string>
@@ -481,7 +514,7 @@
   <string name="makalu_remap_btn_dpi">DPI 键</string>
   <string name="makalu_remap_btn_5">按钮 5</string>
   <string name="makalu_remap_btn_6">按钮 6</string>
-  <string name="makalu_settings_title">设备设置</string>
+  <string name="makalu_settings_title">设置</string>
   <string name="makalu_setting_poll">轮询率:</string>
   <string name="makalu_setting_debounce">按键响应:</string>
   <string name="makalu_setting_angle">角度校正:</string>
@@ -549,6 +582,7 @@
   <string name="dock_remove_action">删除动作</string>
   <!-- 设置（Everest 侧栏部分：键盘布局） -->
   <string name="ev_settings">设置</string>
+  <string name="appearance">外观</string>
   <string name="ev_layout">布局</string>
   <string name="settings_sync_profiles">跨配置文件同步</string>
   <string name="settings_game_mode">游戏模式</string>
@@ -584,8 +618,12 @@
   <string name="keycap_customize_use_mountain_logo">使用 Mountain 标志（固定）</string>
   <string name="keycap_customize_clear_all">清除所有自定义</string>
   <string name="keycap_customize_close">关闭</string>
-  <string name="settings_factory_reset">恢复出厂设置</string>
-  <string name="settings_factory_reset_confirm">此操作会将键盘的游戏模式、指示灯 LED 和灯光效果恢复为出厂默认设置。是否继续？</string>
+  <string name="settings_factory_reset">将所有设置恢复为出厂默认值</string>
+  <string name="settings_factory_reset_hint">清除键盘自身的内存 — 固件配置文件、按键绑定、显示按键图像和照明 — 并清除 K2 中为其保存的配置。这与侧边栏的"恢复默认值"不同，后者仅重置 K2 的配置文件，不会影响设备。</string>
+  <string name="settings_factory_reset_confirm">此操作会将键盘自身的内存恢复到出厂状态：设备上存储的每个固件配置文件、按键绑定、显示按键图像和照明效果都将被清除，K2 中为该键盘保存的配置也会相应删除。之后，K2 只会用列表中的第一个效果重新启动键盘的照明 — 不会向设备推送任何其他内容。此操作无法撤销。是否继续？</string>
+  <string name="settings_factory_reset_busy">正在将键盘重置为出厂默认值，请稍候…</string>
+  <string name="settings_factory_reset_done">键盘已重置为出厂默认值，K2 中为其保存的配置也已清除。其照明已使用列表中的第一个效果重新启动；未向设备推送任何其他内容。</string>
+  <string name="settings_factory_reset_failed">键盘未确认出厂重置。设备和 K2 中保存的配置均未发生任何更改。</string>
   <!-- 键盘宏 -->
   <string name="keyboard_macro">键盘宏</string>
   <string name="macro_library">宏库</string>
@@ -779,6 +817,7 @@
   <string name="bc_pick_device_none">请选择要从中导入的设备。</string>
   <string name="bc_pick_device_label">设备 #{0} — {1} 个配置文件：{2}</string>
   <string name="bc_import_will_wipe">此操作将在导入前删除 "{0}" 上所有现有的 K2 配置文件。</string>
+  <string name="ev_bc_import_will_wipe_firmware">此操作还将对键盘本身进行出厂重置，清除全部 5 个固件槽位中存储的照明、按键绑定和显示按键图像。</string>
   <string name="bc_import_read_failed">无法读取 Base Camp 数据库（{0}）。未导入任何内容，你现有的 K2 配置文件未受影响。</string>
   <!-- Everest 导入 -->
   <string name="ev_no_profiles_in_bc">在 Base Camp 数据库中未找到 Everest 配置文件。</string>


### PR DESCRIPTION
## Summary
- Add SystemMonitor service (CPU/RAM/GPU stats)
- Expand Media Dock behavior and Display Dial screensaver handling
- Fix Everest Max display-key firmware binding causing a spurious Windows "open with" popup on non-exec/url actions
- Fix tray icon double-click (wrong NIN_SELECT constant) not restoring the window under the notify-icon v4 shell behavior
- Add update-download progress bar in Settings
- Update localized strings across all supported languages

## Test plan
- [x] Clean build (0 errors/warnings)
- [ ] Verify system monitor widget on hardware
- [ ] Verify tray icon double-click restores window
- [ ] Verify Everest Max display-key popup no longer appears after resync